### PR TITLE
Improve ReadEx

### DIFF
--- a/NBitcoin/BitcoinStream.cs
+++ b/NBitcoin/BitcoinStream.cs
@@ -276,7 +276,14 @@ namespace NBitcoin
 
 		private void ReadWriteBytes(ref byte[] data, int offset = 0, int count = -1)
 		{
+			if(data == null) throw new ArgumentNullException("data");
+
+			if(data.Length == 0) return;
+
 			count = count == -1 ? data.Length : count;
+
+			if(count == 0) return;
+
 			if(Serializing)
 			{
 				Inner.Write(data, offset, count);
@@ -285,7 +292,7 @@ namespace NBitcoin
 			else
 			{
 				var readen = Inner.ReadEx(data, offset, count, ReadCancellationToken);
-				if(readen == -1)
+				if(readen == 0)
 					throw new EndOfStreamException("No more byte to read");
 				Counter.AddReaden(readen);
 

--- a/NBitcoin/Network.cs
+++ b/NBitcoin/Network.cs
@@ -36,7 +36,7 @@ namespace NBitcoin
 			this.host = host;
 		}
 #if !NOSOCKET
-        IPAddress[] _Addresses = null;
+		IPAddress[] _Addresses = null;
 		public IPAddress[] GetAddressNodes()
 		{
 			if(_Addresses != null)
@@ -189,7 +189,7 @@ namespace NBitcoin
 		}
 
 #if !NOSOCKET
-        List<DNSSeedData> vSeeds = new List<DNSSeedData>();
+		List<DNSSeedData> vSeeds = new List<DNSSeedData>();
 		List<NetworkAddress> vFixedSeeds = new List<NetworkAddress>();
 #else
 		List<string> vSeeds = new List<string>();
@@ -324,7 +324,7 @@ namespace NBitcoin
 			assert(consensus.HashGenesisBlock == uint256.Parse("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"));
 			assert(genesis.Header.HashMerkleRoot == uint256.Parse("0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
 #if !NOSOCKET
-            vSeeds.Add(new DNSSeedData("bitcoin.sipa.be", "seed.bitcoin.sipa.be")); // Pieter Wuille
+			vSeeds.Add(new DNSSeedData("bitcoin.sipa.be", "seed.bitcoin.sipa.be")); // Pieter Wuille
 			vSeeds.Add(new DNSSeedData("bluematt.me", "dnsseed.bluematt.me")); // Matt Corallo
 			vSeeds.Add(new DNSSeedData("dashjr.org", "dnsseed.bitcoin.dashjr.org")); // Luke Dashjr
 			vSeeds.Add(new DNSSeedData("bitcoinstats.com", "seed.bitcoinstats.com")); // Christian Decker
@@ -347,8 +347,8 @@ namespace NBitcoin
 			base58Prefixes[(int)Base58Type.WITNESS_P2WSH] = new byte[] { (10) };
 
 #if !NOSOCKET
-            // Convert the pnSeeds array into usable address objects.
-            Random rand = new Random();
+			// Convert the pnSeeds array into usable address objects.
+			Random rand = new Random();
 			TimeSpan nOneWeek = TimeSpan.FromDays(7);
 			for(int i = 0; i < pnSeed.Length; i++)
 			{
@@ -395,7 +395,7 @@ namespace NBitcoin
 			assert(consensus.HashGenesisBlock == uint256.Parse("0x000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"));
 
 #if !NOSOCKET
-            vFixedSeeds.Clear();
+			vFixedSeeds.Clear();
 			vSeeds.Clear();
 			vSeeds.Add(new DNSSeedData("bitcoin.petertodd.org", "testnet-seed.bitcoin.petertodd.org"));
 			vSeeds.Add(new DNSSeedData("bluematt.me", "testnet-seed.bluematt.me"));
@@ -440,8 +440,8 @@ namespace NBitcoin
 			vFixedSeeds.Clear();
 
 #if !NOSOCKET
-            // Convert the pnSeeds array into usable address objects.
-            Random rand = new Random();
+			// Convert the pnSeeds array into usable address objects.
+			Random rand = new Random();
 			TimeSpan nOneWeek = TimeSpan.FromDays(7);
 			var pnSeed = new[] { "37.34.48.17" };
 			for(int i = 0; i < pnSeed.Length; i++)
@@ -495,7 +495,7 @@ namespace NBitcoin
 			assert(consensus.HashGenesisBlock == uint256.Parse("0x0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"));
 
 #if !NOSOCKET
-            vSeeds.Clear();  // Regtest mode doesn't have any DNS seeds.
+			vSeeds.Clear();  // Regtest mode doesn't have any DNS seeds.
 #endif
 			base58Prefixes = Network.TestNet.base58Prefixes.ToArray();
 			base58Prefixes[(int)Base58Type.PUBKEY_ADDRESS] = new byte[] { (111) };
@@ -880,7 +880,7 @@ namespace NBitcoin
 			return new BitcoinScriptAddress(scriptId, this);
 		}
 
-        public Message ParseMessage(byte[] bytes, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION)
+		public Message ParseMessage(byte[] bytes, ProtocolVersion version = ProtocolVersion.PROTOCOL_VERSION)
 		{
 			BitcoinStream bstream = new BitcoinStream(bytes);
 			Message message = new Message();
@@ -894,7 +894,7 @@ namespace NBitcoin
 		}
 
 #if !NOSOCKET
-        public IEnumerable<NetworkAddress> SeedNodes
+		public IEnumerable<NetworkAddress> SeedNodes
 		{
 			get
 			{
@@ -960,7 +960,7 @@ namespace NBitcoin
 				cancellation.ThrowIfCancellationRequested();
 
 				var read = stream.ReadEx(bytes, 0, bytes.Length, cancellation);
-				if(read == -1)
+				if(read == 0)
 					if(throwIfEOF)
 						throw new EndOfStreamException("No more bytes to read");
 					else


### PR DESCRIPTION
This PR does the following:

1. Only take the slow path if token is cancelable.
2. Always call EndRead.
3. Fix stream depletion condition (0 instead of -1).
4. Fix tabs.
5. Generals cleanups. Hope they are OK.
6. Fix callers expecting -1.
8. Fix callers reading 0 bytes. They should not do that. This might have resulted in a performance improvement.
9. Argument validation to harden this brittle code path.

I ran the tests for both ReadEx variants on Desktop 4.6. Is this enough? I don't have anything else set up.

There are test failures but they seem configuration related. Some did not terminate which was annoying. Maybe a test subset could be defined which is easy and safe to run on contributors machines.

I did not test performance since none of this should have caused any regressions.

In the `ReadMagic` method I found `if(read != 1)` which is always false. Maybe this should be reviewed.

Questions:

1. Is it safe to run tests on a computer with a production wallet?
2. Would you consider switching code style over to the default VS style? I can see that the "if(" styling is non-standard. It's easiest to contribute if you can just press Ctrl-K-D. I do that routinely. It removes the need to manually format many trivial things. I found myself constantly fighting the built-in formatting and it can be quite persistent :)

Addresses https://github.com/MetacoSA/NBitcoin/issues/183.