### PR TITLE
Add async to ITransactionRepository

### DIFF
--- a/NBitcoin/BlockrTransactionRepository.cs
+++ b/NBitcoin/BlockrTransactionRepository.cs
@@ -59,10 +59,20 @@ namespace NBitcoin
 			}
 		}
 
+        public Task<Transaction> GetAsync(uint256 txId)
+        {
+            return Task.Run(() => Get(txId));
+        }
+
 		public void Put(uint256 txId, Transaction tx)
 		{
 			
 		}
+
+        public Task PutAsync(uint256 txId, Transaction tx)
+        {
+            return Task.Run(() => Put(txId, tx));
+        }
 
 		#endregion
 	}

--- a/NBitcoin/CachedTransactionRepository.cs
+++ b/NBitcoin/CachedTransactionRepository.cs
@@ -19,23 +19,33 @@ namespace NBitcoin
 		#region ITransactionRepository Members
 
 		public Transaction Get(uint256 txId)
+        {
+            return GetAsync(txId).Result;
+        }
+
+		public async Task<Transaction> GetAsync(uint256 txId)
 		{
 			Transaction result = null;
 			if(!_Transactions.TryGetValue(txId, out result))
 			{
-				result = _Inner.Get(txId);
+				result = await _Inner.GetAsync(txId);
 				_Transactions.Add(txId, result);
 			}
 			return result;
 		}
 
 		public void Put(uint256 txId, Transaction tx)
+        {
+            PutAsync(txId, tx).RunSynchronously();
+        }
+
+		public async Task PutAsync(uint256 txId, Transaction tx)
 		{
 			if(!_Transactions.ContainsKey(txId))
 				_Transactions.Add(txId, tx);
 			else
 				_Transactions[txId] = tx;
-			_Inner.Put(txId, tx);
+			await _Inner.PutAsync(txId, tx);
 		}
 
 		#endregion

--- a/NBitcoin/ITransactionRepository.cs
+++ b/NBitcoin/ITransactionRepository.cs
@@ -10,5 +10,8 @@ namespace NBitcoin
 	{
 		Transaction Get(uint256 txId);
 		void Put(uint256 txId, Transaction tx);
+
+        Task<Transaction> GetAsync(uint256 txId);
+        Task PutAsync(uint256 txId, Transaction tx);
 	}
 }

--- a/NBitcoin/NoSqlTransactionRepository.cs
+++ b/NBitcoin/NoSqlTransactionRepository.cs
@@ -34,6 +34,11 @@ namespace NBitcoin
 			return _Repository.Get<Transaction>(GetId(txId));
 		}
 
+        public Task<Transaction> GetAsync(uint256 txId)
+        {
+            return Task.Run(() => Get(txId));
+        }
+
 		private string GetId(uint256 txId)
 		{
 			return "tx-" + txId.ToString();
@@ -43,6 +48,11 @@ namespace NBitcoin
 		{
 			_Repository.Put(GetId(txId), tx);
 		}
+
+        public Task PutAsync(uint256 txId, Transaction tx)
+        {
+            return Task.Run(() => Put(txId, tx));
+        }
 
 		#endregion
 	}

--- a/NBitcoin/OpenAsset/CachedColoredTransactionRepository.cs
+++ b/NBitcoin/OpenAsset/CachedColoredTransactionRepository.cs
@@ -28,24 +28,34 @@ namespace NBitcoin.OpenAsset
 			}
 		}
 
-		public ColoredTransaction Get(uint256 txId)
+        public ColoredTransaction Get(uint256 txId)
+        {
+            return GetAsync(txId).Result;
+        }
+
+		public async Task<ColoredTransaction> GetAsync(uint256 txId)
 		{
 			ColoredTransaction result = null;
 			if(!_ColoredTransactions.TryGetValue(txId, out result))
 			{
-				result = _Inner.Get(txId);
+				result = await _Inner.GetAsync(txId);
 				_ColoredTransactions.Add(txId, result);
 			}
 			return result;
 		}
 
 		public void Put(uint256 txId, ColoredTransaction tx)
