### PR TITLE
External hook to extend TransactionBuilder.FindCoin

### DIFF
--- a/NBitcoin/TransactionBuilder.cs
+++ b/NBitcoin/TransactionBuilder.cs
@@ -376,6 +376,8 @@ namespace NBitcoin
 			set;
 		}
 
+		public Func<OutPoint, ICoin> CoinFinder { get; set; }
+
 		LockTime? _LockTime;
 		public TransactionBuilder SetLockTime(LockTime lockTime)
 		{
@@ -777,7 +779,12 @@ namespace NBitcoin
 
 		private ICoin FindCoin(OutPoint outPoint)
 		{
-			return _BuilderGroups.SelectMany(c => c.Coins).FirstOrDefault(c => c.Outpoint == outPoint);
+			var result = _BuilderGroups.SelectMany(c => c.Coins).FirstOrDefault(c => c.Outpoint == outPoint);
+
+			if (result == null && CoinFinder != null)
+				result = CoinFinder(outPoint);
+
+			return result;
 		}
 
 		readonly static PayToScriptHashTemplate payToScriptHash = new PayToScriptHashTemplate();


### PR DESCRIPTION
Extends FindCoin to use a callback to try to find a coin if the requested outpoint is not found in the coins added to the builder.  The callback is responsible for finding the tx and constructing the appropriate kind of coin.

This facilitates signing of transactions that the builder did not build, and eliminates the need to AddCoin appropriate coins before signing "foreign" transactions.  Basically, this allows for "coin-on-demand" for signing.
