### PR TITLE
Tx bldr convenience fns

### DIFF
--- a/NBitcoin/TransactionBuilder.cs
+++ b/NBitcoin/TransactionBuilder.cs
@@ -479,6 +479,11 @@ namespace NBitcoin
 			return ctx.ChangeAmount;
 		}
 
+		public TransactionBuilder SendAsset(Script scriptPubKey, AssetId assetId, ulong assetQuantity)
+		{
+			return SendAsset(scriptPubKey, new Asset(assetId, assetQuantity));
+		}
+
 		public TransactionBuilder SendAsset(Script scriptPubKey, Asset asset)
 		{
 			AssertOpReturn("Colored Coin");
@@ -553,7 +558,7 @@ namespace NBitcoin
 
 		AssetId _IssuedAsset;
 
-		private TransactionBuilder IssueAsset(Script scriptPubKey, Asset asset)
+		public TransactionBuilder IssueAsset(Script scriptPubKey, Asset asset)
 		{
 			AssertOpReturn("Colored Coin");
 			if(_IssuedAsset == null)
@@ -723,11 +728,11 @@ namespace NBitcoin
 		{
 			return SignTransaction(transaction, SigHash.All);
 		}
-		public void SignTransactionInPlace(Transaction transaction)
+		public Transaction SignTransactionInPlace(Transaction transaction)
 		{
-			SignTransactionInPlace(transaction, SigHash.All);
+			return SignTransactionInPlace(transaction, SigHash.All);
 		}
-		public void SignTransactionInPlace(Transaction transaction, SigHash sigHash)
+		public Transaction SignTransactionInPlace(Transaction transaction, SigHash sigHash)
 		{
 			TransactionSigningContext ctx = new TransactionSigningContext(this, transaction);
 			ctx.SigHash = sigHash;
@@ -740,6 +745,7 @@ namespace NBitcoin
 					Sign(ctx, txIn, coin, i);
 				}
 			}
+			return transaction; 
 		}
 
 		public bool Verify(Transaction tx, Money expectFees = null)


### PR DESCRIPTION
Promote IssueAsset(Script, Asset) from private to public, so that assets can be issued to p2sh / multisig addresses using RedeemScripts.
Add a fn result to SignTransactionInPlace so this function can be used in fluent style call chains.
