### PR TITLE
Refactoring - Split Base58Encoder and Base58CheckEncoder

### DIFF
--- a/NBitcoin/DataEncoders/Base58Encoder.cs
+++ b/NBitcoin/DataEncoders/Base58Encoder.cs
@@ -66,12 +66,12 @@ namespace NBitcoin.DataEncoders
 				var dv = BigInteger.DivRem(bn, bn58, out rem);
 				bn = dv;
 				var c = (int)rem;
-				str += PszBase58[c];
+				str += pszBase58[c];
 			}
 
 			// Leading zeroes encoded as base58 zeros
 			for (int i = offset; i < offset+count && data[i] == 0; i++)
-				str += PszBase58[0];
+				str += pszBase58[0];
 
 			// Convert little endian std::string to big endian
 			str = new String(str.ToCharArray().Reverse().ToArray()); //keep that way to be portable
@@ -79,7 +79,7 @@ namespace NBitcoin.DataEncoders
 		}
 
 
-		const string PszBase58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+		const string pszBase58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 
 
 		public override byte[] DecodeData(string encoded)
@@ -102,7 +102,7 @@ namespace NBitcoin.DataEncoders
 
 			for(int y = i ; y < encoded.Length ; y++)
 			{
-				var p1 = PszBase58.IndexOf(encoded[y]);
+				var p1 = pszBase58.IndexOf(encoded[y]);
 				if(p1 == -1)
 				{
 					while(IsSpace(encoded[y]))
@@ -131,7 +131,7 @@ namespace NBitcoin.DataEncoders
 
 			// Restore leading zeros
 			int nLeadingZeros = 0;
-			for(int y = i ; y < encoded.Length && encoded[y] == PszBase58[0] ; y++)
+			for(int y = i ; y < encoded.Length && encoded[y] == pszBase58[0] ; y++)
 				nLeadingZeros++;
 
 

--- a/NBitcoin/DataEncoders/Base58Encoder.cs
+++ b/NBitcoin/DataEncoders/Base58Encoder.cs
@@ -5,54 +5,73 @@ using System.Numerics;
 
 namespace NBitcoin.DataEncoders
 {
+	public class Base58CheckEncoder : Base58Encoder
+	{
+		private static readonly Base58Encoder InternalEncoder = new Base58Encoder();
+
+		public override string EncodeData(byte[] data, int offset, int count)
+		{
+			var toEncode = new byte[count + 4];
+			Buffer.BlockCopy(data, offset, toEncode, 0, count);
+
+			var hash = Hashes.Hash256(data, offset, count).ToBytes();
+			Buffer.BlockCopy(hash, 0, toEncode, count, 4);
+
+			return InternalEncoder.EncodeData(toEncode, 0, toEncode.Length);
+		}
+
+		public override byte[] DecodeData(string encoded)
+		{
+			var vchRet = InternalEncoder.DecodeData(encoded);
+			if (vchRet.Length < 4)
+			{
+				Array.Clear(vchRet, 0, vchRet.Length);
+				throw new FormatException("Invalid checked base 58 string");
+			}
+			var calculatedHash = Hashes.Hash256(vchRet, 0, vchRet.Length - 4).ToBytes().SafeSubarray(0, 4);
+			var expectedHash = vchRet.SafeSubarray(vchRet.Length - 4, 4);
+
+			if (!Utils.ArrayEqual(calculatedHash, expectedHash))
+			{
+				Array.Clear(vchRet, 0, vchRet.Length);
+				throw new FormatException("Invalid hash of the base 58 string");
+			}
+			vchRet = vchRet.SafeSubarray(0, vchRet.Length - 4);
+			return vchRet;
+		}
+	}
+
 	public class Base58Encoder : DataEncoder
 	{
 		public override string EncodeData(byte[] data, int offset, int count)
-		{
-			if(Check)
-			{
-				var toEncode = new byte[count + 4];
-				Buffer.BlockCopy(data, offset, toEncode, 0, count);
-
-				var hash = Hashes.Hash256(data, offset, count).ToBytes();
-				Buffer.BlockCopy(hash, 0, toEncode, count, 4);
-
-				return EncodeDataCore(toEncode, 0, toEncode.Length);
-			}
-
-			return EncodeDataCore(data, offset, count);
-		}
-
-		private static string EncodeDataCore(byte[] data, int offset, int count)
 		{
 			BigInteger bn58 = 58;
 			BigInteger bn0 = 0;
 
 			// Convert big endian data to little endian
 			// Extra zero at the end make sure bignum will interpret as a positive number
-			byte[] vchTmp = data.SafeSubarray(offset, count).Reverse().Concat(new byte[] { 0x00 }).ToArray();
+			var vchTmp = data.SafeSubarray(offset, count).Reverse().Concat(new byte[] { 0x00 }).ToArray();
 
 			// Convert little endian data to bignum
-			BigInteger bn = new BigInteger(vchTmp);
+			var bn = new BigInteger(vchTmp);
 
 			// Convert bignum to std::string
-			String str = "";
+			var str = "";
 			// Expected size increase from base58 conversion is approximately 137%
 			// use 138% to be safe
 
-			BigInteger dv = BigInteger.Zero;
-			BigInteger rem = BigInteger.Zero;
 			while(bn > bn0)
 			{
-				dv = BigInteger.DivRem(bn, bn58, out rem);
+				BigInteger rem;
+				var dv = BigInteger.DivRem(bn, bn58, out rem);
 				bn = dv;
 				var c = (int)rem;
-				str += pszBase58[c];
+				str += PszBase58[c];
 			}
 
 			// Leading zeroes encoded as base58 zeros
 			for (int i = offset; i < offset+count && data[i] == 0; i++)
-				str += pszBase58[0];
+				str += PszBase58[0];
 
 			// Convert little endian std::string to big endian
 			str = new String(str.ToCharArray().Reverse().ToArray()); //keep that way to be portable
@@ -60,7 +79,7 @@ namespace NBitcoin.DataEncoders
 		}
 
 
-		const string pszBase58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+		const string PszBase58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 
 
 		public override byte[] DecodeData(string encoded)
@@ -68,37 +87,11 @@ namespace NBitcoin.DataEncoders
 			if (encoded == null)
 				throw new ArgumentNullException("encoded");
 
-			if(Check)
-			{
-				var vchRet = DecodeDataCore(encoded);
-				if(vchRet.Length < 4)
-				{
-					Array.Clear(vchRet, 0, vchRet.Length);
-					throw new FormatException("Invalid checked base 58 string");
-				}
-				var calculatedHash = Hashes.Hash256(vchRet, 0, vchRet.Length - 4).ToBytes().SafeSubarray(0, 4);
-				var expectedHash = vchRet.SafeSubarray(vchRet.Length - 4, 4);
-
-				if(!Utils.ArrayEqual(calculatedHash, expectedHash))
-				{
-					Array.Clear(vchRet, 0, vchRet.Length);
-					throw new FormatException("Invalid hash of the base 58 string");
-				}
-				vchRet = vchRet.SafeSubarray(0, vchRet.Length - 4);
-				return vchRet;
-			}
-
-			return DecodeDataCore(encoded);
-		}
-
-		private static byte[] DecodeDataCore(string encoded)
-		{
 			var result = new byte[0];
 			if(encoded.Length == 0)
 				return result;
 			BigInteger bn58 = 58;
 			BigInteger bn = 0;
-			BigInteger bnChar;
 			int i = 0;
 			while(IsSpace(encoded[i]))
 			{
@@ -109,7 +102,7 @@ namespace NBitcoin.DataEncoders
 
 			for(int y = i ; y < encoded.Length ; y++)
 			{
-				var p1 = pszBase58.IndexOf(encoded[y]);
+				var p1 = PszBase58.IndexOf(encoded[y]);
 				if(p1 == -1)
 				{
 					while(IsSpace(encoded[y]))
@@ -122,7 +115,7 @@ namespace NBitcoin.DataEncoders
 						throw new FormatException("Invalid base 58 string");
 					break;
 				}
-				bnChar = new BigInteger(p1);
+				var bnChar = new BigInteger(p1);
 				bn = BigInteger.Multiply(bn, bn58);
 				bn += bnChar;
 			}
@@ -138,20 +131,13 @@ namespace NBitcoin.DataEncoders
 
 			// Restore leading zeros
 			int nLeadingZeros = 0;
-			for(int y = i ; y < encoded.Length && encoded[y] == pszBase58[0] ; y++)
+			for(int y = i ; y < encoded.Length && encoded[y] == PszBase58[0] ; y++)
 				nLeadingZeros++;
 
 
 			result = new byte[nLeadingZeros + vchTmp.Length];
 			Array.Copy(vchTmp.Reverse().ToArray(), 0, result, nLeadingZeros, vchTmp.Length);
 			return result;
-		}
-
-
-		public bool Check
-		{
-			get;
-			set;
 		}
 	}
 }

--- a/NBitcoin/DataEncoders/Encoders.cs
+++ b/NBitcoin/DataEncoders/Encoders.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Globalization;
-using System.Linq;
-
-namespace NBitcoin.DataEncoders
+﻿namespace NBitcoin.DataEncoders
 {
 	public abstract class DataEncoder
 	{
@@ -65,10 +61,7 @@ namespace NBitcoin.DataEncoders
 			}
 		}
 
-		static readonly Base58Encoder _Base58Check = new Base58Encoder()
-				{
-					Check = true
-				};
+		private static readonly Base58CheckEncoder _Base58Check = new Base58CheckEncoder();
 		public static DataEncoder Base58Check
 		{
 			get
@@ -85,48 +78,5 @@ namespace NBitcoin.DataEncoders
 				return _Base64;
 			}
 		}
-
-		//public static DataEncoder Bin
-		//{
-		//	get
-		//	{
-		//		return null;
-		//	}
-		//}
-		//public static DataEncoder Dec
-		//{
-		//	get
-		//	{
-		//		return null;
-		//	}
-		//}
-		//public static DataEncoder RFC1751
-		//{
-		//	get
-		//	{
-		//		return null;
-		//	}
-		//}
-		//public static DataEncoder Poetry
-		//{
-		//	get
-		//	{
-		//		return null;
-		//	}
-		//}
-		//public static DataEncoder Rot13
-		//{
-		//	get
-		//	{
-		//		return null;
-		//	}
-		//}
-		//public static DataEncoder Easy16
-		//{
-		//	get
-		//	{
-		//		return null;
-		//	}
-		//}
 	}
 }


### PR DESCRIPTION
This PR splits the Base58Encoder in two classes 

- **Base58Encoder** and,
- **Base58CheckEncoder**

It makes the code easier to read and avoid the need for having the **Check property flag**, the **if(Check) statement** and the **private methods**. The change is quite isolated with no side effects. The **Core Tests** pass green all.