### PR TITLE
New RPCClientAsync class

### DIFF
--- a/NBitcoin/NBitcoin.csproj
+++ b/NBitcoin/NBitcoin.csproj
@@ -33,9 +33,8 @@
     <Reference Include="BouncyCastle.Crypto">
       <HintPath>..\packages\BouncyCastle.1.7.0\lib\Net40-Client\BouncyCastle.Crypto.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="protobuf-net">
       <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
@@ -46,6 +45,7 @@
       <HintPath>..\packages\System.Data.SQLite.Core.1.0.92.0\lib\net45\System.Data.SQLite.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Serialization" />
@@ -108,6 +108,7 @@
     <Compile Include="RPC\BlockExplorerFormatter.cs" />
     <Compile Include="RPC\RawFormatter.cs" />
     <Compile Include="RPC\RPCClient.cs" />
+    <Compile Include="RPC\RPCClientAsync.cs" />
     <Compile Include="RPC\RPCException.cs" />
     <Compile Include="RPC\RPCRequest.cs" />
     <Compile Include="RPC\RPCResponse.cs" />
@@ -264,7 +265,6 @@
       <Name>Mono.Nat</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/NBitcoin/RPC/RPCClientAsync.cs
+++ b/NBitcoin/RPC/RPCClientAsync.cs
@@ -1,0 +1,324 @@
+﻿using NBitcoin.DataEncoders;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Formatting;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NBitcoin.RPC
+{
+    public class RPCClientAsync
+    {
+        private HttpClient http;
+
+        public Uri Address
+		{
+			get
+			{
+				return http.BaseAddress;
+			}
+		}
+
+        public NetworkCredential Credentials { get; private set; }
+
+        public Network Network { get; private set; }
+
+        public RPCClientAsync(NetworkCredential credentials, string host, Network network)
+			: this(credentials, (new UriBuilder() { Host = host, Scheme = "http", Port = network.RPCPort}).Uri , network)
+		{
+		}
+
+		public RPCClientAsync(NetworkCredential credentials, Uri address, Network network = null)
+		{
+
+			if(credentials == null)
+				throw new ArgumentNullException("credentials");
+			if(address == null)
+				throw new ArgumentNullException("address");
+			if(network == null)
+			{
+				network = new[] { Network.Main, Network.TestNet, Network.RegTest }.FirstOrDefault(n => n.RPCPort == address.Port);
+				if(network == null)
+					throw new ArgumentNullException("network");
+			}
+			Credentials = credentials;
+			Network = network;
+
+            var handler = new HttpClientHandler();
+            handler.Credentials = credentials;
+            http = new HttpClient(handler);
+            http.BaseAddress = address;
+		}
+
+		public async Task<RPCResponse> SendCommand(RPCOperations commandName, params object[] parameters)
+		{
+			return await SendCommand(commandName.ToString(), parameters);
+		}
+
+		/// <summary>
+		/// Send a command
+		/// </summary>
+		/// <param name="commandName">https://en.bitcoin.it/wiki/Original_Bitcoin_client/API_calls_list</param>
+		/// <param name="parameters"></param>
+		/// <returns></returns>
+		public async Task<RPCResponse> SendCommand(string commandName, params object[] parameters)
+		{
+			return await SendCommand(new RPCRequest(commandName, parameters));
+		}
+
+		public async Task<RPCResponse> SendCommand(RPCRequest request, bool throwIfRPCError = true)
+		{
+            var httpResponse = await http.PostAsync("", request, new JsonMediaTypeFormatter(), "application/json-rpc");
+
+			RPCResponse response = null;
+
+            response = await httpResponse.Content.ReadAsAsync<RPCResponse>();
+             
+			if(throwIfRPCError)
+			    response.ThrowIfError();
+
+            return response;
+		}
+
+		public async Task<UnspentCoin[]> ListUnspent()
+		{
+			var response = await SendCommand(RPCOperations.listunspent);
+			return ((JArray)response.Result).Select(i => new UnspentCoin((JObject)i)).ToArray();
+		}
+
+		public async Task<BitcoinAddress> GetAccountAddress(string account)
+		{
+			var response = await SendCommand(RPCOperations.getaccountaddress, account);
+			return Network.CreateFromBase58Data<BitcoinAddress>((string)response.Result);
+		}
+
+		public async Task<BitcoinSecret> DumpPrivKey(BitcoinAddress address)
+		{
+			var response = await SendCommand(RPCOperations.dumpprivkey, address.ToString());
+			return Network.CreateFromBase58Data<BitcoinSecret>((string)response.Result);
+		}
+
+		public async Task<uint256> GetBestBlockHash()
+		{
+            var response = await SendCommand(RPCOperations.getbestblockhash);
+			return new uint256((string)response.Result);
+		}
+
+		public async Task<BitcoinSecret> GetAccountSecret(string account)
+		{
+			var address = await GetAccountAddress(account);
+			return await DumpPrivKey(address);
+		}
+
+		public async Task<Transaction> DecodeRawTransaction(string rawHex)
+		{
+			var response = await SendCommand(RPCOperations.decoderawtransaction, rawHex);
+			return Transaction.Parse(response.Result.ToString(), RawFormat.Satoshi);
+		}
+		public async Task<Transaction> DecodeRawTransaction(byte[] raw)
+		{
+			return await DecodeRawTransaction(Encoders.Hex.EncodeData(raw));
+		}
+
+		/// <summary>
+		/// getrawtransaction only returns on txn which are not entirely spent unless you run bitcoinq with txindex=1.
+		/// </summary>
+		/// <param name="txid"></param>
+		/// <returns></returns>
+		public async Task<Transaction> GetRawTransaction(uint256 txid, bool throwIfNotFound = true)
+		{
+			var response = await SendCommand(new RPCRequest("getrawtransaction", new[] { txid.ToString() }), throwIfNotFound);
+			if(throwIfNotFound)
+				response.ThrowIfError();
+			if(response.Error != null && response.Error.Code == RPCErrorCode.RPC_INVALID_ADDRESS_OR_KEY)
+				return null;
+			else
+				response.ThrowIfError();
+
+			var tx = new Transaction();
+			tx.ReadWrite(Encoders.Hex.DecodeData(response.Result.ToString()));
+			return tx;
+		}
+
+		public async Task SendRawTransaction(byte[] bytes)
+		{
+			await SendCommand(RPCOperations.sendrawtransaction, Encoders.Hex.EncodeData(bytes));
+		}
+
+		public async Task SendRawTransaction(Transaction tx)
+		{
+			await SendRawTransaction(tx.ToBytes());
+		}
+
+		public async Task LockUnspent(params OutPoint[] outpoints)
+		{
+			await LockUnspentCore(false, outpoints);
+		}
+
+		public async Task UnlockUnspent(params OutPoint[] outpoints)
+		{
+			await LockUnspentCore(true, outpoints);
+		}
+
+		private async Task LockUnspentCore(bool unlock, OutPoint[] outpoints)
+		{
+			if(outpoints == null || outpoints.Length == 0)
+				return;
+			List<object> parameters = new List<object>();
+			parameters.Add(unlock);
+			JArray array = new JArray();
+			parameters.Add(array);
+			foreach(var outp in outpoints)
+			{
+				var obj = new JObject();
+				obj["txid"] = outp.Hash.ToString();
+				obj["vout"] = outp.N;
+				array.Add(obj);
+			}
+			await SendCommand(RPCOperations.lockunspent, parameters.ToArray());
+		}
+
+		public async Task<BlockHeader> GetBlockHeader(int height)
+		{
+			var hash = await GetBlockHash(height);
+			return await GetBlockHeader(hash);
+		}
+
+		/// <summary>
+		/// Get the a whole block, will fail if bitcoinq does not run with txindex=1 and one of the transaction of the block is entirely spent
+		/// </summary>
+		/// <param name="blockId"></param>
+		/// <returns></returns>
+		public async Task<Block> GetBlock(uint256 blockId)
+		{
+			var resp = await SendCommand(RPCOperations.getblock, blockId.ToString());
+			var header = ParseBlockHeader(resp);
+			Block block = new Block(header);
+			var transactions = resp.Result["tx"] as JArray;
+			try
+			{
+				foreach(var tx in transactions)
+				{
+					block.AddTransaction(await GetRawTransaction(new uint256(tx.ToString())));
+				}
+			}
+			catch(RPCException ex)
+			{
+				if(ex.RPCCode == RPCErrorCode.RPC_INVALID_ADDRESS_OR_KEY)
+					return null;
+				throw;
+			}
+			return block;
+		}
+
+		public async Task<BlockHeader> GetBlockHeader(uint256 blockHash)
+		{
+			var resp = await SendCommand(RPCOperations.getblock, blockHash.ToString());
+			return ParseBlockHeader(resp);
+		}
+
+		private BlockHeader ParseBlockHeader(RPCResponse resp)
+		{
+			BlockHeader header = new BlockHeader();
+			header.Version = (int)resp.Result["version"];
+			header.Nonce = (uint)resp.Result["nonce"];
+			header.Bits = new Target(Encoders.Hex.DecodeData((string)resp.Result["bits"]));
+			if(resp.Result["previousblockhash"] != null)
+			{
+				header.HashPrevBlock = new uint256(Encoders.Hex.DecodeData((string)resp.Result["previousblockhash"]), false);
+			}
+			if(resp.Result["time"] != null)
+			{
+				header.BlockTime = Utils.UnixTimeToDateTime((uint)resp.Result["time"]);
+			}
+			if(resp.Result["merkleroot"] != null)
+			{
+				header.HashMerkleRoot = new uint256(Encoders.Hex.DecodeData((string)resp.Result["merkleroot"]), false);
+			}
+			return header;
+		}
+
+        // TODO: Change sync IEnumerable<T> to async IObservable<T> using Rx.Net
+        /// <summary>
+		/// GetTransactions only returns on txn which are not entirely spent unless you run bitcoinq with txindex=1.
+		/// </summary>
+		/// <param name="blockHash"></param>
+		/// <returns></returns>
+        public IEnumerable<Transaction> GetTransactionsSync(uint256 blockHash)
+        {
+            if (blockHash == null)
+                throw new ArgumentNullException("blockHash");
+
+            var resp = SendCommand(RPCOperations.getblock, blockHash.ToString()).Result;
+
+            var tx = resp.Result["tx"] as JArray;
+            if (tx != null)
+            {
+                foreach (var item in tx)
+                {
+                    var result = GetRawTransaction(new uint256(item.ToString()), false).Result;
+                    if (result != null)
+                        yield return result;
+                }
+            }
+        }
+
+        // With Rx.Net, we can do this:
+        //public IEnumerable<Transaction> GetTransactions(uint256 blockHash)
+        //{
+        //    if(blockHash == null)
+        //        throw new ArgumentNullException("blockHash");
+
+        //    return GetTransactionsSource(blockHash).ToEnumerable();
+        //}
+
+        //private IObservable<Transaction> GetTransactionsSource(uint256 blockHash)
+        //{
+        //    return Observable.Create<string>(
+        //            async obs =>
+        //            {
+        //                var resp = await SendCommand(RPCOperations.getblock, blockHash.ToString());
+
+        //                var tx = resp.Result["tx"] as JArray;
+        //                if (tx != null)
+        //                {
+        //                    foreach (var item in tx)
+        //                    {
+        //                        var result = await GetRawTransaction(new uint256(item.ToString()), false);
+        //                        if (result != null)
+        //                            obs.OnNext(result);
+        //                    }
+        //                }
+        //            });
+        //}
+
+        // TODO: Change sync IEnumerable<T> to async IObservable<T> using Rx.Net
+        public IEnumerable<Transaction> GetTransactionsSync(int height)
+		{
+			return GetTransactionsSync(GetBlockHash(height).Result);
+		}
+
+		public async Task<uint256> GetBlockHash(int height)
+		{
+			var resp = await SendCommand(RPCOperations.getblockhash, height);
+			return new uint256(resp.Result.ToString());
+		}
+
+		public async Task<int> GetBlockCount()
+		{
+            var response = await SendCommand(RPCOperations.getblockcount);
+			return (int)response.Result;
+		}
+
+		public async Task<uint256[]> GetRawMempool()
+		{
+			var result = await SendCommand(RPCOperations.getrawmempool);
+			var array = (JArray)result.Result;
+			return array.Select(o => new uint256((string)o)).ToArray();
+		}
+    }
+}

