### PR TITLE
private key valid in range [1, N-1]

### DIFF
--- a/NBitcoin/Key.cs
+++ b/NBitcoin/Key.cs
@@ -69,8 +69,8 @@ namespace NBitcoin
 
 		private static bool Check(byte[] vch)
 		{
-			var candidate = new uint256(vch.SafeSubarray(0, KEY_SIZE));
-			return candidate < N;
+			var candidateKey = new uint256(vch.SafeSubarray(0, KEY_SIZE));
+			return candidateKey > 0 && candidateKey < N;
 		}
 
 		PubKey _PubKey;


### PR DESCRIPTION
According to [rfc6979](https://tools.ietf.org/html/rfc6979), private key must be in the range [1, N-1]. 