### PR TITLE
Update BlockrTransactionRepository.cs

### DIFF
--- a/NBitcoin/BlockrTransactionRepository.cs
+++ b/NBitcoin/BlockrTransactionRepository.cs
@@ -125,7 +125,7 @@ namespace NBitcoin
 				var json = JObject.Parse(result);
 				var status = json["status"];
 				var code = json["code"];
-				if(status != null && status.ToString() == "error")
+				if(status != null && (status.ToString() == "error" || status.ToString() == "fail")
 				{
 					throw new BlockrException(json);
 				}


### PR DESCRIPTION
BlockR retourne "fail" en status et non "error" sur BroadcastAsync
exemple : {"status":"fail","data":"Could not push your transaction!","code":500,"message":"Did you sign your transaction?"}

Désolé, c'est la premiere fois qur GitHub et j'ai oublié une parenthèse a la fin de ma modification
if(status != null && (status.ToString() == "error" || status.ToString() == "fail"))
