### PR TITLE
Minor cosmetics (inconsistent naming and method order)

### DIFF
--- a/NBitcoin/BuilderExtensions/OPTrueExtension.cs
+++ b/NBitcoin/BuilderExtensions/OPTrueExtension.cs
@@ -6,46 +6,46 @@ using System.Threading.Tasks;
 
 namespace NBitcoin.BuilderExtensions
 {
-	public class OPTrueExtension : BuilderExtension
-	{
-		public override bool CanGenerateScriptSig(Script scriptPubKey)
-		{
-			return scriptPubKey.Length == 1 && scriptPubKey.ToBytes(true)[0] == (byte)OpcodeType.OP_TRUE;
-		}
+    public class OPTrueExtension : BuilderExtension
+    {
+        public override bool CanCombineScriptSig(Script scriptPubKey, Script a, Script b)
+        {
+            return false;
+        }
 
-		public override Script GenerateScriptSig(Script scriptPubKey, IKeyRepository keyRepo, ISigner signer)
-		{
-			return Script.Empty;
-		}
+        public override bool CanDeduceScriptPubKey(Script scriptSig)
+        {
+            return false;
+        }
 
-		public override Script DeduceScriptPubKey(Script scriptSig)
-		{
-			throw new NotSupportedException();
-		}
+        public override bool CanEstimateScriptSigSize(Script scriptPubKey)
+        {
+            return CanGenerateScriptSig(scriptPubKey);
+        }
 
-		public override bool CanDeduceScriptPubKey(Script scriptSig)
-		{
-			return false;
-		}
+        public override bool CanGenerateScriptSig(Script scriptPubKey)
+        {
+            return scriptPubKey.Length == 1 && scriptPubKey.ToBytes(true)[0] == (byte)OpcodeType.OP_TRUE;
+        }
 
-		public override bool CanEstimateScriptSigSize(Script scriptPubKey)
-		{
-			return CanGenerateScriptSig(scriptPubKey);
-		}
+        public override Script CombineScriptSig(Script scriptPubKey, Script a, Script b)
+        {
+            throw new NotSupportedException();
+        }
 
-		public override int EstimateScriptSigSize(Script scriptPubKey)
-		{
-			return 1;
-		}
+        public override Script DeduceScriptPubKey(Script scriptSig)
+        {
+            throw new NotSupportedException();
+        }
 
-		public override bool CanCombineScriptSig(Script scriptPubKey, Script a, Script b)
-		{
-			return false;
-		}
+        public override int EstimateScriptSigSize(Script scriptPubKey)
+        {
+            return 1;
+        }
 
-		public override Script CombineScriptSig(Script scriptPubKey, Script a, Script b)
-		{
-			throw new NotSupportedException();
-		}
-	}
+        public override Script GenerateScriptSig(Script scriptPubKey, IKeyRepository keyRepo, ISigner signer)
+        {
+            return Script.Empty;
+        }
+    }
 }

--- a/NBitcoin/BuilderExtensions/OPTrueExtension.cs
+++ b/NBitcoin/BuilderExtensions/OPTrueExtension.cs
@@ -6,46 +6,46 @@ using System.Threading.Tasks;
 
 namespace NBitcoin.BuilderExtensions
 {
-    public class OPTrueExtension : BuilderExtension
-    {
-        public override bool CanCombineScriptSig(Script scriptPubKey, Script a, Script b)
-        {
-            return false;
-        }
+	public class OPTrueExtension : BuilderExtension
+	{
+		public override bool CanCombineScriptSig(Script scriptPubKey, Script a, Script b)
+		{
+			return false;
+		}
 
-        public override bool CanDeduceScriptPubKey(Script scriptSig)
-        {
-            return false;
-        }
+		public override bool CanDeduceScriptPubKey(Script scriptSig)
+		{
+			return false;
+		}
 
-        public override bool CanEstimateScriptSigSize(Script scriptPubKey)
-        {
-            return CanGenerateScriptSig(scriptPubKey);
-        }
+		public override bool CanEstimateScriptSigSize(Script scriptPubKey)
+		{
+			return CanGenerateScriptSig(scriptPubKey);
+		}
 
-        public override bool CanGenerateScriptSig(Script scriptPubKey)
-        {
-            return scriptPubKey.Length == 1 && scriptPubKey.ToBytes(true)[0] == (byte)OpcodeType.OP_TRUE;
-        }
+		public override bool CanGenerateScriptSig(Script scriptPubKey)
+		{
+			return scriptPubKey.Length == 1 && scriptPubKey.ToBytes(true)[0] == (byte)OpcodeType.OP_TRUE;
+		}
 
-        public override Script CombineScriptSig(Script scriptPubKey, Script a, Script b)
-        {
-            throw new NotSupportedException();
-        }
+		public override Script CombineScriptSig(Script scriptPubKey, Script a, Script b)
+		{
+			throw new NotSupportedException();
+		}
 
-        public override Script DeduceScriptPubKey(Script scriptSig)
-        {
-            throw new NotSupportedException();
-        }
+		public override Script DeduceScriptPubKey(Script scriptSig)
+		{
+			throw new NotSupportedException();
+		}
 
-        public override int EstimateScriptSigSize(Script scriptPubKey)
-        {
-            return 1;
-        }
+		public override int EstimateScriptSigSize(Script scriptPubKey)
+		{
+			return 1;
+		}
 
-        public override Script GenerateScriptSig(Script scriptPubKey, IKeyRepository keyRepo, ISigner signer)
-        {
-            return Script.Empty;
-        }
-    }
+		public override Script GenerateScriptSig(Script scriptPubKey, IKeyRepository keyRepo, ISigner signer)
+		{
+			return Script.Empty;
+		}
+	}
 }

