### PR TITLE
Base32 address format for native witness outputs

### DIFF
--- a/NBitcoin.Tests/Bech32Test.cs
+++ b/NBitcoin.Tests/Bech32Test.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+using NBitcoin.DataEncoders;
+using Xunit;
+
+namespace NBitcoin.Tests
+{
+	[Trait("UnitTest", "UnitTest")]
+	public class Bech32Test
+	{
+		private static string[] VALID_CHECKSUM =
+		{
+			"A12UEL5L",
+			"an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1tt5tgs",
+			"abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw",
+			"11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j",
+			"split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w"
+		};
+
+		private static string[][] VALID_ADDRESS = {
+			new [] { "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4", "0014751e76e8199196d454941c45d1b3a323f1433bd6"},
+			new [] { "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7","00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262"},
+			new [] { "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx", "8128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6"},
+			new [] { "BC1SW50QA3JX3S", "9002751e"},
+			new [] { "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj", "8210751e76e8199196d454941c45d1b3a323"},
+			new [] { "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy", "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433"},
+		};
+
+		private static string[] INVALID_ADDRESS = {
+			"tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty",
+			"bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5",
+			"BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2",
+			"bc1rw5uspcuh",
+			"bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90",
+			"BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P",
+			"tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7",
+			"tb1pw508d6qejxtdg4y5r3zarqfsj6c3",
+			"tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv",
+		};
+
+		[Fact]
+		public void ValidateValidChecksum()
+		{
+			foreach (var test in VALID_CHECKSUM)
+			{
+				byte[] hrp;
+				Encoders.Bech32.Bech32Decode(test, out hrp);
+				if (hrp == null) throw new Exception();
+				var pos = test.LastIndexOf('1');
+				var test2 = test.Substring(0, pos + 1) + ((test[pos + 1]) ^ 1) + test.Substring(pos + 2);
+
+				Assert.Throws<FormatException>(() => Encoders.Bech32.Bech32Decode(test2, out hrp));
+			}
+		}
+
+		[Fact]
+		public void ValidAddress()
+		{
+			foreach (var address in VALID_ADDRESS)
+			{
+				byte witVer;
+				var hrp = "bc";
+				byte[] witProg;
+				try
+				{
+					witProg = Encoders.Bech32.Decode(hrp, address[0], out witVer);
+				}
+				catch
+				{
+					hrp = "tb";
+					witProg = Encoders.Bech32.Decode(hrp, address[0], out witVer);
+				}
+
+				var scriptPubkey = Scriptpubkey(witVer, witProg);
+				var hex = string.Join("", scriptPubkey.Select(x => x.ToString("x2")));
+				Assert.Equal(hex, address[1]);
+
+				var addr = Encoders.Bech32.Encode(Encoding.ASCII.GetBytes(hrp), witVer, witProg);
+				Assert.Equal(address[0].ToLowerInvariant(), addr);
+			}
+		}
+
+		[Fact]
+		public void InvalidAddress()
+		{
+			foreach (var test in INVALID_ADDRESS)
+			{
+				byte witver;
+				Assert.Throws<FormatException>(()=>Encoders.Bech32.Decode("bc", test, out witver));
+				Assert.Throws<FormatException>(() => Encoders.Bech32.Decode("tb", test, out witver));
+			}
+		}
+
+		private static byte[] Scriptpubkey(byte witver, byte[] witprog)
+		{
+			var v = witver > 0 ? witver + 0x80 : 0;
+			return (new[] { (byte)v, (byte)witprog.Length }).Concat(witprog);
+		}
+	}
+}

--- a/NBitcoin.Tests/NBitcoin.Tests.csproj
+++ b/NBitcoin.Tests/NBitcoin.Tests.csproj
@@ -66,6 +66,7 @@
     <Compile Include="AssertEx.cs" />
     <Compile Include="AssetMoneyTests.cs" />
     <Compile Include="base58_tests.cs" />
+    <Compile Include="Bech32Test.cs" />
     <Compile Include="Benchmark.cs" />
     <Compile Include="bip32_tests.cs" />
     <Compile Include="BIP38Tests.cs" />

