### PR TITLE
Add doc comments to BitcoinExtKey and ExtKey

### DIFF
--- a/NBitcoin/BIP32/BitcoinExtKey.cs
+++ b/NBitcoin/BIP32/BitcoinExtKey.cs
@@ -24,21 +24,29 @@
 	}
 
 	/// <summary>
-	/// Base58 representation of an ExtKey
+	/// Base58 representation of an ExtKey, within a particular network.
 	/// </summary>
 	public class BitcoinExtKey : BitcoinExtKeyBase, ISecret
 	{
+		/// <summary>
+		/// Constructor. Creates an extended key from the Base58 representation, checking the expected network.
+		/// </summary>
 		public BitcoinExtKey(string base58, Network expectedNetwork = null)
 			: base(base58, expectedNetwork)
 		{
-
 		}
+
+		/// <summary>
+		/// Constructor. Creates a representation of an extended key, within the specified network.
+		/// </summary>
 		public BitcoinExtKey(ExtKey key, Network network)
 			: base(key, network)
 		{
-
 		}
 
+		/// <summary>
+		/// Gets whether the data is the correct expected length.
+		/// </summary>
 		protected override bool IsValid
 		{
 			get
@@ -48,6 +56,10 @@
 		}
 
 		ExtKey _Key;
+
+		/// <summary>
+		/// Gets the extended key, converting from the Base58 representation.
+		/// </summary>
 		public ExtKey ExtKey
 		{
 			get
@@ -61,7 +73,9 @@
 			}
 		}
 
-
+		/// <summary>
+		/// Gets the type of item represented by this Base58 data.
+		/// </summary>
 		public override Base58Type Type
 		{
 			get
@@ -70,6 +84,10 @@
 			}
 		}
 
+		/// <summary>
+		/// Gets the script of the hash of the public key corresponing to the private key 
+		/// of the extended key of this Base58 item.
+		/// </summary>
 		public override Script ScriptPubKey
 		{
 			get
@@ -78,6 +96,9 @@
 			}
 		}
 
+		/// <summary>
+		/// Gets the Base58 representation, in the same network, of the neutered extended key.
+		/// </summary>
 		public BitcoinExtPubKey Neuter()
 		{
 			return ExtKey.Neuter().GetWif(Network);
@@ -85,6 +106,9 @@
 
 		#region ISecret Members
 
+		/// <summary>
+		/// Gets the private key of the extended key of this Base58 item.
+		/// </summary>
 		public Key PrivateKey
 		{
 			get
@@ -95,6 +119,9 @@
 
 		#endregion
 
+		/// <summary>
+		/// Implicit cast from BitcoinExtKey to ExtKey.
+		/// </summary>
 		public static implicit operator ExtKey(BitcoinExtKey key)
 		{
 			if(key == null)
@@ -104,22 +131,31 @@
 	}
 
 	/// <summary>
-	/// Base58 representation of an ExtPubKey
+	/// Base58 representation of an ExtPubKey, within a particular network.
 	/// </summary>
 	public class BitcoinExtPubKey : BitcoinExtKeyBase
 	{
-		public BitcoinExtPubKey(ExtPubKey key, Network network)
-			: base(key, network)
-		{
-
-		}
-
+		/// <summary>
+		/// Constructor. Creates an extended public key from the Base58 representation, checking the expected network.
+		/// </summary>
 		public BitcoinExtPubKey(string base58, Network expectedNetwork = null)
 			: base(base58, expectedNetwork)
 		{
 		}
 
+		/// <summary>
+		/// Constructor. Creates a representation of an extended public key, within the specified network.
+		/// </summary>
+		public BitcoinExtPubKey(ExtPubKey key, Network network)
+			: base(key, network)
+		{
+		}
+
 		ExtPubKey _PubKey;
+
+		/// <summary>
+		/// Gets the extended public key, converting from the Base58 representation.
+		/// </summary>
 		public ExtPubKey ExtPubKey
 		{
 			get
@@ -133,6 +169,9 @@
 			}
 		}
 
+		/// <summary>
+		/// Gets the type of item represented by this Base58 data.
+		/// </summary>
 		public override Base58Type Type
 		{
 			get
@@ -141,6 +180,9 @@
 			}
 		}
 
+		/// <summary>
+		/// Gets the script of the hash of the public key of the extended key of this Base58 item.
+		/// </summary>
 		public override Script ScriptPubKey
 		{
 			get
@@ -149,6 +191,9 @@
 			}
 		}
 
+		/// <summary>
+		/// Implicit cast from BitcoinExtPubKey to ExtPubKey.
+		/// </summary>
 		public static implicit operator ExtPubKey(BitcoinExtPubKey key)
 		{
 			if(key == null)


### PR DESCRIPTION
* Mostly just adding doc comments (which appear as help in VS Intellisense) to methods.
* Re-ordered a couple of methods to keep overloads together.
* Fixed a small typo/bug in the argument validation of one constructor of ExtKey (it was comparing a length against itself).