--- a/NBitcoin/BuilderExtensions/P2MultiSigBuilderExtension.cs
+++ b/NBitcoin/BuilderExtensions/P2MultiSigBuilderExtension.cs
@@ -6,98 +6,98 @@ using System.Threading.Tasks;
 
 namespace NBitcoin.BuilderExtensions
 {
-    public class P2MultiSigBuilderExtension : BuilderExtension
-    {
-        public override bool CanCombineScriptSig(Script scriptPubKey, Script a, Script b)
-        {
-            return PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey) != null;
-        }
+	public class P2MultiSigBuilderExtension : BuilderExtension
+	{
+		public override bool CanCombineScriptSig(Script scriptPubKey, Script a, Script b)
+		{
+			return PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey) != null;
+		}
 
-        public override bool CanDeduceScriptPubKey(Script scriptSig)
-        {
-            return false;
-        }
+		public override bool CanDeduceScriptPubKey(Script scriptSig)
+		{
+			return false;
+		}
 
-        public override bool CanEstimateScriptSigSize(Script scriptPubKey)
-        {
-            return PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey) != null;
-        }
+		public override bool CanEstimateScriptSigSize(Script scriptPubKey)
+		{
+			return PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey) != null;
+		}
 
-        public override bool CanGenerateScriptSig(Script scriptPubKey)
-        {
-            return PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey) != null;
-        }
+		public override bool CanGenerateScriptSig(Script scriptPubKey)
+		{
+			return PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey) != null;
+		}
 
-        public override Script CombineScriptSig(Script scriptPubKey, Script a, Script b)
-        {
-            var para = PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey);
-            // Combine all the signatures we've got:
-            var aSigs = PayToMultiSigTemplate.Instance.ExtractScriptSigParameters(a);
-            if (aSigs == null)
-                return b;
-            var bSigs = PayToMultiSigTemplate.Instance.ExtractScriptSigParameters(b);
-            if (bSigs == null)
-                return a;
-            int pubkeyCount = 0;
-            TransactionSignature[] sigs = new TransactionSignature[para.PubKeys.Length];
-            for (int i = 0; i < para.PubKeys.Length; i++)
-            {
-                var aSig = i < aSigs.Length ? aSigs[i] : null;
-                var bSig = i < bSigs.Length ? bSigs[i] : null;
-                var sig = aSig ?? bSig;
-                if (sig != null)
-                {
-                    sigs[pubkeyCount] = sig;
-                    pubkeyCount++;
-                }
-                if (pubkeyCount == para.SignatureCount)
-                    break;
-            }
-            if (pubkeyCount == para.SignatureCount)
-                sigs = sigs.Where(s => s != null && s != TransactionSignature.Empty).ToArray();
-            return PayToMultiSigTemplate.Instance.GenerateScriptSig(sigs);
-        }
+		public override Script CombineScriptSig(Script scriptPubKey, Script a, Script b)
+		{
+			var para = PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey);
+			// Combine all the signatures we've got:
+			var aSigs = PayToMultiSigTemplate.Instance.ExtractScriptSigParameters(a);
+			if (aSigs == null)
+				return b;
+			var bSigs = PayToMultiSigTemplate.Instance.ExtractScriptSigParameters(b);
+			if (bSigs == null)
+				return a;
+			int pubkeyCount = 0;
+			TransactionSignature[] sigs = new TransactionSignature[para.PubKeys.Length];
+			for (int i = 0; i < para.PubKeys.Length; i++)
+			{
+				var aSig = i < aSigs.Length ? aSigs[i] : null;
+				var bSig = i < bSigs.Length ? bSigs[i] : null;
+				var sig = aSig ?? bSig;
+				if (sig != null)
+				{
+					sigs[pubkeyCount] = sig;
+					pubkeyCount++;
+				}
+				if (pubkeyCount == para.SignatureCount)
+					break;
+			}
+			if (pubkeyCount == para.SignatureCount)
+				sigs = sigs.Where(s => s != null && s != TransactionSignature.Empty).ToArray();
+			return PayToMultiSigTemplate.Instance.GenerateScriptSig(sigs);
+		}
 
-        public override Script DeduceScriptPubKey(Script scriptSig)
-        {
-            throw new NotImplementedException();
-        }
+		public override Script DeduceScriptPubKey(Script scriptSig)
+		{
+			throw new NotImplementedException();
+		}
 
-        public override int EstimateScriptSigSize(Script scriptPubKey)
-        {
-            var p2mk = PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey);
-            return PayToMultiSigTemplate.Instance.GenerateScriptSig(Enumerable.Range(0, p2mk.SignatureCount).Select(o => DummySignature).ToArray()).Length;
-        }
+		public override int EstimateScriptSigSize(Script scriptPubKey)
+		{
+			var p2mk = PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey);
+			return PayToMultiSigTemplate.Instance.GenerateScriptSig(Enumerable.Range(0, p2mk.SignatureCount).Select(o => DummySignature).ToArray()).Length;
+		}
 
