### PR TITLE
Update Portable: Add BitcoinUriBuilder support, create subfolder structure

### DIFF
--- a/NBitcoin.Portable/NBitcoin.Portable(portable-net45+netcore45+wpa81+MonoAndroid1+MonoTouch1).csproj
+++ b/NBitcoin.Portable/NBitcoin.Portable(portable-net45+netcore45+wpa81+MonoAndroid1+MonoTouch1).csproj
@@ -38,22 +38,22 @@
       <Link>Base58Data.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\BIP32\BitcoinExtKey.cs">
-      <Link>BitcoinExtKey.cs</Link>
+      <Link>BIP32\BitcoinExtKey.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\BIP32\ExtKey.cs">
-      <Link>ExtKey.cs</Link>
+      <Link>BIP32\ExtKey.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\BIP32\ExtPubKey.cs">
-      <Link>ExtPubKey.cs</Link>
+      <Link>BIP32\ExtPubKey.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\BIP32\KeyPath.cs">
-      <Link>KeyPath.cs</Link>
+      <Link>BIP32\KeyPath.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\BIP38\BitcoinConfirmationCode.cs">
-      <Link>BitcoinConfirmationCode.cs</Link>
+      <Link>BIP38\BitcoinConfirmationCode.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\BIP38\BitcoinEncryptedSecret.cs">
-      <Link>BitcoinEncryptedSecret.cs</Link>
+      <Link>BIP38\BitcoinEncryptedSecret.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Coins.cs">
       <Link>Coins.cs</Link>
@@ -71,7 +71,7 @@
       <Link>Properties\AssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\BIP38\BitcoinPassphraseCode.cs">
-      <Link>BitcoinPassphraseCode.cs</Link>
+      <Link>BIP38\BitcoinPassphraseCode.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\BitcoinAddress.cs">
       <Link>BitcoinAddress.cs</Link>
@@ -110,58 +110,58 @@
       <Link>CompositeDisposable.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Crypto\Cryptsharp\BitMath.cs">
-      <Link>BitMath.cs</Link>
+      <Link>Crypto\Cryptsharp\BitMath.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Crypto\Cryptsharp\BitPacking.cs">
-      <Link>BitPacking.cs</Link>
+      <Link>Crypto\Cryptsharp\BitPacking.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Crypto\Cryptsharp\ByteArray.cs">
-      <Link>ByteArray.cs</Link>
+      <Link>Crypto\Cryptsharp\ByteArray.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Crypto\Cryptsharp\Check.cs">
-      <Link>Check.cs</Link>
+      <Link>Crypto\Cryptsharp\Check.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Crypto\Cryptsharp\Exceptions.cs">
-      <Link>Exceptions.cs</Link>
+      <Link>Crypto\Cryptsharp\Exceptions.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Crypto\Cryptsharp\Pbkdf2.cs">
-      <Link>Pbkdf2.cs</Link>
+      <Link>Crypto\Cryptsharp\Pbkdf2.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Crypto\Cryptsharp\Salsa20Core.cs">
-      <Link>Salsa20Core.cs</Link>
+      <Link>Crypto\Cryptsharp\Salsa20Core.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Crypto\Cryptsharp\SCrypt.cs">
-      <Link>SCrypt.cs</Link>
+      <Link>Crypto\Cryptsharp\SCrypt.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Crypto\Cryptsharp\Security.cs">
-      <Link>Security.cs</Link>
+      <Link>Crypto\Cryptsharp\Security.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Crypto\DeterministicECDSA.cs">
-      <Link>DeterministicECDSA.cs</Link>
+      <Link>Crypto\DeterministicECDSA.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Crypto\ECDSASignature.cs">
-      <Link>ECDSASignature.cs</Link>
+      <Link>Crypto\ECDSASignature.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Crypto\ECKey.cs">
-      <Link>ECKey.cs</Link>
+      <Link>Crypto\ECKey.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Crypto\Hashes.cs">
-      <Link>Hashes.cs</Link>
+      <Link>Crypto\Hashes.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\DataEncoders\ASCIIEncoder.cs">
-      <Link>ASCIIEncoder.cs</Link>
+      <Link>DataEncoders\ASCIIEncoder.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\DataEncoders\Base58Encoder.cs">
-      <Link>Base58Encoder.cs</Link>
+      <Link>DataEncoders\Base58Encoder.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\DataEncoders\Base64Encoder.cs">
-      <Link>Base64Encoder.cs</Link>
+      <Link>DataEncoders\Base64Encoder.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\DataEncoders\Encoders.cs">
-      <Link>Encoders.cs</Link>
+      <Link>DataEncoders\Encoders.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\DataEncoders\HexEncoder.cs">
-      <Link>HexEncoder.cs</Link>
+      <Link>DataEncoders\HexEncoder.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\IBitcoinSerializable.cs">
       <Link>IBitcoinSerializable.cs</Link>