--- a/NBitcoin/DataEncoders/Bech32Encoder.cs
+++ b/NBitcoin/DataEncoders/Bech32Encoder.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace NBitcoin.DataEncoders
+{
+	public class Bech32Encoder
+	{
+		private static readonly byte[] Byteset = Encoders.ASCII.DecodeData("qpzry9x8gf2tvdw0s3jn54khce6mua7l");
+		private static readonly uint[] Generator = { 0x3b6a57b2U, 0x26508e6dU, 0x1ea119faU, 0x3d4233ddU, 0x2a1462b3U };
+
+		private static uint Polymod(byte[] values)
+		{
+			uint chk = 1;
+			foreach (var value in values)
+			{
+				var top = chk >> 25;
+				chk = value ^ ((chk & 0x1ffffff) << 5);
+				foreach (var i in Enumerable.Range(0, 5))
+				{
+					chk ^= ((top >> i) & 1) == 1 ? Generator[i] : 0;
+				}
+			}
+			return chk;
+		}
+
+		private static byte[] HrpExpand(byte[] hrp)
+		{
+			var len = hrp.Length;
+			var ret = new byte[(2 * len) + 1];
+			for (int i = 0; i < len; i++)
+			{
+				ret[i] = (byte)(hrp[i] >> 5);
+				ret[i + len + 1] = (byte)(hrp[i] & 31);
+			}
+			return ret;
+		}
+
+		private static bool VerifyChecksum(byte[] hrp, byte[] data)
+		{
+			var values = HrpExpand(hrp).Concat(data);
+			return Polymod(values) == 1;
+		}
+
+		private static byte[] CreateChecksum(byte[] hrp, byte[] data)
+		{
+			var values = HrpExpand(hrp).Concat(data, new byte[] { 0, 0, 0, 0, 0, 0 });
+			var polymod = Polymod(values) ^ 1;
+			var ret = new byte[6];
+			foreach (var i in Enumerable.Range(0, 6))
+			{
+				ret[i] = (byte)((polymod >> 5 * (5 - i)) & 31);
+			}
+			return ret;
+		}
+
+		public static string Bech32Encode(byte[] hrp, byte[] data)
+		{
+			var combined = data.Concat(CreateChecksum(hrp, data));
+			var tmp = new byte[combined.Length];
+			for (int i = 0; i < combined.Length; i++)
+			{
+				tmp[i] = Byteset[combined[i]];
+			}
+			return Encoders.ASCII.EncodeData(hrp.Concat(new byte[] { 49 }, tmp));
+		}
+
+		public byte[] Bech32Decode(string bech, out byte[] hrp)
+		{
+			if (bech != bech.ToLowerInvariant() && bech != bech.ToUpperInvariant())
+				throw new FormatException("bech cannot mix upper and lower case");
+
+			var buffer = Encoders.ASCII.DecodeData(bech);
+			if (buffer.Any(b => b < 33 || b > 126))
+			{
+				throw new FormatException("bech chars are out of range");
+			}
+			bech = bech.ToLowerInvariant();
+			buffer = Encoders.ASCII.DecodeData(bech);
+			var pos = bech.LastIndexOf("1", StringComparison.InvariantCultureIgnoreCase);
+			if (pos < 1 || pos + 7 > bech.Length || bech.Length > 90)
+			{
+				throw new FormatException("bech missing separator, separator misplaced or too long input");
+			}
+			if (buffer.Skip(pos + 1).Any(x => !Byteset.Contains(x)))
+			{
+				throw new FormatException("bech chars are out of range");
+			}
+
+			buffer = Encoders.ASCII.DecodeData(bech);
+			hrp = Encoders.ASCII.DecodeData(bech.Substring(0, pos));
+			var data = new byte[bech.Length - pos - 1];
+			for (int j = 0, i = pos + 1; i < bech.Length; i++, j++)
+			{
+				data[j] = (byte)Array.IndexOf(Byteset, buffer[i]);
+			}
+			if (!VerifyChecksum(hrp, data))
+			{
+				throw new FormatException("Error while veriying checksum");
+			}
+			return data.Take(data.Length - 6).ToArray();
+		}
+
+		private static byte[] ConvertBits(IEnumerable<byte> data, int fromBits, int toBits, bool pad = true)
+		{
+			var acc = 0;
+			var bits = 0;
+			var maxv = (1 << toBits) - 1;
+			var ret = new List<byte>();
+			foreach (var value in data)
+			{
+				if ((value >> fromBits) > 0)
+					throw new ArgumentOutOfRangeException();
+				acc = (acc << fromBits) | value;
+				bits += fromBits;
+				while (bits >= toBits)
+				{
+					bits -= toBits;
+					ret.Add((byte)((acc >> bits) & maxv));
+				}
+			}
+			if (pad)
+			{
+				if (bits > 0)
+				{
+					ret.Add((byte)((acc << (toBits - bits)) & maxv));
+				}
+			}
+			else if (bits >= fromBits || (byte)(((acc << (toBits - bits)) & maxv)) != 0)
+			{
+				throw new FormatException();
+			}
+			return ret.ToArray();
+		}
+
+		public byte[] Decode(string hrp, string addr, out byte witnessVerion)
+		{
+			byte[] hrpgot;
+			var data = Bech32Decode(addr, out hrpgot);
+			if (hrp != Encoders.ASCII.EncodeData(hrpgot))
+				throw new FormatException("Mismatching human readeable part");
+
+			var decoded = ConvertBits(data.Skip(1), 5, 8, false);
+			if (decoded.Length < 2 || decoded.Length > 40)
+				throw new FormatException("Invalid decoded data length");
+
+			witnessVerion = data[0];
+			if (witnessVerion > 16)
+				throw new FormatException("Invalid decoded witness version");
+
+			if (witnessVerion == 0 && decoded.Length != 20 && decoded.Length != 32)
+				throw new FormatException("Decoded witness program with unknown length");
+			return decoded;
+		}
+
+		public string Encode(byte[] hrp, byte witnessVerion, byte[] witnessProgramm)
+		{
+			var data = (new[] { witnessVerion }).Concat(ConvertBits(witnessProgramm, 8, 5));
+			var ret = Bech32Encode(hrp, data);
+			return ret;
+		}
+	}
+}