-        public override Script GenerateScriptSig(Script scriptPubKey, IKeyRepository keyRepo, ISigner signer)
-        {
-            var multiSigParams = PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey);
-            TransactionSignature[] signatures = new TransactionSignature[multiSigParams.PubKeys.Length];
-            var keys =
-                multiSigParams
-                .PubKeys
-                .Select(p => keyRepo.FindKey(p.ScriptPubKey))
-                .ToArray();
+		public override Script GenerateScriptSig(Script scriptPubKey, IKeyRepository keyRepo, ISigner signer)
+		{
+			var multiSigParams = PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey);
+			TransactionSignature[] signatures = new TransactionSignature[multiSigParams.PubKeys.Length];
+			var keys =
+				multiSigParams
+				.PubKeys
+				.Select(p => keyRepo.FindKey(p.ScriptPubKey))
+				.ToArray();
 
-            int sigCount = 0;
-            for (int i = 0; i < keys.Length; i++)
-            {
-                if (sigCount == multiSigParams.SignatureCount)
-                    break;
-                if (keys[i] != null)
-                {
-                    var sig = signer.Sign(keys[i]);
-                    signatures[i] = sig;
-                    sigCount++;
-                }
-            }
+			int sigCount = 0;
+			for (int i = 0; i < keys.Length; i++)
+			{
+				if (sigCount == multiSigParams.SignatureCount)
+					break;
+				if (keys[i] != null)
+				{
+					var sig = signer.Sign(keys[i]);
+					signatures[i] = sig;
+					sigCount++;
+				}
+			}
 
-            IEnumerable<TransactionSignature> sigs = signatures;
-            if (sigCount == multiSigParams.SignatureCount)
-            {
-                sigs = sigs.Where(s => s != TransactionSignature.Empty && s != null);
-            }
-            return PayToMultiSigTemplate.Instance.GenerateScriptSig(sigs);
-        }
-    }
+			IEnumerable<TransactionSignature> sigs = signatures;
+			if (sigCount == multiSigParams.SignatureCount)
+			{
+				sigs = sigs.Where(s => s != TransactionSignature.Empty && s != null);
+			}
+			return PayToMultiSigTemplate.Instance.GenerateScriptSig(sigs);
+		}
+	}
 }

--- a/NBitcoin/BuilderExtensions/P2MultiSigBuilderExtension.cs
+++ b/NBitcoin/BuilderExtensions/P2MultiSigBuilderExtension.cs
@@ -6,98 +6,98 @@ using System.Threading.Tasks;
 
 namespace NBitcoin.BuilderExtensions
 {
-	public class P2MultiSigBuilderExtension : BuilderExtension
-	{
-		public override bool CanGenerateScriptSig(Script scriptPubkey)
-		{
-			return PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubkey) != null;
-		}
+    public class P2MultiSigBuilderExtension : BuilderExtension
+    {
+        public override bool CanCombineScriptSig(Script scriptPubKey, Script a, Script b)
+        {
+            return PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey) != null;
+        }
 
-		public override Script GenerateScriptSig(Script scriptPubKey, IKeyRepository keyRepo, ISigner signer)
-		{
-			var multiSigParams = PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey);
-			TransactionSignature[] signatures = new TransactionSignature[multiSigParams.PubKeys.Length];
-			var keys =
-				multiSigParams
-				.PubKeys
-				.Select(p => keyRepo.FindKey(p.ScriptPubKey))
-				.ToArray();
+        public override bool CanDeduceScriptPubKey(Script scriptSig)
+        {
+            return false;
+        }
 
-			int sigCount = 0;
-			for(int i = 0; i < keys.Length; i++)
-			{
-				if(sigCount == multiSigParams.SignatureCount)
-					break;
-				if(keys[i] != null)
-				{
-					var sig = signer.Sign(keys[i]);
-					signatures[i] = sig;
-					sigCount++;
-				}
-			}
+        public override bool CanEstimateScriptSigSize(Script scriptPubKey)
+        {
+            return PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey) != null;
+        }
 
-			IEnumerable<TransactionSignature> sigs = signatures;
-			if(sigCount == multiSigParams.SignatureCount)
-			{
-				sigs = sigs.Where(s => s != TransactionSignature.Empty && s != null);
-			}
-			return PayToMultiSigTemplate.Instance.GenerateScriptSig(sigs);
-		}
+        public override bool CanGenerateScriptSig(Script scriptPubKey)
+        {
+            return PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey) != null;
+        }
 
-		public override Script DeduceScriptPubKey(Script scriptSig)
-		{
-			throw new NotImplementedException();
-		}
+        public override Script CombineScriptSig(Script scriptPubKey, Script a, Script b)
+        {
+            var para = PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey);
+            // Combine all the signatures we've got:
+            var aSigs = PayToMultiSigTemplate.Instance.ExtractScriptSigParameters(a);
+            if (aSigs == null)
+                return b;
+            var bSigs = PayToMultiSigTemplate.Instance.ExtractScriptSigParameters(b);
+            if (bSigs == null)
+                return a;
+            int pubkeyCount = 0;
+            TransactionSignature[] sigs = new TransactionSignature[para.PubKeys.Length];
+            for (int i = 0; i < para.PubKeys.Length; i++)
+            {
+                var aSig = i < aSigs.Length ? aSigs[i] : null;
+                var bSig = i < bSigs.Length ? bSigs[i] : null;
+                var sig = aSig ?? bSig;
+                if (sig != null)
+                {
+                    sigs[pubkeyCount] = sig;
+                    pubkeyCount++;
+                }
+                if (pubkeyCount == para.SignatureCount)
+                    break;
+            }
+            if (pubkeyCount == para.SignatureCount)
+                sigs = sigs.Where(s => s != null && s != TransactionSignature.Empty).ToArray();
+            return PayToMultiSigTemplate.Instance.GenerateScriptSig(sigs);
+        }
 
