### PR TITLE
Removed unused references

### DIFF
--- a/NBitcoin/NBitcoin.csproj
+++ b/NBitcoin/NBitcoin.csproj
@@ -42,14 +42,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Base58Data.cs" />


### PR DESCRIPTION
I have removed some unused assembly reference from the main project.
I see that also Microsoft.CSharp is unused, but I have not removed it, as removing it will help if someone wish to use a previous framework version but on the other side keeping it can be useful if in future someone need dynamic keyword. Let me know your preference.

Very good job your cleanup of BC. Just to understand there is a reason for the unreferenced interfaces (like for example Asn1SetParser) you keep there ?

