### PR TITLE
Shortcut default coin selector when target = 0

### DIFF
--- a/NBitcoin/TransactionBuilder.cs
+++ b/NBitcoin/TransactionBuilder.cs
@@ -40,9 +40,13 @@ namespace NBitcoin
 			if(targetCoin != null)
 				return new[] { targetCoin };
 
-			var orderedCoins = coins.OrderBy(s => s.Amount).ToArray();
 			List<ICoin> result = new List<ICoin>();
 			Money total = Money.Zero;
+
+			if (target == Money.Zero)
+				return result;
+
+			var orderedCoins = coins.OrderBy(s => s.Amount).ToArray();
 
 			foreach(var coin in orderedCoins)
 			{


### PR DESCRIPTION
Default coin selector does 1000 random walks when the target value is zero.  Target can be zero when a transaction contains only a colored coin issuance and the input coin is exactly the bearer coin dust value.