-		public override bool CanDeduceScriptPubKey(Script scriptSig)
-		{
-			return false;
-		}
+        public override Script DeduceScriptPubKey(Script scriptSig)
+        {
+            throw new NotImplementedException();
+        }
 
-		public override bool CanEstimateScriptSigSize(Script scriptPubkey)
-		{
-			return PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubkey) != null;
-		}
+        public override int EstimateScriptSigSize(Script scriptPubKey)
+        {
+            var p2mk = PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey);
+            return PayToMultiSigTemplate.Instance.GenerateScriptSig(Enumerable.Range(0, p2mk.SignatureCount).Select(o => DummySignature).ToArray()).Length;
+        }
 
-		public override int EstimateScriptSigSize(Script scriptPubKey)
-		{
-			var p2mk = PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey);
-			return PayToMultiSigTemplate.Instance.GenerateScriptSig(Enumerable.Range(0, p2mk.SignatureCount).Select(o => DummySignature).ToArray()).Length;
-		}
+        public override Script GenerateScriptSig(Script scriptPubKey, IKeyRepository keyRepo, ISigner signer)
+        {
+            var multiSigParams = PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey);
+            TransactionSignature[] signatures = new TransactionSignature[multiSigParams.PubKeys.Length];
+            var keys =
+                multiSigParams
+                .PubKeys
+                .Select(p => keyRepo.FindKey(p.ScriptPubKey))
+                .ToArray();
 
-		public override bool CanCombineScriptSig(Script scriptPubKey, Script a, Script b)
-		{
-			return PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey) != null;
-		}
+            int sigCount = 0;
+            for (int i = 0; i < keys.Length; i++)
+            {
+                if (sigCount == multiSigParams.SignatureCount)
+                    break;
+                if (keys[i] != null)
+                {
+                    var sig = signer.Sign(keys[i]);
+                    signatures[i] = sig;
+                    sigCount++;
+                }
+            }
 
-		public override Script CombineScriptSig(Script scriptPubKey, Script a, Script b)
-		{
-			var para = PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey);
-			// Combine all the signatures we've got:
-			var aSigs = PayToMultiSigTemplate.Instance.ExtractScriptSigParameters(a);
-			if(aSigs == null)
-				return b;
-			var bSigs = PayToMultiSigTemplate.Instance.ExtractScriptSigParameters(b);
-			if(bSigs == null)
-				return a;
-			int pubkeyCount = 0;
-			TransactionSignature[] sigs = new TransactionSignature[para.PubKeys.Length];
-			for(int i = 0; i < para.PubKeys.Length; i++)
-			{
-				var aSig = i < aSigs.Length ? aSigs[i] : null;
-				var bSig = i < bSigs.Length ? bSigs[i] : null;
-				var sig = aSig ?? bSig;
-				if(sig != null)
-				{
-					sigs[pubkeyCount] = sig;
-					pubkeyCount++;
-				}
-				if(pubkeyCount == para.SignatureCount)
-					break;
-			}
-			if(pubkeyCount == para.SignatureCount)
-				sigs = sigs.Where(s => s != null && s != TransactionSignature.Empty).ToArray();
-			return PayToMultiSigTemplate.Instance.GenerateScriptSig(sigs);
-		}
-	}
+            IEnumerable<TransactionSignature> sigs = signatures;
+            if (sigCount == multiSigParams.SignatureCount)
+            {
+                sigs = sigs.Where(s => s != TransactionSignature.Empty && s != null);
+            }
+            return PayToMultiSigTemplate.Instance.GenerateScriptSig(sigs);
+        }
+    }
 }

--- a/NBitcoin/BuilderExtensions/P2MultiSigBuilderExtension.cs
+++ b/NBitcoin/BuilderExtensions/P2MultiSigBuilderExtension.cs
@@ -33,27 +33,27 @@ namespace NBitcoin.BuilderExtensions
 			var para = PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey);
 			// Combine all the signatures we've got:
 			var aSigs = PayToMultiSigTemplate.Instance.ExtractScriptSigParameters(a);
-			if (aSigs == null)
+			if(aSigs == null)
 				return b;
 			var bSigs = PayToMultiSigTemplate.Instance.ExtractScriptSigParameters(b);
-			if (bSigs == null)
+			if(bSigs == null)
 				return a;
 			int pubkeyCount = 0;
 			TransactionSignature[] sigs = new TransactionSignature[para.PubKeys.Length];
-			for (int i = 0; i < para.PubKeys.Length; i++)
+			for(int i = 0; i < para.PubKeys.Length; i++)
 			{
 				var aSig = i < aSigs.Length ? aSigs[i] : null;
 				var bSig = i < bSigs.Length ? bSigs[i] : null;
 				var sig = aSig ?? bSig;
-				if (sig != null)
+				if(sig != null)
 				{
 					sigs[pubkeyCount] = sig;
 					pubkeyCount++;
 				}
-				if (pubkeyCount == para.SignatureCount)
+				if(pubkeyCount == para.SignatureCount)
 					break;
 			}