@@ -200,37 +200,37 @@
       <Link>ObjectStream.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\OpenAsset\Asset.cs">
-      <Link>Asset.cs</Link>
+      <Link>OpenAsset\Asset.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\OpenAsset\AssetId.cs">
-      <Link>AssetId.cs</Link>
+      <Link>OpenAsset\AssetId.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\OpenAsset\BitcoinAssetId.cs">
-      <Link>BitcoinAssetId.cs</Link>
+      <Link>OpenAsset\BitcoinAssetId.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\OpenAsset\CachedColoredTransactionRepository.cs">
-      <Link>CachedColoredTransactionRepository.cs</Link>
+      <Link>OpenAsset\CachedColoredTransactionRepository.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\OpenAsset\ColoredTransaction.cs">
-      <Link>ColoredTransaction.cs</Link>
+      <Link>OpenAsset\ColoredTransaction.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\OpenAsset\ColorMarker.cs">
-      <Link>ColorMarker.cs</Link>
+      <Link>OpenAsset\ColorMarker.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\OpenAsset\Extensions.cs">
-      <Link>Extensions.cs</Link>
+      <Link>OpenAsset\Extensions.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\OpenAsset\IColoredTransactionRepository.cs">
-      <Link>IColoredTransactionRepository.cs</Link>
+      <Link>OpenAsset\IColoredTransactionRepository.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\OpenAsset\NoSqlColoredTransactionRepository.cs">
-      <Link>NoSqlColoredTransactionRepository.cs</Link>
+      <Link>OpenAsset\NoSqlColoredTransactionRepository.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Protocol\Payloads\RejectPayload.cs">
-      <Link>RejectPayload.cs</Link>
+      <Link>Protocol\Payloads\RejectPayload.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Protocol\PerformanceCounter.cs">
-      <Link>PerformanceCounter.cs</Link>
+      <Link>Protocol\PerformanceCounter.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\PubKey.cs">
       <Link>PubKey.cs</Link>
@@ -239,13 +239,13 @@
       <Link>RandomUtils.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\RPC\BlockExplorerFormatter.cs">
-      <Link>BlockExplorerFormatter.cs</Link>
+      <Link>RPC\BlockExplorerFormatter.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\RPC\RawFormatter.cs">
-      <Link>RawFormatter.cs</Link>
+      <Link>RPC\RawFormatter.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\RPC\SatoshiFormatter.cs">
-      <Link>SatoshiFormatter.cs</Link>
+      <Link>RPC\SatoshiFormatter.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Script.cs">
       <Link>Script.cs</Link>
@@ -266,13 +266,13 @@
       <Link>StandardScriptTemplate.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Stealth\BitcoinStealthAddress.cs">
-      <Link>BitcoinStealthAddress.cs</Link>
+      <Link>Stealth\BitcoinStealthAddress.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Stealth\StealthMetadata.cs">
-      <Link>StealthMetadata.cs</Link>
+      <Link>Stealth\StealthMetadata.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Stealth\StealthPayment.cs">
-      <Link>StealthPayment.cs</Link>
+      <Link>Stealth\StealthPayment.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\StreamObjectStream.cs">
       <Link>StreamObjectStream.cs</Link>
@@ -313,8 +313,18 @@
     <Compile Include="..\NBitcoin\Versions.cs">
       <Link>Versions.cs</Link>
     </Compile>
+    <Compile Include="..\NBitcoin\Payment\HttpEncoder.cs">
+		<Link>Payment\HttpEncoder.cs</Link>
+	</Compile>
+    <Compile Include="..\NBitcoin\Payment\HttpUtility.cs">
+		<Link>Payment\HttpUtility.cs</Link>
+	</Compile>
     <Compile Include="RandomUtils.partial.cs" />
     <Compile Include="TraceStub\TraceSource.cs" />
+    <Compile Include="Payment\BitcoinUrlBuilder.cs" />
+    <Compile Include="..\NBitcoin\Payment\UriHelper.cs" >
+		<Link>Payment\UriHelper.cs</Link>
+	</Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\NBitcoin\MedianFilter.tt">
@@ -337,7 +347,7 @@
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
-	<Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" Condition="'$(Portable)' == '1'" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" Condition="'$(Portable)' == '1'" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/NBitcoin.Portable/NBitcoin.Portable(portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1).csproj
+++ b/NBitcoin.Portable/NBitcoin.Portable(portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1).csproj
@@ -41,22 +41,22 @@
       <Link>Base58Data.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\BIP32\BitcoinExtKey.cs">
