### PR TITLE
Allow contributors to avoid messing spaces and tabs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.cs]
+indent_style = tab


### PR DESCRIPTION
Contributors, not just the new ones, use to mess **[SPACE]s** with **[TAB]s** because preferences vary from project to project. This is a bit frustating for everybody, commiters and reviewers. I think a possible solution could be to encorage contributors to use [EditorConfig](http://editorconfig.org/) settings. 

While this is supported OOB in vcode, in visual studio we need to install the [EditConfig extension](https://marketplace.visualstudio.com/items?itemName=EditorConfigTeam.EditorConfig). Anyway, the good part is that those who use vcode and those that install (or have already installed) the extension will not mess the tabulation anymore. 