-			if (pubkeyCount == para.SignatureCount)
+			if(pubkeyCount == para.SignatureCount)
 				sigs = sigs.Where(s => s != null && s != TransactionSignature.Empty).ToArray();
 			return PayToMultiSigTemplate.Instance.GenerateScriptSig(sigs);
 		}
@@ -80,11 +80,11 @@ namespace NBitcoin.BuilderExtensions
 				.ToArray();
 
 			int sigCount = 0;
-			for (int i = 0; i < keys.Length; i++)
+			for(int i = 0; i < keys.Length; i++)
 			{
-				if (sigCount == multiSigParams.SignatureCount)
+				if(sigCount == multiSigParams.SignatureCount)
 					break;
-				if (keys[i] != null)
+				if(keys[i] != null)
 				{
 					var sig = signer.Sign(keys[i]);
 					signatures[i] = sig;
@@ -93,7 +93,7 @@ namespace NBitcoin.BuilderExtensions
 			}
 
 			IEnumerable<TransactionSignature> sigs = signatures;
-			if (sigCount == multiSigParams.SignatureCount)
+			if(sigCount == multiSigParams.SignatureCount)
 			{
 				sigs = sigs.Where(s => s != TransactionSignature.Empty && s != null);
 			}

--- a/NBitcoin/BuilderExtensions/P2PKBuilderExtension.cs
+++ b/NBitcoin/BuilderExtensions/P2PKBuilderExtension.cs
@@ -6,50 +6,50 @@ using System.Threading.Tasks;
 
 namespace NBitcoin.BuilderExtensions
 {
-    public class P2PKBuilderExtension : BuilderExtension
-    {
-        public override bool CanCombineScriptSig(Script scriptPubKey, Script a, Script b)
-        {
-            return false;
-        }
+	public class P2PKBuilderExtension : BuilderExtension
+	{
+		public override bool CanCombineScriptSig(Script scriptPubKey, Script a, Script b)
+		{
+			return false;
+		}
 
-        public override bool CanDeduceScriptPubKey(Script scriptSig)
-        {
-            return false;
-        }
+		public override bool CanDeduceScriptPubKey(Script scriptSig)
+		{
+			return false;
+		}
 
-        public override bool CanEstimateScriptSigSize(Script scriptPubKey)
-        {
-            return PayToPubkeyTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey) != null;
-        }
+		public override bool CanEstimateScriptSigSize(Script scriptPubKey)
+		{
+			return PayToPubkeyTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey) != null;
+		}
 
-        public override bool CanGenerateScriptSig(Script scriptPubKey)
-        {
-            return PayToPubkeyTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey) != null;
-        }
+		public override bool CanGenerateScriptSig(Script scriptPubKey)
+		{
+			return PayToPubkeyTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey) != null;
+		}
 
-        public override Script CombineScriptSig(Script scriptPubKey, Script a, Script b)
-        {
-            throw new NotImplementedException();
-        }
+		public override Script CombineScriptSig(Script scriptPubKey, Script a, Script b)
+		{
+			throw new NotImplementedException();
+		}
 
-        public override Script DeduceScriptPubKey(Script scriptSig)
-        {
-            throw new NotImplementedException();
-        }
+		public override Script DeduceScriptPubKey(Script scriptSig)
+		{
+			throw new NotImplementedException();
+		}
 
-        public override int EstimateScriptSigSize(Script scriptPubKey)
-        {
-            return PayToPubkeyTemplate.Instance.GenerateScriptSig(DummySignature).Length;
-        }
+		public override int EstimateScriptSigSize(Script scriptPubKey)
+		{
+			return PayToPubkeyTemplate.Instance.GenerateScriptSig(DummySignature).Length;
+		}
 
-        public override Script GenerateScriptSig(Script scriptPubKey, IKeyRepository keyRepo, ISigner signer)
-        {
-            var key = keyRepo.FindKey(scriptPubKey);
-            if (key == null)
-                return null;
-            var sig = signer.Sign(key);
-            return PayToPubkeyTemplate.Instance.GenerateScriptSig(sig);
-        }
-    }
+		public override Script GenerateScriptSig(Script scriptPubKey, IKeyRepository keyRepo, ISigner signer)
+		{
+			var key = keyRepo.FindKey(scriptPubKey);
+			if (key == null)
+				return null;
+			var sig = signer.Sign(key);
+			return PayToPubkeyTemplate.Instance.GenerateScriptSig(sig);
+		}
+	}
 }

