### PR TITLE
Add method to retrieve chain code bytes for an ExtKey object.

### DIFF
--- a/NBitcoin/BIP32/ExtKey.cs
+++ b/NBitcoin/BIP32/ExtKey.cs
@@ -38,6 +38,16 @@ namespace NBitcoin
 				return nChild;
 			}
 		}
+		public byte[] ChainCode
+		{
+			get
+			{
+				byte[] chainCodeCopy = new byte[vchChainCode.Length];
+				Buffer.BlockCopy(vchChainCode, 0, chainCodeCopy, 0, vchChainCode.Length);
+
+				return chainCodeCopy;
+			}
+		}
 
 		public ExtKey(BitcoinExtPubKey extPubKey, BitcoinSecret key)
 			: this(extPubKey.ExtPubKey, key.PrivateKey)

--- a/NBitcoin/BIP32/ExtPubKey.cs
+++ b/NBitcoin/BIP32/ExtPubKey.cs
@@ -54,6 +54,16 @@ namespace NBitcoin
 				return pubkey;
 			}
 		}
+		public byte[] ChainCode
+		{
+			get
+			{
+				byte[] chainCodeCopy = new byte[vchChainCode.Length];
+				Buffer.BlockCopy(vchChainCode, 0, chainCodeCopy, 0, vchChainCode.Length);
+
+				return chainCodeCopy;
+			}
+		}
 
 		internal ExtPubKey()
 		{


### PR DESCRIPTION
I need to get (and use) the chain code for generated HD nodes. I tried retrieving the chain code by calling GetBytes() so I can use the right 256 bits for the chain code, but somehow GetBytes returns 592 bits instead of the expect 512 bits (left 256 bits master private key, right 256 bits master chain code). Since the chain code bytes are right there in the class as a private byte array I think it would be very useful to expose them through a method.

Let me know what you think about this approach (I need the chain code no matter what though).