--- a/NBitcoin/RPC/RPCException.cs
+++ b/NBitcoin/RPC/RPCException.cs
@@ -44,6 +44,8 @@ namespace NBitcoin.RPC
 		RPC_WALLET_WRONG_ENC_STATE = -15, // Command given in wrong wallet encryption state (encrypting an encrypted wallet etc.)
 		RPC_WALLET_ENCRYPTION_FAILED = -16, // Failed to encrypt the wallet
 		RPC_WALLET_ALREADY_UNLOCKED = -17, // Wallet is already unlocked
+
+        NO_ERROR = 0,
 	}
 
 

--- a/NBitcoin/RPC/RPCRequest.cs
+++ b/NBitcoin/RPC/RPCRequest.cs
@@ -4,11 +4,13 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace NBitcoin.RPC
 {
+    [DataContract]
 	public class RPCRequest
 	{
 		public RPCRequest(string method, object[] parameters)
@@ -22,26 +24,18 @@ namespace NBitcoin.RPC
 			JsonRpc = "1.0";
 			Id = 1;
 		}
-		public string JsonRpc
-		{
-			get;
-			set;
-		}
-		public int Id
-		{
-			get;
-			set;
-		}
-		public string Method
-		{
-			get;
-			set;
-		}
-		public object[] Params
-		{
-			get;
-			set;
-		}
+
+        [DataMember(Name="jsonrpc")]
+        public string JsonRpc { get; set; }
+
+        [DataMember(Name="id")]
+        public int Id { get; set; }
+
+        [DataMember(Name="method")]
+        public string Method { get; set; }
+
+        [DataMember(Name="params")]
+        public object[] Params { get; set; }
 
 		public void WriteJSON(TextWriter writer)
 		{

--- a/NBitcoin/RPC/RPCResponse.cs
+++ b/NBitcoin/RPC/RPCResponse.cs
@@ -12,11 +12,15 @@ namespace NBitcoin.RPC
 	//{"code":-32601,"message":"Method not found"}
 	public class RPCError
 	{
-		public RPCError(JObject error)
-		{
-			Code = (RPCErrorCode)((int)error.GetValue("code"));
-			Message = (string)error.GetValue("message");
-		}
+        public RPCError()
+        { }
+
+        public RPCError(JObject error)
+        {
+            Code = (RPCErrorCode)((int)error.GetValue("code"));
+            Message = (string)error.GetValue("message");
+        }
+
 		public RPCErrorCode Code
 		{
 			get;
@@ -32,6 +36,9 @@ namespace NBitcoin.RPC
 	//{"result":null,"error":{"code":-32601,"message":"Method not found"},"id":1}
 	public class RPCResponse
 	{
+        public RPCResponse()
+        { }
+
 		public RPCResponse(JObject json)
 		{
 			var error = json.GetValue("error") as JObject;
@@ -41,6 +48,7 @@ namespace NBitcoin.RPC
 			}
 			Result = json.GetValue("result") as JToken;
 		}
+
 		public RPCError Error
 		{
 			get;
@@ -61,7 +69,7 @@ namespace NBitcoin.RPC
 
 		public void ThrowIfError()
 		{
-			if(Error != null)
+			if(Error != null && Error.Code != RPCErrorCode.NO_ERROR)
 			{
 				throw new RPCException(Error.Code, Error.Message, this);
 			}

--- a/NBitcoin/packages.config
+++ b/NBitcoin/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="BouncyCastle" version="1.7.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net45" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net45" />
   <package id="System.Data.SQLite.Core" version="1.0.92.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
New RPCClientAsync class which uses async/await pattern everywhere, to get more throughput with fewer blocking threads. Uses HttpClient internally to make requests and serialize JSON.

The Json serialization of the RPCRequest and RPCResponse are handled by the HttpClient built-in json serializers, To get the json-rpc member names right, I added DataMember attributes to the properties of RPCRequest.  If having RPCRequest and RPCResponse (and RPCError) cohabiting two different serialization models is too weird, I can create separate dto classes for the HttpClient based RPCClientAsync.

Note that yield return for IEnumerable generators (for RPCClientAsync:GetTransactions) doesn't mesh well with the TAP async/await pattern. It can be solved using Rx.NET Observable<T> (to create an asynchronous generator of enumerable items) but that will require adding Rx.NET as a dependency to NBitcoin.  For the moment, RPCClientAsync:GetTransactions is implemented as a synchronous operation. Each call to the enumerator.Next will internally make a blocking network call to fetch the raw transaction.

Opinions?