--- a/NBitcoin/DataEncoders/Encoders.cs
+++ b/NBitcoin/DataEncoders/Encoders.cs
@@ -79,5 +79,14 @@
 				return _Base64;
 			}
 		}
+
+		private static readonly Bech32Encoder _Bech32Encoder = new Bech32Encoder();
+		public static Bech32Encoder Bech32
+		{
+			get
+			{
+				return _Bech32Encoder;
+			}
+		}
 	}
 }

--- a/NBitcoin/NBitcoin.csproj
+++ b/NBitcoin/NBitcoin.csproj
@@ -72,6 +72,7 @@
     <Compile Include="BuilderExtensions\P2MultiSigBuilderExtension.cs" />
     <Compile Include="BuilderExtensions\P2PKBuilderExtension.cs" />
     <Compile Include="BuilderExtensions\P2PKHBuilderExtension.cs" />
+    <Compile Include="DataEncoders\Bech32Encoder.cs" />
     <Compile Include="FeeRate.cs" />
     <Compile Include="JsonConverters\AssetIdJsonConverter.cs" />
     <Compile Include="JsonConverters\Base58JsonConverter.cs" />

--- a/NBitcoin/Utils.cs
+++ b/NBitcoin/Utils.cs
@@ -298,6 +298,21 @@ namespace NBitcoin
 			Buffer.BlockCopy(array, offset, data, 0, count);
 			return data;
 		}
+
+		internal static byte[] Concat(this byte[] arr, params byte[][] arrs)
+		{
+			var len = arr.Length + arrs.Sum(a => a.Length);
+			var ret = new byte[len];
+			Buffer.BlockCopy(arr, 0, ret, 0, arr.Length);
+			var pos = arr.Length;
+			foreach (var a in arrs)
+			{
+				Buffer.BlockCopy(a, 0, ret, pos, a.Length);
+				pos += a.Length;
+			}
+			return ret;
+		}
+
 	}
 
 	public class Utils


### PR DESCRIPTION
## Intro
In the [this](https://github.com/sipa/bech32) Sipa's github repo, there is a BIP proposal describing a new base32 based address encoding format for native witness outputs. Also, in the same repo, there are reference implementations for Javascript, C and Python. 

## What's this PR for?
This PR is for adapting [my .NET implementation](https://github.com/lontivero/Bech32) to NBitcoin.

## Scope
* This PR only contains the Bech32 encoder/decoder code, its unit tests and minimal adaptions. 
* This doesn't make changes for using bech32 as default encoding format for `BitcoinWitPubKeyAddress`

## Notes
The Bech32 Encoder was included in the `Encoders` class. However it doesn't inherits from `DataEncoder` abstract class because the methods signatures don't match (Bech32 EncodeData and DecodeData accept two parameters instead of only one)

 