-      <Link>BitcoinExtKey.cs</Link>
+      <Link>BIP32\BitcoinExtKey.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\BIP32\ExtKey.cs">
-      <Link>ExtKey.cs</Link>
+      <Link>BIP32\ExtKey.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\BIP32\ExtPubKey.cs">
-      <Link>ExtPubKey.cs</Link>
+      <Link>BIP32\ExtPubKey.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\BIP32\KeyPath.cs">
-      <Link>KeyPath.cs</Link>
+      <Link>BIP32\KeyPath.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\BIP38\BitcoinConfirmationCode.cs">
-      <Link>BitcoinConfirmationCode.cs</Link>
+      <Link>BIP38\BitcoinConfirmationCode.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\BIP38\BitcoinEncryptedSecret.cs">
-      <Link>BitcoinEncryptedSecret.cs</Link>
+      <Link>BIP38\BitcoinEncryptedSecret.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Coins.cs">
       <Link>Coins.cs</Link>
@@ -74,7 +74,7 @@
       <Link>Properties\AssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\BIP38\BitcoinPassphraseCode.cs">
-      <Link>BitcoinPassphraseCode.cs</Link>
+      <Link>BIP38\BitcoinPassphraseCode.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\BitcoinAddress.cs">
       <Link>BitcoinAddress.cs</Link>
@@ -113,58 +113,58 @@
       <Link>CompositeDisposable.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Crypto\Cryptsharp\BitMath.cs">
-      <Link>BitMath.cs</Link>
+      <Link>Crypto\Cryptsharp\BitMath.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Crypto\Cryptsharp\BitPacking.cs">
-      <Link>BitPacking.cs</Link>
+      <Link>Crypto\Cryptsharp\BitPacking.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Crypto\Cryptsharp\ByteArray.cs">
-      <Link>ByteArray.cs</Link>
+      <Link>Crypto\Cryptsharp\ByteArray.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Crypto\Cryptsharp\Check.cs">
-      <Link>Check.cs</Link>
+      <Link>Crypto\Cryptsharp\Check.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Crypto\Cryptsharp\Exceptions.cs">
-      <Link>Exceptions.cs</Link>
+      <Link>Crypto\Cryptsharp\Exceptions.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Crypto\Cryptsharp\Pbkdf2.cs">
-      <Link>Pbkdf2.cs</Link>
+      <Link>Crypto\Cryptsharp\Pbkdf2.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Crypto\Cryptsharp\Salsa20Core.cs">
-      <Link>Salsa20Core.cs</Link>
+      <Link>Crypto\Cryptsharp\Salsa20Core.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Crypto\Cryptsharp\SCrypt.cs">
-      <Link>SCrypt.cs</Link>
+      <Link>Crypto\Cryptsharp\SCrypt.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Crypto\Cryptsharp\Security.cs">
-      <Link>Security.cs</Link>
+      <Link>Crypto\Cryptsharp\Security.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Crypto\DeterministicECDSA.cs">
-      <Link>DeterministicECDSA.cs</Link>
+      <Link>Crypto\DeterministicECDSA.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Crypto\ECDSASignature.cs">
-      <Link>ECDSASignature.cs</Link>
+      <Link>Crypto\ECDSASignature.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Crypto\ECKey.cs">
-      <Link>ECKey.cs</Link>
+      <Link>Crypto\ECKey.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Crypto\Hashes.cs">
-      <Link>Hashes.cs</Link>
+      <Link>Crypto\Hashes.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\DataEncoders\ASCIIEncoder.cs">
-      <Link>ASCIIEncoder.cs</Link>
+      <Link>DataEncoders\ASCIIEncoder.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\DataEncoders\Base58Encoder.cs">
-      <Link>Base58Encoder.cs</Link>
+      <Link>DataEncoders\Base58Encoder.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\DataEncoders\Base64Encoder.cs">
-      <Link>Base64Encoder.cs</Link>
+      <Link>DataEncoders\Base64Encoder.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\DataEncoders\Encoders.cs">
-      <Link>Encoders.cs</Link>
+      <Link>DataEncoders\Encoders.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\DataEncoders\HexEncoder.cs">
-      <Link>HexEncoder.cs</Link>
+      <Link>DataEncoders\HexEncoder.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\IBitcoinSerializable.cs">
       <Link>IBitcoinSerializable.cs</Link>
@@ -203,37 +203,37 @@
       <Link>ObjectStream.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\OpenAsset\Asset.cs">