--- a/NBitcoin/BuilderExtensions/P2PKBuilderExtension.cs
+++ b/NBitcoin/BuilderExtensions/P2PKBuilderExtension.cs
@@ -46,7 +46,7 @@ namespace NBitcoin.BuilderExtensions
 		public override Script GenerateScriptSig(Script scriptPubKey, IKeyRepository keyRepo, ISigner signer)
 		{
 			var key = keyRepo.FindKey(scriptPubKey);
-			if (key == null)
+			if(key == null)
 				return null;
 			var sig = signer.Sign(key);
 			return PayToPubkeyTemplate.Instance.GenerateScriptSig(sig);

--- a/NBitcoin/BuilderExtensions/P2PKBuilderExtension.cs
+++ b/NBitcoin/BuilderExtensions/P2PKBuilderExtension.cs
@@ -6,50 +6,50 @@ using System.Threading.Tasks;
 
 namespace NBitcoin.BuilderExtensions
 {
-	public class P2PKBuilderExtension : BuilderExtension
-	{
-		public override bool CanGenerateScriptSig(Script scriptPubkey)
-		{
-			return PayToPubkeyTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubkey) != null;
-		}
+    public class P2PKBuilderExtension : BuilderExtension
+    {
+        public override bool CanCombineScriptSig(Script scriptPubKey, Script a, Script b)
+        {
+            return false;
+        }
 
-		public override Script GenerateScriptSig(Script scriptPubKey, IKeyRepository keyRepo, ISigner signer)
-		{
-			var key = keyRepo.FindKey(scriptPubKey);
-			if(key == null)
-				return null;
-			var sig = signer.Sign(key);
-			return PayToPubkeyTemplate.Instance.GenerateScriptSig(sig);
-		}
+        public override bool CanDeduceScriptPubKey(Script scriptSig)
+        {
+            return false;
+        }
 
-		public override Script DeduceScriptPubKey(Script scriptSig)
-		{
-			throw new NotImplementedException();
-		}
+        public override bool CanEstimateScriptSigSize(Script scriptPubKey)
+        {
+            return PayToPubkeyTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey) != null;
+        }
 
-		public override bool CanDeduceScriptPubKey(Script scriptSig)
-		{
-			return false;
-		}
+        public override bool CanGenerateScriptSig(Script scriptPubKey)
+        {
+            return PayToPubkeyTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey) != null;
+        }
 
-		public override bool CanEstimateScriptSigSize(Script scriptPubkey)
-		{
-			return PayToPubkeyTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubkey) != null;
-		}
+        public override Script CombineScriptSig(Script scriptPubKey, Script a, Script b)
+        {
+            throw new NotImplementedException();
+        }
 
-		public override int EstimateScriptSigSize(Script scriptPubKey)
-		{
-			return PayToPubkeyTemplate.Instance.GenerateScriptSig(DummySignature).Length;
-		}
+        public override Script DeduceScriptPubKey(Script scriptSig)
+        {
+            throw new NotImplementedException();
+        }
 
-		public override bool CanCombineScriptSig(Script scriptPubKey, Script a, Script b)
-		{
-			return false;
-		}
+        public override int EstimateScriptSigSize(Script scriptPubKey)
+        {
+            return PayToPubkeyTemplate.Instance.GenerateScriptSig(DummySignature).Length;
+        }
 
-		public override Script CombineScriptSig(Script scriptPubKey, Script a, Script b)
-		{
-			throw new NotImplementedException();
-		}
-	}
+        public override Script GenerateScriptSig(Script scriptPubKey, IKeyRepository keyRepo, ISigner signer)
+        {
+            var key = keyRepo.FindKey(scriptPubKey);
+            if (key == null)
+                return null;
+            var sig = signer.Sign(key);
+            return PayToPubkeyTemplate.Instance.GenerateScriptSig(sig);
+        }
+    }
 }

