### PR TITLE
Removed duplicate exclude tag from Common.csproj

### DIFF
--- a/NBitcoin.Portable/Common.csproj
+++ b/NBitcoin.Portable/Common.csproj
@@ -16,9 +16,6 @@
     <ExcludedStuff Include="..\NBitcoin\**\*.partial.cs">
       <Visible>false</Visible>
     </ExcludedStuff>
-    <ExcludedStuff Include="..\NBitcoin\**\*.partial.cs">
-      <Visible>false</Visible>
-    </ExcludedStuff>
     <ExcludedStuff Include="..\NBitcoin\MedianFilter.cs">
       <Visible>false</Visible>
     </ExcludedStuff>


### PR DESCRIPTION
I removed the extra `<ExcludedStuff>` tag since it was a duplicate (so it seems?)

I'm not sure if there was a reason for it to be in there twice, but it seems redundant.