### PR TITLE
Fix missing cancellation check in ReadEx

### DIFF
--- a/NBitcoin/Utils.cs
+++ b/NBitcoin/Utils.cs
@@ -148,6 +148,12 @@ namespace NBitcoin
 					{
 						WaitHandle.WaitAny(new WaitHandle[] { ar.AsyncWaitHandle, cancellation.WaitHandle }, -1);
 					}
+
+					//EndRead might block, so we need to test cancellation before calling it.
+					//This also is a bug because calling EndRead after BeginRead is contractually required.
+					//A potential fix is to use the ReadAsync API. Another fix is to register a callback with BeginRead that calls EndRead in all cases.
+					cancellation.ThrowIfCancellationRequested(); 
+
 					currentReadCount = stream.EndRead(ar);
 				}
 				else


### PR DESCRIPTION
I added the cancellation check back and documented that there's a bug. Since the bug was present before these changes it's no worse than before.

This fix was missing from my previous work. Since the original PR is now merged I'm submitting a new one.

A better fix would be to use ReadAsync in all ReadEx versions if that API is available and the token can be cancelled. This should be faster than Begin/EndRead for *all* Stream types, even those that do not provide a specialized ReadAsync. Waiting for a task or a cancellation token requires only one WaitHandle which is managed internally. That's why I think it would be faster.

Note, that if ReadAsync is not overriden the token is not used at all. So ReadEx would need to `Task.WaitAll(ioTask, cancellationToken)`. Maybe it's faster to construct a Task from the token and then `Task.WaitAny` on both tasks.

Also, Reflector shows that `NetworkStream.ReadAsync` does not use the token either. Cancellation should not work in the existing code...