### PR TITLE
Replace unchecked((uint)-1) with uint.MaxValue

### DIFF
--- a/NBitcoin/Transaction.cs
+++ b/NBitcoin/Transaction.cs
@@ -17,7 +17,7 @@ namespace NBitcoin
 		{
 			get
 			{
-				return (hash == 0 && n == unchecked((uint)-1));
+				return (hash == 0 && n == uint.MaxValue);
 			}
 		}
 		private uint256 hash;


### PR DESCRIPTION
Unchecked will cause problems with MSIL type safety verifications. uint.MaxValue is equivalent.
