### PR TITLE
Add LowS flag in Standard ScriptVerify for reducing malleability Tx attacks

### DIFF
--- a/NBitcoin/Script.cs
+++ b/NBitcoin/Script.cs
@@ -89,13 +89,14 @@ namespace NBitcoin
  * blocks and we must accept those blocks.
  */
 		Standard =
-			Mandatory |
-			DerSig |
-			StrictEnc |
-			MinimalData |
-			NullDummy |
-			DiscourageUpgradableNops |
-			CleanStack,
+			  Mandatory
+			| DerSig
+			| StrictEnc
+			| MinimalData
+			| NullDummy
+			| DiscourageUpgradableNops
+			| CleanStack
+			| LowS
 	}
 
 	/** Signature hash types/flags */


### PR DESCRIPTION
@NicolasDorier this PR is for adding the ScriptVerify.LowS flag in the ScriptVerify.Standard to require the usage of the low S value in the ECDSA signature when NBitcoin validates transactions. Also, have in mind that this flag is used when calling the *bitcoinconsensus_verify_script* function (core consensus library).

This cames from the gmaxwell's PR https://github.com/bitcoin/bitcoin/pull/6769. Take a look at it. 