--- a/NBitcoin/BuilderExtensions/P2PKHBuilderExtension.cs
+++ b/NBitcoin/BuilderExtensions/P2PKHBuilderExtension.cs
@@ -6,62 +6,62 @@ using System.Threading.Tasks;
 
 namespace NBitcoin.BuilderExtensions
 {
-	public class P2PKHBuilderExtension : BuilderExtension
-	{
-		public override bool CanGenerateScriptSig(Script scriptPubkey)
-		{
-			return PayToPubkeyHashTemplate.Instance.CheckScriptPubKey(scriptPubkey);
-		}
+    public class P2PKHBuilderExtension : BuilderExtension
+    {
+        public override bool CanCombineScriptSig(Script scriptPubKey, Script a, Script b)
+        {
+            return PayToPubkeyHashTemplate.Instance.CheckScriptPubKey(scriptPubKey);
+        }
 
-		public override Script GenerateScriptSig(Script scriptPubKey, IKeyRepository keyRepo, ISigner signer)
-		{
-			var parameters = PayToPubkeyHashTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey);
-			var key = keyRepo.FindKey(parameters.ScriptPubKey);
-			if(key == null)
-				return null;
-			var sig = signer.Sign(key);
-			return PayToPubkeyHashTemplate.Instance.GenerateScriptSig(sig, key.PubKey);
-		}
+        public override bool CanDeduceScriptPubKey(Script scriptSig)
+        {
+            var para = PayToPubkeyHashTemplate.Instance.ExtractScriptSigParameters(scriptSig);
+            return para != null && para.PublicKey != null;
+        }
 
-		public override Script DeduceScriptPubKey(Script scriptSig)
-		{
-			var p2pkh = PayToPubkeyHashTemplate.Instance.ExtractScriptSigParameters(scriptSig);
-			return p2pkh.PublicKey.Hash.ScriptPubKey;
-		}
+        public override bool CanEstimateScriptSigSize(Script scriptPubKey)
+        {
+            return PayToPubkeyHashTemplate.Instance.CheckScriptPubKey(scriptPubKey);
+        }
 
-		public override bool CanDeduceScriptPubKey(Script scriptSig)
-		{
-			var para = PayToPubkeyHashTemplate.Instance.ExtractScriptSigParameters(scriptSig);
-			return para != null && para.PublicKey != null;
-		}
+        public override bool CanGenerateScriptSig(Script scriptPubKey)
+        {
+            return PayToPubkeyHashTemplate.Instance.CheckScriptPubKey(scriptPubKey);
+        }
 
-		public override bool CanEstimateScriptSigSize(Script scriptPubkey)
-		{
-			return PayToPubkeyHashTemplate.Instance.CheckScriptPubKey(scriptPubkey);
-		}
+        public override Script CombineScriptSig(Script scriptPubKey, Script a, Script b)
+        {
+            var aSig = PayToPubkeyHashTemplate.Instance.ExtractScriptSigParameters(a);
+            var bSig = PayToPubkeyHashTemplate.Instance.ExtractScriptSigParameters(b);
+            if (aSig == null)
+                return b;
+            if (bSig == null)
+                return a;
+            var merged = new PayToPubkeyHashScriptSigParameters();
+            merged.PublicKey = aSig.PublicKey ?? bSig.PublicKey;
+            merged.TransactionSignature = aSig.TransactionSignature ?? bSig.TransactionSignature;
+            return PayToPubkeyHashTemplate.Instance.GenerateScriptSig(merged);
+        }
 
-		public override int EstimateScriptSigSize(Script scriptPubkey)
-		{
-			return PayToPubkeyHashTemplate.Instance.GenerateScriptSig(DummySignature, DummyPubKey).Length;
-		}
+        public override Script DeduceScriptPubKey(Script scriptSig)
+        {
+            var p2pkh = PayToPubkeyHashTemplate.Instance.ExtractScriptSigParameters(scriptSig);
+            return p2pkh.PublicKey.Hash.ScriptPubKey;
+        }
 
-		public override bool CanCombineScriptSig(Script scriptPubKey, Script a, Script b)
-		{
-			return PayToPubkeyHashTemplate.Instance.CheckScriptPubKey(scriptPubKey);
-		}
+        public override int EstimateScriptSigSize(Script scriptPubKey)
+        {
+            return PayToPubkeyHashTemplate.Instance.GenerateScriptSig(DummySignature, DummyPubKey).Length;
+        }
 
-		public override Script CombineScriptSig(Script scriptPubKey, Script a, Script b)
-		{
-			var aSig = PayToPubkeyHashTemplate.Instance.ExtractScriptSigParameters(a);
-			var bSig = PayToPubkeyHashTemplate.Instance.ExtractScriptSigParameters(b);
-			if(aSig == null)
-				return b;
-			if(bSig == null)
-				return a;
-			var merged = new PayToPubkeyHashScriptSigParameters();
-			merged.PublicKey = aSig.PublicKey ?? bSig.PublicKey;
-			merged.TransactionSignature = aSig.TransactionSignature ?? bSig.TransactionSignature;
-			return PayToPubkeyHashTemplate.Instance.GenerateScriptSig(merged);
-		}
-	}
+        public override Script GenerateScriptSig(Script scriptPubKey, IKeyRepository keyRepo, ISigner signer)
+        {
+            var parameters = PayToPubkeyHashTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey);
+            var key = keyRepo.FindKey(parameters.ScriptPubKey);
+            if (key == null)
+                return null;
+            var sig = signer.Sign(key);
+            return PayToPubkeyHashTemplate.Instance.GenerateScriptSig(sig, key.PubKey);
+        }
+    }
 }

