### PR TITLE
Implement Node.TimeOffset property

### DIFF
--- a/NBitcoin.Tests/ProtocolTests.cs
+++ b/NBitcoin.Tests/ProtocolTests.cs
@@ -218,6 +218,7 @@ namespace NBitcoin.Tests
 				Assert.True(seed.State == NodeState.HandShaked);
 				seed.Disconnect();
 				Assert.True(seed.State == NodeState.Offline);
+				Assert.NotNull(seed.TimeOffset);
 			}
 		}
 
@@ -552,6 +553,7 @@ namespace NBitcoin.Tests
 				Assert.Equal(NodeState.HandShaked, toS2.State);
 				Thread.Sleep(100); //Let the time to Server2 to add the new node, else the test was failing sometimes.
 				Assert.Equal(NodeState.HandShaked, tester.Node2.State);
+				Assert.NotNull(toS2.TimeOffset);
 			}
 		}
 

--- a/NBitcoin/Protocol/Node.cs
+++ b/NBitcoin/Protocol/Node.cs
@@ -389,6 +389,7 @@ namespace NBitcoin.Protocol
 			}
 			if(version != null)
 			{
+				TimeOffset = DateTimeOffset.Now - version.Timestamp;
 				if((version.Services & NodeServices.NODE_WITNESS) != 0)
 					_SupportedTransactionOptions |= TransactionOptions.Witness;
 			}
@@ -807,6 +808,12 @@ namespace NBitcoin.Protocol
 		}
 
 		public DateTimeOffset LastSeen
+		{
+			get;
+			private set;
+		}
+
+		public TimeSpan? TimeOffset
 		{
 			get;
 			private set;


### PR DESCRIPTION
Because "getinfo" and "getnetworkinfo" RPC commands (in addition to potentially elsewhere) require the calculation of the median time offset between us and other nodes, this adds Node.TimeOffset

TimeOffset is captured from VersionPayload packet

Fixes https://github.com/MetacoSA/NBitcoin/issues/235