### PR TITLE
Wait for an async in an using block

### DIFF
--- a/NBitcoin/CachedNoSqlRepository.cs
+++ b/NBitcoin/CachedNoSqlRepository.cs
@@ -114,7 +114,8 @@ namespace NBitcoin
 			{
 				InnerRepository
 					.PutBatch(_Removed.Select(k => Tuple.Create<string, IBitcoinSerializable>(k, null))
-							  .Concat(_Added.Select(k => Tuple.Create<string, IBitcoinSerializable>(k, new Raw(_Table[k])))));
+							.Concat(_Added.Select(k => Tuple.Create<string, IBitcoinSerializable>(k, new Raw(_Table[k])))))
+					.GetAwaiter().GetResult();
 				_Removed.Clear();
 				_Added.Clear();
 				_Table.Clear();


### PR DESCRIPTION
The non-blocking async operation, PutBatchAsync(...) was not awaited or
waited in the using block. However, the lock might be released before
the completion of PutBatchAsync(...). Even though there is no memory
accesses in the PutBatchAsync call graph, which need to be protected by
the lock, it is a bad practice to use a fire & forget async call in the
using blocks, especially if the IDisposable object is a lock.

GetAwaiter().GetResult() is used to unwrap the AggrageException.