### PR TITLE
Cache result of BitcoinSecret.GetAddress 

### DIFF
--- a/NBitcoin/BitcoinSecret.cs
+++ b/NBitcoin/BitcoinSecret.cs
@@ -27,9 +27,14 @@ namespace NBitcoin
 		{
 		}
 
+        private BitcoinAddress _address; 
+
 		public BitcoinAddress GetAddress()
 		{
-			return Key.PubKey.GetAddress(Network);
+            if (_address == null)
+                _address = Key.PubKey.GetAddress(Network);
+
+            return _address;
 		}
 
 		public Key Key


### PR DESCRIPTION
Cache result of BitcoinSecret.GetAddress to reduce cost of subsequent calls. Address never changes for this private key.
