### PR TITLE
EnsureMarkerInserted multiples

### DIFF
--- a/NBitcoin/TransactionBuilder.cs
+++ b/NBitcoin/TransactionBuilder.cs
@@ -225,8 +225,17 @@ namespace NBitcoin
 				var txout = Transaction.Outputs.FirstOrDefault(o => Script.IsNullOrEmpty(o.ScriptPubKey));
 				if(txout == null)
 				{
-					txout = Transaction.AddOutput(new TxOut());
-					txout.Value = Money.Zero;
+					int i = 0;
+					var cm = ColorMarker.Get(Transaction, out i);
+					if (cm == null)
+					{
+						txout = Transaction.AddOutput(new TxOut());
+						txout.Value = Money.Zero;
+					}
+					else
+					{
+						txout = Transaction.Outputs[i];
+					}
 				}
 				return txout;
 			}


### PR DESCRIPTION
Not an observed bug, but paranoia: make sure EnsureMarkerInserted doesn't insert multiple color marker outputs.
