### PR TITLE
add RPCPort for regtest

### DIFF
--- a/NBitcoin/Network.cs
+++ b/NBitcoin/Network.cs
@@ -693,6 +693,7 @@ namespace NBitcoin
 			genesis = CreateGenesisBlock(1296688602, 2, 0x207fffff, 1, Money.Coins(50m));
 			consensus.HashGenesisBlock = genesis.GetHash();
 			nDefaultPort = 18444;
+			nRPCPort = 18332;
 			//strDataDir = "regtest";
 			assert(consensus.HashGenesisBlock == uint256.Parse("0x0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"));
 


### PR DESCRIPTION
@NicolasDorier RPCPort is not provided for regtest and that doesn't allow me to work against local node in regtest network. 

Bitcoin core reference implementation [uses 18332](https://github.com/bitcoin/bitcoin/blob/57b34599b2deb179ff1bd97ffeab91ec9f904d85/src/chainparamsbase.cpp#L62) as default port for regtest. 

This tiny change is what I need for moving forward however I thing it is not okay or at least not enough because I should be able to specify the RPC port in the RPCClient constructor. For example:

```c#
var firstNodeRpcClient  = new RPCClient(credentials, "http://localhost:18332");
var secondNodeRpcClient = new RPCClient(credentials, "http://localhost:28332");
var thirdNodeRpcClient  = new RPCClient(credentials, "http://localhost:38332");
```

Given there isn't anything preventing multiple nodes running in  the same machine, it should be possible to connect to all of them with no restriction.