+        {
+            PutAsync(txId, tx).RunSynchronously();
+        }
+
+		public async Task PutAsync(uint256 txId, ColoredTransaction tx)
 		{
 			if(!_ColoredTransactions.ContainsKey(txId))
 				_ColoredTransactions.Add(txId, tx);
 			else
 				_ColoredTransactions[txId] = tx;
-			_Inner.Put(txId, tx);
+			await _Inner.PutAsync(txId, tx);
 		}
 
 		#endregion

--- a/NBitcoin/OpenAsset/CoinprismColoredTransactionRepository.cs
+++ b/NBitcoin/OpenAsset/CoinprismColoredTransactionRepository.cs
@@ -45,6 +45,16 @@ namespace NBitcoin.OpenAsset
 
 			}
 
+            public Task<Transaction> GetAsync(uint256 txId)
+            {
+                return Task.FromResult<Transaction>(null);
+            }
+
+            public async Task PutAsync(uint256 txId, Transaction tx)
+            {
+                await Task.Yield();
+            }
+
 			#endregion
 		}
 		#region IColoredTransactionRepository Members
@@ -132,9 +142,19 @@ namespace NBitcoin.OpenAsset
 			}
 		}
 
+        public Task<ColoredTransaction> GetAsync(uint256 txId)
+        {
+            return Task.Run(() => Get(txId));
+        }
+
 		public void Put(uint256 txId, ColoredTransaction tx)
 		{
 		}
+
+        public Task PutAsync(uint256 txId, ColoredTransaction tx)
+        {
+            return Task.Run(() => Put(txId, tx));
+        }
 
 		#endregion
 	}

--- a/NBitcoin/OpenAsset/IColoredTransactionRepository.cs
+++ b/NBitcoin/OpenAsset/IColoredTransactionRepository.cs
@@ -14,5 +14,8 @@ namespace NBitcoin.OpenAsset
 		}
 		ColoredTransaction Get(uint256 txId);
 		void Put(uint256 txId, ColoredTransaction tx);
-	}
+
+        Task<ColoredTransaction> GetAsync(uint256 txId);
+        Task PutAsync(uint256 txId, ColoredTransaction tx);
+    }
 }

--- a/NBitcoin/OpenAsset/NoSqlColoredTransactionRepository.cs
+++ b/NBitcoin/OpenAsset/NoSqlColoredTransactionRepository.cs
@@ -53,6 +53,11 @@ namespace NBitcoin.OpenAsset
 			return _Repository.Get<ColoredTransaction>(GetId(txId));
 		}
 
+   		public Task<ColoredTransaction> GetAsync(uint256 txId)
+        {
+            return Task.Run(() => Get(txId));
+        }
+
 		private string GetId(uint256 txId)
 		{
 			return "ctx-" + txId;
@@ -62,6 +67,11 @@ namespace NBitcoin.OpenAsset
 		{
 			_Repository.Put(GetId(txId), tx);
 		}
+
+  		public Task PutAsync(uint256 txId, ColoredTransaction tx)
+        {
+            return Task.Run(() => Put(txId, tx));
+        }
 
 		#endregion
 	}

--- a/NBitcoin/RPCTransactionRepository.cs
+++ b/NBitcoin/RPCTransactionRepository.cs
@@ -23,10 +23,19 @@ namespace NBitcoin
 			return _Client.GetRawTransaction(txId, false);
 		}
 
+        public Task<Transaction> GetAsync(uint256 txId)
+        {
+            return Task.Run(() => Get(txId));
+        }
+
 		public void Put(uint256 txId, Transaction tx)
 		{
-			
 		}
+
+        public Task PutAsync(uint256 txId, Transaction tx)
+        {
+            return Task.Run(() => Put(txId, tx));
+        }
 
 		#endregion
 	}


### PR DESCRIPTION
- Add async methods to ITransactionRepository, IColoredTransactionRepository, and ColoredCoinTransaction.FetchColors
- Add default async implementations for existing non-async repository implementations.
- Add transaction link to ColoredCoinTransaction
- Extracted the ancestor resolve loop out of FetchColors to preserve the input params (tx) in FetchColors.
