### PR TITLE
ExtKey constructor to create object from a private key and chain code

### DIFF
--- a/NBitcoin/BIP32/ExtKey.cs
+++ b/NBitcoin/BIP32/ExtKey.cs
@@ -65,6 +65,18 @@ namespace NBitcoin
 			this.vchFingerprint = extPubKey.vchFingerprint;
 			this.key = privateKey;
 		}
+        public ExtKey(Key masterKey, byte[] chainCode)
+        {
+            if(masterKey == null)
+                throw new ArgumentNullException("masterKey");
+            if(chainCode == null)
+                throw new ArgumentNullException("chainCode");
+            if(chainCode.Length != vchChainCode.Length)
+                throw new ArgumentException(string.Format("The chain code must be {0} bytes.", vchChainCode.Length), "chainCode");
+
+            this.key = masterKey;
+            Buffer.BlockCopy(chainCode, 0, vchChainCode, 0, vchChainCode.Length);
+        }
 		public ExtKey()
 		{
 			byte[] seed = RandomUtils.GetBytes(64);


### PR DESCRIPTION
As discussed on Twitter (https://twitter.com/NicolasDorier/status/733997857120739328) I have a private key and a chain code and I need to be able to create an ExtKey object from that. I added a constructor that does this.