-      <Link>Asset.cs</Link>
+      <Link>OpenAsset\Asset.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\OpenAsset\AssetId.cs">
-      <Link>AssetId.cs</Link>
+      <Link>OpenAsset\AssetId.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\OpenAsset\BitcoinAssetId.cs">
-      <Link>BitcoinAssetId.cs</Link>
+      <Link>OpenAsset\BitcoinAssetId.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\OpenAsset\CachedColoredTransactionRepository.cs">
-      <Link>CachedColoredTransactionRepository.cs</Link>
+      <Link>OpenAsset\CachedColoredTransactionRepository.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\OpenAsset\ColoredTransaction.cs">
-      <Link>ColoredTransaction.cs</Link>
+      <Link>OpenAsset\ColoredTransaction.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\OpenAsset\ColorMarker.cs">
-      <Link>ColorMarker.cs</Link>
+      <Link>OpenAsset\ColorMarker.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\OpenAsset\Extensions.cs">
-      <Link>Extensions.cs</Link>
+      <Link>OpenAsset\Extensions.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\OpenAsset\IColoredTransactionRepository.cs">
-      <Link>IColoredTransactionRepository.cs</Link>
+      <Link>OpenAsset\IColoredTransactionRepository.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\OpenAsset\NoSqlColoredTransactionRepository.cs">
-      <Link>NoSqlColoredTransactionRepository.cs</Link>
+      <Link>OpenAsset\NoSqlColoredTransactionRepository.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Protocol\Payloads\RejectPayload.cs">
-      <Link>RejectPayload.cs</Link>
+      <Link>Protocol\Payloads\RejectPayload.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Protocol\PerformanceCounter.cs">
-      <Link>PerformanceCounter.cs</Link>
+      <Link>Protocol\PerformanceCounter.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\PubKey.cs">
       <Link>PubKey.cs</Link>
@@ -242,13 +242,13 @@
       <Link>RandomUtils.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\RPC\BlockExplorerFormatter.cs">
-      <Link>BlockExplorerFormatter.cs</Link>
+      <Link>RPC\BlockExplorerFormatter.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\RPC\RawFormatter.cs">
-      <Link>RawFormatter.cs</Link>
+      <Link>RPC\RawFormatter.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\RPC\SatoshiFormatter.cs">
-      <Link>SatoshiFormatter.cs</Link>
+      <Link>RPC\SatoshiFormatter.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Script.cs">
       <Link>Script.cs</Link>
@@ -269,13 +269,13 @@
       <Link>StandardScriptTemplate.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Stealth\BitcoinStealthAddress.cs">
-      <Link>BitcoinStealthAddress.cs</Link>
+      <Link>Stealth\BitcoinStealthAddress.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Stealth\StealthMetadata.cs">
-      <Link>StealthMetadata.cs</Link>
+      <Link>Stealth\StealthMetadata.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\Stealth\StealthPayment.cs">
-      <Link>StealthPayment.cs</Link>
+      <Link>Stealth\StealthPayment.cs</Link>
     </Compile>
     <Compile Include="..\NBitcoin\StreamObjectStream.cs">
       <Link>StreamObjectStream.cs</Link>
@@ -316,6 +316,12 @@
     <Compile Include="..\NBitcoin\Versions.cs">
       <Link>Versions.cs</Link>
     </Compile>
+    <Compile Include="..\NBitcoin\Payment\HttpEncoder.cs">
+        <Link>Payment\HttpEncoder.cs</Link>
+    </Compile>
+    <Compile Include="..\NBitcoin\Payment\HttpUtility.cs">
+        <Link>Payment\HttpUtility.cs</Link>
+    </Compile>
     <Compile Include="RandomUtils.partial.cs" />
     <Compile Include="System.Numerics\BigInteger.cs" />
     <Compile Include="System.Numerics\BigIntegerBuilder.cs" />
@@ -324,6 +330,10 @@
     <Compile Include="System.Numerics\NumericsHelpers.cs" />
     <Compile Include="System.Numerics\SR.cs" />
     <Compile Include="TraceStub\TraceSource.cs" />
+	<Compile Include="Payment\BitcoinUrlBuilder.cs" />
+    <Compile Include="..\NBitcoin\Payment\UriHelper.cs" >
+        <Link>Payment\UriHelper.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\NBitcoin\MedianFilter.tt">

