### PR TITLE
Coin ctr

### DIFF
--- a/NBitcoin/Coin.cs
+++ b/NBitcoin/Coin.cs
@@ -189,6 +189,13 @@ namespace NBitcoin
 			Outpoint = outpoint;
 			TxOut = txOut;
 		}
+
+        public Coin(uint256 txHash, uint outputIndex, Money amount, Script scriptPubKey)
+        {
+            Outpoint = new OutPoint(txHash, outputIndex);
+            TxOut = new TxOut(amount, scriptPubKey);
+        }
+
 		public OutPoint Outpoint
 		{
 			get;


### PR DESCRIPTION
Add Coin() constructor taking the raw input data (txhash, outindex, amount, scriptPubKey). Constructs OutPoint and TxOut internally.
