### PR TITLE
Transaction: make AddInput(Transaction,int) be more clever

### DIFF
--- a/NBitcoin/NBitcoin.csproj
+++ b/NBitcoin/NBitcoin.csproj
@@ -6,7 +6,7 @@
 		<Description>The C# Bitcoin Library</Description>
 	</PropertyGroup>
 	<PropertyGroup>
-        <Version>4.0.0.8</Version>
+        <Version>4.0.0.9</Version>
     </PropertyGroup>
   <PropertyGroup>
     <TargetFrameworks>net461;netstandard1.3;netstandard1.1</TargetFrameworks>

--- a/NBitcoin/Transaction.cs
+++ b/NBitcoin/Transaction.cs
@@ -1426,6 +1426,7 @@ namespace NBitcoin
 			var @in = new TxIn();
 			@in.PrevOut.Hash = prevTx.GetHash();
 			@in.PrevOut.N = (uint)outIndex;
+			@in.ScriptSig = prevTx.Outputs.ElementAt(outIndex).ScriptPubKey;
 			AddInput(@in);
 			return @in;
 		}


### PR DESCRIPTION
I assume this method was added to make it easier to add
inputs to a transaction without the need to create the
Input object itself. This is great, but to make it even
more great, we can even fill the ScriptSig property of
the new input for the API user so that they don't need
to mutate the inputs of the transaction after returning
it in order to be able to sign it later.

(If the ScriptSig of the input returned by this method
was not modified before trying to sign the transaction,
signing it would throw the exception below:)

```
System.InvalidOperationException: ScriptSigs should be filled with either previo
us scriptPubKeys or redeem script (for P2SH)
```