### PR TITLE
make FeeRate comparable

### DIFF
--- a/NBitcoin.Tests/util_tests.cs
+++ b/NBitcoin.Tests/util_tests.cs
@@ -382,6 +382,38 @@ namespace NBitcoin.Tests
 		}
 
 		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void FeeRateComparison()
+		{
+			var a = new FeeRate(Money.Coins(2.0m));
+			var b = new FeeRate(Money.Coins(4.0m));
+			Assert.True(a < b);
+			Assert.True(b > a);
+			Assert.False(b < a);
+			Assert.False(a > b);
+			Assert.True(a != b);
+			Assert.True(b != a);
+
+			Assert.True(FeeRate.Min(a, b) == a);
+			Assert.True(FeeRate.Min(b, a) == a);
+			Assert.True(FeeRate.Max(a, b) == b);
+			Assert.True(FeeRate.Max(b, a) == b);
+
+			Assert.True(a.CompareTo(b) < 0);
+			Assert.True(b.CompareTo(a) > 0);
+			Assert.True(a.CompareTo(a) == 0);
+			Assert.True(b.CompareTo(b) == 0);
+
+			var aa = new FeeRate(Money.Coins(2.0m));
+			var bb = new FeeRate(Money.Coins(4.0m));
+
+			Assert.True(a == aa);
+			Assert.True(b == bb);
+			Assert.True(aa == a);
+			Assert.True(bb == b);
+		}
+
+		[Fact]
 		[Trait("Core", "Core")]
 		public void util_IsHex()
 		{

--- a/NBitcoin/FeeRate.cs
+++ b/NBitcoin/FeeRate.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace NBitcoin
 {
-	public class FeeRate
+	public class FeeRate : IEquatable<FeeRate>, IComparable<FeeRate>
 	{
 		private readonly Money _FeePerK;
 		/// <summary>
@@ -72,5 +72,112 @@ namespace NBitcoin
 			return String.Format("{0} BTC/kB", _FeePerK.ToString());
 		}
 
+		#region IEquatable<FeeRate> Members
+
+		public bool Equals(FeeRate other)
+		{
+			return other != null && _FeePerK.Equals(other._FeePerK);
+		}
+
+		public int CompareTo(FeeRate other)
+		{
+			return other == null 
+				? 1 
+				: _FeePerK.CompareTo(other._FeePerK);
+		}
+
+		#endregion
+
+		#region IComparable Members
+
+		public int CompareTo(object obj)
+		{
+			if (obj == null)
+				return 1;
+			var m = obj as FeeRate;
+			if (m != null)
+				return _FeePerK.CompareTo(m._FeePerK);
+#if !(PORTABLE || NETCORE)
+			return _FeePerK.CompareTo(obj);
+#else
+			return _FeePerK.CompareTo((long)obj);
+#endif
+		}
+
+		#endregion
+
+		public static bool operator <(FeeRate left, FeeRate right)
+		{
+			if (left == null)
+				throw new ArgumentNullException("left");
+			if (right == null)
+				throw new ArgumentNullException("right");
+			return left._FeePerK < right._FeePerK;
+		}
+		public static bool operator >(FeeRate left, FeeRate right)
+		{
+			if (left == null)
+				throw new ArgumentNullException("left");
+			if (right == null)
+				throw new ArgumentNullException("right");
+			return left._FeePerK > right._FeePerK;
+		}
+		public static bool operator <=(FeeRate left, FeeRate right)
+		{
+			if (left == null)
+				throw new ArgumentNullException("left");
+			if (right == null)
+				throw new ArgumentNullException("right");
+			return left._FeePerK <= right._FeePerK;
+		}
+		public static bool operator >=(FeeRate left, FeeRate right)
+		{
+			if (left == null)
+				throw new ArgumentNullException("left");
+			if (right == null)
+				throw new ArgumentNullException("right");
+			return left._FeePerK >= right._FeePerK;
+		}
+
+		public static bool operator ==(FeeRate left, FeeRate right)
+		{
+			if (Object.ReferenceEquals(left, right))
+				return true;
+			if (((object)left == null) || ((object)right == null))
+				return false;
+			return left._FeePerK == right._FeePerK;
+		}
+
+		public static bool operator !=(FeeRate left, FeeRate right)
+		{
+			return !(left == right);
+		}
+
+		public override int GetHashCode()
+		{
+			return _FeePerK.GetHashCode();
+		}
+
+		public static FeeRate Min(FeeRate left, FeeRate right)
+		{
+			if (left == null)
+				throw new ArgumentNullException("left");
+			if (right == null)
+				throw new ArgumentNullException("right");
+			return left <= right 
+				? left 
+				: right;
+		}
+
+		public static FeeRate Max(FeeRate left, FeeRate right)
+		{
+			if (left == null)
+				throw new ArgumentNullException("left");
+			if (right == null)
+				throw new ArgumentNullException("right");
+			return left >= right
+				? left
+				: right;
+		}
 	}
 }


### PR DESCRIPTION
I have to play with fees coming fron different fee providers and the code looks better when FeeRate class implements IComparable.

The following is just pseudocode for illustrating the point:
```c#
var fee = await _feeProvider.GetFeeAsync();
fee = FeeRate.Max(fee, Configuration.MinFee);

if(fee > Configuration.MaxFee)
    throw new PanicException($"Too high fees for {tx.GetSerialized()} bytes = {fee}");
```