--- a/NBitcoin.Portable/Payment/BitcoinUrlBuilder.cs
+++ b/NBitcoin.Portable/Payment/BitcoinUrlBuilder.cs
@@ -1,0 +1,174 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Web.NBitcoin;
+
+namespace NBitcoin.Payment
+{
+	/// <summary>
+	/// https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki
+	/// </summary>
+	public class BitcoinUrlBuilder
+	{
+		public BitcoinUrlBuilder()
+		{
+
+		}
+		public BitcoinUrlBuilder(Uri uri)
+			: this(uri.AbsoluteUri)
+		{
+
+		}
+		public BitcoinUrlBuilder(string uri)
+		{
+			if(!uri.StartsWith("bitcoin:", StringComparison.OrdinalIgnoreCase))
+				throw new FormatException("Invalid scheme");
+			uri = uri.Remove(0, "bitcoin:".Length);
+			if(uri.StartsWith("//"))
+				uri = uri.Remove(0, 2);
+
+			var paramStart = uri.IndexOf('?');
+			string address = null;
+			if(paramStart == -1)
+				address = uri;
+			else
+			{
+				address = uri.Substring(0, paramStart);
+				uri = uri.Remove(0, 1); //remove ?
+			}
+			if(address != String.Empty)
+			{
+				Address = Network.CreateFromBase58Data<BitcoinAddress>(address);
+			}
+			uri = uri.Remove(0, address.Length);
+
+			var parameters = UriHelper.DecodeQueryParameters(uri);
+			if(parameters.ContainsKey("amount"))
+			{
+				Amount = Money.Parse(parameters["amount"]);
+				parameters.Remove("amount");
+			}
+			if(parameters.ContainsKey("label"))
+			{
+				Label = parameters["label"];
+				parameters.Remove("label");
+			}
+			if(parameters.ContainsKey("message"))
+			{
+				Message = parameters["message"];
+				parameters.Remove("message");
+			}
+			if(parameters.ContainsKey("r"))
+			{
+				PaymentRequestUrl = new Uri(parameters["r"], UriKind.Absolute);
+				parameters.Remove("r");
+			}
+			_UnknowParameters = parameters;
+			var reqParam = parameters.Keys.FirstOrDefault(k => k.StartsWith("req-", StringComparison.OrdinalIgnoreCase));
+			if(reqParam != null)
+				throw new FormatException("Non compatible required parameter " + reqParam);
+		}
+
+		private readonly Dictionary<string, string> _UnknowParameters = new Dictionary<string,string>();
+		public Dictionary<string,string> UnknowParameters
+		{
+			get
+			{
+				return _UnknowParameters;
+			}
+		}
+
+		/// <summary>
+		/// https://github.com/bitcoin/bips/blob/master/bip-0072.mediawiki
+		/// </summary>
+		public Uri PaymentRequestUrl
+		{
+			get;
+			set;
+		}
+
+		public BitcoinAddress Address
+		{
+			get;
+			set;
+		}
+		public Money Amount
+		{
+			get;
+			set;
+		}
+		public string Label
+		{
+			get;
+			set;
+		}
+		public string Message
+		{
+			get;
+			set;
+		}
+		public Uri Uri
+		{
+			get
+			{
+				Dictionary<string, string> parameters = new Dictionary<string, string>();
+				StringBuilder builder = new StringBuilder();
+				builder.Append("bitcoin:");
+				if(Address != null)
+				{
+					builder.Append(Address.ToString());
+				}
+
+				if(Amount != null)
+				{
+					parameters.Add("amount", Amount.ToString());
+				}
+				if(Label != null)
+				{
+					parameters.Add("label", Label.ToString());
+				}
+				if(Message != null)
+				{
+					parameters.Add("message", Message.ToString());
+				}
+				if(PaymentRequestUrl != null)
+				{
+					parameters.Add("r", PaymentRequestUrl.ToString());
+				}
+
+				foreach(var kv in UnknowParameters)
+				{
+					parameters.Add(kv.Key, kv.Value);
+				}
+
+				WriteParameters(parameters, builder);
+
+				return new System.Uri(builder.ToString(), UriKind.Absolute);
+			}
+		}
+
+		private static void WriteParameters(Dictionary<string, string> parameters, StringBuilder builder)
+		{
+			bool first = true;
+			foreach(var parameter in parameters)
+			{
+				if(first)
+				{
+					first = false;
+					builder.Append("?");
+				}
+				else
+					builder.Append("&");
+				builder.Append(parameter.Key);
+				builder.Append("=");
+				builder.Append(HttpUtility.UrlEncode(parameter.Value));
+			}
+		}
+
+		public override string ToString()
+		{
+			return Uri.AbsoluteUri;
+		}
+	}
+}


### PR DESCRIPTION
Just a small update to niceify the code, and also add support for one crucial part: BitcoinUriBuilder.
Unfortunately some code is different on Portable platform, so that had to be changed (mainly the StringComparison and the namespaces used).
