### PR TITLE
GetEstimatedFee & TryGetEstimatedFee methods

### DIFF
--- a/NBitcoin.Tests/RPCClientTests.cs
+++ b/NBitcoin.Tests/RPCClientTests.cs
@@ -123,7 +123,7 @@ namespace NBitcoin.Tests
 		}
 
 		[Fact]
-		public void GetEstimatedFee()
+		public void EstimateFeeRate()
 		{
 			using (var builder = NodeBuilder.Create())
 			{
@@ -131,12 +131,12 @@ namespace NBitcoin.Tests
 				node.Start();
 				node.Generate(101);
 				var rpc = node.CreateRPCClient();
-				Assert.Throws<InvalidOperationException>(()=> rpc.GetEstimatedFee(1));
+				Assert.Throws<NoEstimationException>(()=> rpc.EstimateFeeRate(1));
 			}
 		}
 
 		[Fact]
-		public void TryGetEstimatedFee()
+		public void TryEstimateFeeRate()
 		{
 			using (var builder = NodeBuilder.Create())
 			{
@@ -145,7 +145,7 @@ namespace NBitcoin.Tests
 				node.Generate(101);
 				var rpc = node.CreateRPCClient();
 				FeeRate feeRate;
-				Assert.False(rpc.TryGetEstimatedFee(1, out feeRate));
+				Assert.False(rpc.TryEstimateFeeRate(1, out feeRate));
 			}
 		}
 

--- a/NBitcoin.Tests/RPCClientTests.cs
+++ b/NBitcoin.Tests/RPCClientTests.cs
@@ -109,7 +109,7 @@ namespace NBitcoin.Tests
 
 
 		[Fact]
-		public void CanEstimateFees()
+		public void CanEstimateFees_Obsolete()
 		{
 			using(var builder = NodeBuilder.Create())
 			{
@@ -119,6 +119,33 @@ namespace NBitcoin.Tests
 				var rpc = node.CreateRPCClient();
 				var result = rpc.EstimateFee(1);
 				Assert.Equal(Money.Zero, result.FeePerK);
+			}
+		}
+
+		[Fact]
+		public void GetEstimatedFee()
+		{
+			using (var builder = NodeBuilder.Create())
+			{
+				var node = builder.CreateNode();
+				node.Start();
+				node.Generate(101);
+				var rpc = node.CreateRPCClient();
+				Assert.Throws<InvalidOperationException>(()=> rpc.GetEstimatedFee(1));
+			}
+		}
+
+		[Fact]
+		public void TryGetEstimatedFee()
+		{
+			using (var builder = NodeBuilder.Create())
+			{
+				var node = builder.CreateNode();
+				node.Start();
+				node.Generate(101);
+				var rpc = node.CreateRPCClient();
+				FeeRate feeRate;
+				Assert.False(rpc.TryGetEstimatedFee(1, out feeRate));
 			}
 		}
 

--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -718,6 +718,57 @@ namespace NBitcoin.RPC
 			return Money.Parse(response.Result.ToString());
 		}
 
+		/// <summary>
+		/// Get the estimated fee per kb for being confirmed in nblock
+		/// </summary>
+		/// <param name="nblock"></param>
+		/// <returns>The estimated fee rate</returns>
+		/// <exception cref="InvalidOperationException">when fee couldn't be estimated</exception>
+		public FeeRate GetEstimatedFee(int nblock)
+		{
+			var response = SendCommand(RPCOperations.estimatefee, nblock);
+			var result = response.Result.Value<decimal>();
+			var money = Money.Coins(result);
+			if (money.Satoshi < 0)
+				throw new InvalidOperationException("Couldn't estimate fee for " + nblock + " blocks");
+			return new FeeRate(money);
+		}
+
+		/// <summary>
+		/// Get the estimated fee per kb for being confirmed in nblock
+		/// </summary>
+		/// <param name="nblock"></param>
+		/// <returns>true if fee rate could be estimated; otherwise false</returns>
+		public bool TryGetEstimatedFee(int nblock, out FeeRate feeRate)
+		{
+			try
+			{
+				feeRate = GetEstimatedFee(nblock);
+				return true;
+			}
+			catch(InvalidOperationException e)
+			{
+				feeRate = null;
+				return false;
+			}
+		}
+
+		/// <summary>
+		/// Get the estimated fee per kb for being confirmed in nblock
+		/// </summary>
+		/// <param name="nblock"></param>
+		/// <returns>The estimated fee rate</returns>
+		/// <exception cref="InvalidOperationException">when fee couldn't be estimated</exception>
+		public async Task<FeeRate> GetEstimatedFeeAsync(int nblock)
+		{
+			var response = await SendCommandAsync(RPCOperations.estimatefee, nblock).ConfigureAwait(false);
+			var result = response.Result.Value<decimal>();
+			var money = Money.Coins(result);
+			if (money.Satoshi < 0)
+				throw new InvalidOperationException("Couldn't estimate fee for " + nblock + " blocks");
+			return new FeeRate(money);
+		}
+
 		public decimal EstimatePriority(int nblock)
 		{
 			decimal priority = 0;

--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -695,6 +695,7 @@ namespace NBitcoin.RPC
 		/// </summary>
 		/// <param name="nblock"></param>
 		/// <returns></returns>
+		[Obsolete("Use GetEstimatedFee or TryGetEstimatedFee instead")]
 		public FeeRate EstimateFee(int nblock)
 		{
 			var response = SendCommand(RPCOperations.estimatefee, nblock);
@@ -710,6 +711,7 @@ namespace NBitcoin.RPC
 		/// </summary>
 		/// <param name="nblock"></param>
 		/// <returns></returns>
+		[Obsolete("Use GetEstimatedFeeAsync or TryGetEstimatedFeeAsync instead")]
 		public async Task<Money> EstimateFeeAsync(int nblock)
 		{
 			var response = await SendCommandAsync(RPCOperations.estimatefee, nblock).ConfigureAwait(false);


### PR DESCRIPTION
This PR is for issue https://github.com/MetacoSA/NBitcoin/issues/209 and marks `EstimateFee` and `EstimateFeeAsync` as Obsolete methods. It also creates the three new methods:  `GetEstimatedFee`, `TryGetEstimatedFee`  and `GetEstimateFeeAsync`.
  