### PR TITLE
minor bug fixes

### DIFF
--- a/NBitcoin/Money.cs
+++ b/NBitcoin/Money.cs
@@ -29,16 +29,14 @@ namespace NBitcoin
 		public static bool TryParse(string bitcoin, out Money nRet)
 		{
 			nRet = new Money(0);
-			if(bitcoin.Length == 0)
+            if (string.IsNullOrEmpty(bitcoin))
 				return false;
 
 			string strWhole = "";
 			long nUnits = 0;
 
-
 			int i = 0;
-			if(i >= bitcoin.Length)
-				return false;
+
 			while(DataEncoder.IsSpace(bitcoin[i]))
 			{
 				if(i >= bitcoin.Length)

--- a/NBitcoin/Protocol/NodeServer.cs
+++ b/NBitcoin/Protocol/NodeServer.cs
@@ -298,7 +298,7 @@ namespace NBitcoin.Protocol
 
 			var tasks = new[]{
 						new {IP = "91.198.22.70", DNS ="checkip.dyndns.org"}, 
-						new {IP = "74.208.43.192", DNS = "www.showmyip.com"}
+						new {IP = "209.68.27.16", DNS = "www.ipchicken.com"}
 			 }.Select(site =>
 			 {
 				 return Task.Run(() =>


### PR DESCRIPTION
In C# string.Length will throw an exception when string is null which defeats the purpose of TryParse.

Broken external ip service replaced with one chosen from Google. Tested and working with both IP and DNS and correctly parsed by regex.