--- a/NBitcoin/BuilderExtensions/P2PKHBuilderExtension.cs
+++ b/NBitcoin/BuilderExtensions/P2PKHBuilderExtension.cs
@@ -6,62 +6,62 @@ using System.Threading.Tasks;
 
 namespace NBitcoin.BuilderExtensions
 {
-    public class P2PKHBuilderExtension : BuilderExtension
-    {
-        public override bool CanCombineScriptSig(Script scriptPubKey, Script a, Script b)
-        {
-            return PayToPubkeyHashTemplate.Instance.CheckScriptPubKey(scriptPubKey);
-        }
+	public class P2PKHBuilderExtension : BuilderExtension
+	{
+		public override bool CanCombineScriptSig(Script scriptPubKey, Script a, Script b)
+		{
+			return PayToPubkeyHashTemplate.Instance.CheckScriptPubKey(scriptPubKey);
+		}
 
-        public override bool CanDeduceScriptPubKey(Script scriptSig)
-        {
-            var para = PayToPubkeyHashTemplate.Instance.ExtractScriptSigParameters(scriptSig);
-            return para != null && para.PublicKey != null;
-        }
+		public override bool CanDeduceScriptPubKey(Script scriptSig)
+		{
+			var para = PayToPubkeyHashTemplate.Instance.ExtractScriptSigParameters(scriptSig);
+			return para != null && para.PublicKey != null;
+		}
 
-        public override bool CanEstimateScriptSigSize(Script scriptPubKey)
-        {
-            return PayToPubkeyHashTemplate.Instance.CheckScriptPubKey(scriptPubKey);
-        }
+		public override bool CanEstimateScriptSigSize(Script scriptPubKey)
+		{
+			return PayToPubkeyHashTemplate.Instance.CheckScriptPubKey(scriptPubKey);
+		}
 
-        public override bool CanGenerateScriptSig(Script scriptPubKey)
-        {
-            return PayToPubkeyHashTemplate.Instance.CheckScriptPubKey(scriptPubKey);
-        }
+		public override bool CanGenerateScriptSig(Script scriptPubKey)
+		{
+			return PayToPubkeyHashTemplate.Instance.CheckScriptPubKey(scriptPubKey);
+		}
 
-        public override Script CombineScriptSig(Script scriptPubKey, Script a, Script b)
-        {
-            var aSig = PayToPubkeyHashTemplate.Instance.ExtractScriptSigParameters(a);
-            var bSig = PayToPubkeyHashTemplate.Instance.ExtractScriptSigParameters(b);
-            if (aSig == null)
-                return b;
-            if (bSig == null)
-                return a;
-            var merged = new PayToPubkeyHashScriptSigParameters();
-            merged.PublicKey = aSig.PublicKey ?? bSig.PublicKey;
-            merged.TransactionSignature = aSig.TransactionSignature ?? bSig.TransactionSignature;
-            return PayToPubkeyHashTemplate.Instance.GenerateScriptSig(merged);
-        }
+		public override Script CombineScriptSig(Script scriptPubKey, Script a, Script b)
+		{
+			var aSig = PayToPubkeyHashTemplate.Instance.ExtractScriptSigParameters(a);
+			var bSig = PayToPubkeyHashTemplate.Instance.ExtractScriptSigParameters(b);
+			if (aSig == null)
+				return b;
+			if (bSig == null)
+				return a;
+			var merged = new PayToPubkeyHashScriptSigParameters();
+			merged.PublicKey = aSig.PublicKey ?? bSig.PublicKey;
+			merged.TransactionSignature = aSig.TransactionSignature ?? bSig.TransactionSignature;
+			return PayToPubkeyHashTemplate.Instance.GenerateScriptSig(merged);
+		}
 
-        public override Script DeduceScriptPubKey(Script scriptSig)
-        {
-            var p2pkh = PayToPubkeyHashTemplate.Instance.ExtractScriptSigParameters(scriptSig);
-            return p2pkh.PublicKey.Hash.ScriptPubKey;
-        }
+		public override Script DeduceScriptPubKey(Script scriptSig)
+		{
+			var p2pkh = PayToPubkeyHashTemplate.Instance.ExtractScriptSigParameters(scriptSig);
+			return p2pkh.PublicKey.Hash.ScriptPubKey;
+		}
 
-        public override int EstimateScriptSigSize(Script scriptPubKey)
-        {
-            return PayToPubkeyHashTemplate.Instance.GenerateScriptSig(DummySignature, DummyPubKey).Length;
-        }
+		public override int EstimateScriptSigSize(Script scriptPubKey)
+		{
+			return PayToPubkeyHashTemplate.Instance.GenerateScriptSig(DummySignature, DummyPubKey).Length;
+		}
 
-        public override Script GenerateScriptSig(Script scriptPubKey, IKeyRepository keyRepo, ISigner signer)
-        {
-            var parameters = PayToPubkeyHashTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey);
-            var key = keyRepo.FindKey(parameters.ScriptPubKey);
-            if (key == null)
-                return null;
-            var sig = signer.Sign(key);
-            return PayToPubkeyHashTemplate.Instance.GenerateScriptSig(sig, key.PubKey);
-        }
-    }
+		public override Script GenerateScriptSig(Script scriptPubKey, IKeyRepository keyRepo, ISigner signer)
+		{
+			var parameters = PayToPubkeyHashTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey);
+			var key = keyRepo.FindKey(parameters.ScriptPubKey);
+			if (key == null)
+				return null;
+			var sig = signer.Sign(key);
+			return PayToPubkeyHashTemplate.Instance.GenerateScriptSig(sig, key.PubKey);
+		}
+	}
 }

--- a/NBitcoin/BuilderExtensions/P2PKHBuilderExtension.cs
+++ b/NBitcoin/BuilderExtensions/P2PKHBuilderExtension.cs
@@ -33,9 +33,9 @@ namespace NBitcoin.BuilderExtensions
 		{
 			var aSig = PayToPubkeyHashTemplate.Instance.ExtractScriptSigParameters(a);
 			var bSig = PayToPubkeyHashTemplate.Instance.ExtractScriptSigParameters(b);
-			if (aSig == null)
+			if(aSig == null)
 				return b;
-			if (bSig == null)
+			if(bSig == null)
 				return a;
 			var merged = new PayToPubkeyHashScriptSigParameters();
 			merged.PublicKey = aSig.PublicKey ?? bSig.PublicKey;
@@ -58,7 +58,7 @@ namespace NBitcoin.BuilderExtensions
 		{
 			var parameters = PayToPubkeyHashTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey);
 			var key = keyRepo.FindKey(parameters.ScriptPubKey);
-			if (key == null)
+			if(key == null)
 				return null;
 			var sig = signer.Sign(key);
 			return PayToPubkeyHashTemplate.Instance.GenerateScriptSig(sig, key.PubKey);


### PR DESCRIPTION
Just minor cosmetics refactoring. I felt like it's a good way to get familiar with these classes.

-Fix inconsistent method parameter naming inside the BuilderExtension child classes (sometimes scriptPubkey is used instead of scriptPubKey)

-Reorder methods of BuilderExtension child classes to be present in the same order as in  the BuilderExtension base class
