### PR TITLE
use constants, fix extpubkey validation and massages

### DIFF
--- a/NBitcoin/BIP32/ExtPubKey.cs
+++ b/NBitcoin/BIP32/ExtPubKey.cs
@@ -15,14 +15,17 @@ namespace NBitcoin
 			return Network.CreateFromBase58Data<BitcoinExtPubKey>(wif, expectedNetwork).ExtPubKey;
 		}
 
+		private const int FingerprintLength = 4;
+		private const int ChainCodeLength = 32;
+
 		static readonly byte[] validPubKey = Encoders.Hex.DecodeData("0374ef3990e387b5a2992797f14c031a64efd80e5cb843d7c1d4a0274a9bc75e55");
 		internal byte nDepth;
-		internal byte[] vchFingerprint = new byte[4];
+		internal byte[] vchFingerprint = new byte[FingerprintLength];
 		internal uint nChild;
 
 		//
 		internal PubKey pubkey = new PubKey(validPubKey);
-		internal byte[] vchChainCode = new byte[32];
+		internal byte[] vchChainCode = new byte[ChainCodeLength];
 
 		public byte Depth
 		{
@@ -58,8 +61,8 @@ namespace NBitcoin
 		{
 			get
 			{
-				byte[] chainCodeCopy = new byte[vchChainCode.Length];
-				Buffer.BlockCopy(vchChainCode, 0, chainCodeCopy, 0, vchChainCode.Length);
+				byte[] chainCodeCopy = new byte[ChainCodeLength];
+				Buffer.BlockCopy(vchChainCode, 0, chainCodeCopy, 0, ChainCodeLength);
 
 				return chainCodeCopy;
 			}
@@ -84,15 +87,15 @@ namespace NBitcoin
 				throw new ArgumentNullException("chainCode");
 			if(fingerprint == null)
 				throw new ArgumentNullException("fingerprint");
-			if(fingerprint.Length != fingerprint.Length)
-				throw new ArgumentException(string.Format("The fingerprint must be {0} bytes.", fingerprint.Length), "fingerprint");
-			if(chainCode.Length != vchChainCode.Length)
-				throw new ArgumentException(string.Format("The chain code must be {0} bytes.", vchChainCode.Length), "chainCode");
+			if(fingerprint.Length != FingerprintLength)
+				throw new ArgumentException(string.Format("The fingerprint must be {0} bytes.", FingerprintLength), "fingerprint");
+			if(chainCode.Length != ChainCodeLength)
+				throw new ArgumentException(string.Format("The chain code must be {0} bytes.", ChainCodeLength), "chainCode");
 			this.pubkey = pubkey;
 			this.nDepth = depth;
 			this.nChild = child;
-			Buffer.BlockCopy(fingerprint, 0, vchFingerprint, 0, vchFingerprint.Length);
-			Buffer.BlockCopy(chainCode, 0, vchChainCode, 0, vchChainCode.Length);
+			Buffer.BlockCopy(fingerprint, 0, vchFingerprint, 0, FingerprintLength);
+			Buffer.BlockCopy(chainCode, 0, vchChainCode, 0, ChainCodeLength);
 		}
 
 		public ExtPubKey(PubKey masterKey, byte[] chainCode)
@@ -101,10 +104,10 @@ namespace NBitcoin
 				throw new ArgumentNullException("masterKey");
 			if(chainCode == null)
 				throw new ArgumentNullException("chainCode");
-			if(chainCode.Length != vchChainCode.Length)
-				throw new ArgumentException(string.Format("The chain code must be {0} bytes.", vchChainCode.Length), "chainCode");
+			if(chainCode.Length != ChainCodeLength)
+				throw new ArgumentException(string.Format("The chain code must be {0} bytes.", ChainCodeLength), "chainCode");
 			this.pubkey = masterKey;
-			Buffer.BlockCopy(chainCode, 0, vchChainCode, 0, vchChainCode.Length);
+			Buffer.BlockCopy(chainCode, 0, vchChainCode, 0, ChainCodeLength);
 		}
 
 
@@ -120,7 +123,7 @@ namespace NBitcoin
 		}
 		public byte[] CalculateChildFingerprint()
 		{
-			return pubkey.Hash.ToBytes().SafeSubarray(0, vchFingerprint.Length);
+			return pubkey.Hash.ToBytes().SafeSubarray(0, FingerprintLength);
 		}
 
 		public byte[] Fingerprint

--- a/NBitcoin/Key.cs
+++ b/NBitcoin/Key.cs
@@ -174,7 +174,7 @@ namespace NBitcoin
 				throw new InvalidOperationException("You won a prize ! this should happen very rarely. Take a screenshot, and roll the dice again.");
 			var key = parse256LL.Add(kPar).Mod(N);
 			if(key == BigInteger.Zero)
-				throw new InvalidOperationException("You won the big prize ! this would happen only 1 in 2^127. Take a screenshot, and roll the dice again.");
+				throw new InvalidOperationException("You won the big prize ! this has probability lower than 1 in 2^127. Take a screenshot, and roll the dice again.");
 
 			var keyBytes = key.ToByteArrayUnsigned();
 			if(keyBytes.Length < 32)


### PR DESCRIPTION
This PR is for:
+ replacing some constants in the bip32 files,
+ fix an always pass validation  `if(fingerprint.Length != fingerprint.Length)` in ExtPubKey ctor
+ improve an exception message based on what the bip32 says
+ other minors