### PR TITLE
Feat/walletpassphrase

### DIFF
--- a/NBitcoin.Tests/RPCClientTests.cs
+++ b/NBitcoin.Tests/RPCClientTests.cs
@@ -210,6 +210,27 @@ namespace NBitcoin.Tests
 		}
 
 		[Fact]
+		public void CanGetPrivateKeysFromLockedAccount()
+		{
+			using(var builder = NodeBuilder.Create())
+			{
+				var rpc = builder.CreateNode().CreateRPCClient();
+				builder.StartAll();
+				Key key = new Key();
+				var passphrase = "password1234"
+				rpc.SendCommand("encryptwallet", passphrase)
+				rpc.ImportAddress(key.PubKey.GetAddress(Network.RegTest), TestAccount, false);
+				BitcoinAddress address = rpc.GetAccountAddress(TestAccount);
+				rpc.WalletPassPhrase(passphrase, 60)
+				BitcoinSecret secret = rpc.DumpPrivKey(address);
+				BitcoinSecret secret2 = rpc.GetAccountSecret(TestAccount);
+
+				Assert.Equal(secret.ToString(), secret2.ToString());
+				Assert.Equal(address.ToString(), secret.GetAddress().ToString());
+			}
+		}
+
+		[Fact]
 		public void CanDecodeAndEncodeRawTransaction()
 		{
 			var a = new Protocol.AddressManager().Select();

--- a/NBitcoin/RPC/RPCClient.Wallet.cs
+++ b/NBitcoin/RPC/RPCClient.Wallet.cs
@@ -115,7 +115,7 @@ namespace NBitcoin.RPC
 		wallet			 signmessage
 		wallet			 walletlock
 		wallet			 walletpassphrasechange
-		wallet			 walletpassphrase
+		wallet			 walletpassphrase			yes
 	*/
 	public partial class RPCClient
 	{
@@ -599,6 +599,26 @@ namespace NBitcoin.RPC
 				array.Add(obj);
 			}
 			await SendCommandAsync("lockunspent", parameters.ToArray()).ConfigureAwait(false);
+		}
+
+		// walletpassphrase
+
+		public void WalletPassphrase(string passphrase, int timeout)
+		{
+			var parameters = new List<object>();
+			parameters.Add(passphrase)
+			parameters.Add(timeout)
+
+			SendCommand("walletpassphrase", parameters.ToArray());
+		}
+
+		public async Task WalletPassphrase(string passphrase, int timeout)
+		{
+			var parameters = new List<object>();
+			parameters.Add(passphrase)
+			parameters.Add(timeout)
+
+			await SendCommandAsync("walletpassphrase", parameters.ToArray()).ConfigureAwait(false);
 		}
 	}
 }

--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -127,7 +127,7 @@ namespace NBitcoin.RPC
 		wallet			 signmessage
 		wallet			 walletlock
 		wallet			 walletpassphrasechange
-		wallet			 walletpassphrase
+		wallet			 walletpassphrase			yes
 	*/
 	public partial class RPCClient : IBlockRepository
 	{


### PR DESCRIPTION
This implements the `walletpassphrase` rpc call as part of the RPCClient.Wallet. I'm not sure if my test is relevant/shows that the method works because I'm green to unit testing but I figured I'd try. I used this implementation in BreezeHub/BreezeServer and it worked unlocked an encrypted wallet.