### PR TITLE
 Transaction: make Sign(key,coin) overloads stop using `params` keyword

### DIFF
--- a/NBitcoin/NBitcoin.csproj
+++ b/NBitcoin/NBitcoin.csproj
@@ -12,7 +12,7 @@
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>
 	<PropertyGroup>
-        <Version>4.0.0.16</Version>
+        <Version>4.0.0.17</Version>
     </PropertyGroup>
   <PropertyGroup>
     <TargetFrameworks>net461;net452;netstandard1.3;netstandard1.1</TargetFrameworks>

--- a/NBitcoin/Transaction.cs
+++ b/NBitcoin/Transaction.cs
@@ -1458,7 +1458,7 @@ namespace NBitcoin
 		/// <summary>
 		/// Sign a specific coin with the given secret
 		/// </summary>
-		/// <param name="key">Private keys</param>
+		/// <param name="keys">Private keys</param>
 		/// <param name="coins">Coins to sign</param>
 		public void Sign(Key[] keys, params ICoin[] coins)
 		{

--- a/NBitcoin/Transaction.cs
+++ b/NBitcoin/Transaction.cs
@@ -6,8 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NBitcoin
 {

--- a/NBitcoin/Transaction.cs
+++ b/NBitcoin/Transaction.cs
@@ -1450,7 +1450,7 @@ namespace NBitcoin
 		/// </summary>
 		/// <param name="secrets">Secrets</param>
 		/// <param name="coins">Coins to sign</param>
-		public void Sign(ISecret[] secrets, params ICoin[] coins)
+		public void Sign(ISecret[] secrets, ICoin[] coins)
 		{
 			Sign(secrets.Select(s => s.PrivateKey).ToArray(), coins);
 		}
@@ -1460,19 +1460,20 @@ namespace NBitcoin
 		/// </summary>
 		/// <param name="keys">Private keys</param>
 		/// <param name="coins">Coins to sign</param>
-		public void Sign(Key[] keys, params ICoin[] coins)
+		public void Sign(Key[] keys, ICoin[] coins)
 		{
 			TransactionBuilder builder = new TransactionBuilder();
 			builder.AddKeys(keys);
 			builder.AddCoins(coins);
 			builder.SignTransactionInPlace(this);
 		}
+
 		/// <summary>
 		/// Sign a specific coin with the given secret
 		/// </summary>
 		/// <param name="secret">Secret</param>
 		/// <param name="coins">Coins to sign</param>
-		public void Sign(ISecret secret, params ICoin[] coins)
+		public void Sign(ISecret secret, ICoin[] coins)
 		{
 			Sign(new[] { secret }, coins);
 		}
@@ -1480,11 +1481,51 @@ namespace NBitcoin
 		/// <summary>
 		/// Sign a specific coin with the given secret
 		/// </summary>
+		/// <param name="secrets">Secrets</param>
+		/// <param name="coins">Coins to sign</param>
+		public void Sign(ISecret[] secrets, ICoin coin)
+		{
+			Sign(secrets, new[] { coin });
+		}
+
+		/// <summary>
+		/// Sign a specific coin with the given secret
+		/// </summary>
+		/// <param name="secret">Secret</param>
+		/// <param name="coin">Coins to sign</param>
+		public void Sign(ISecret secret, ICoin coin)
+		{
+			Sign(new[] { secret }, new[] { coin });
+		}
+
+		/// <summary>
+		/// Sign a specific coin with the given secret
+		/// </summary>
 		/// <param name="key">Private key</param>
 		/// <param name="coins">Coins to sign</param>
-		public void Sign(Key key, params ICoin[] coins)
+		public void Sign(Key key, ICoin[] coins)
 		{
 			Sign(new[] { key }, coins);
+		}
+
+		/// <summary>
+		/// Sign a specific coin with the given secret
+		/// </summary>
+		/// <param name="key">Private key</param>
+		/// <param name="coin">Coin to sign</param>
+		public void Sign(Key key, ICoin coin)
+		{
+			Sign(new[] { key }, new[] { coin });
+		}
+
+		/// <summary>
+		/// Sign a specific coin with the given secret
+		/// </summary>
+		/// <param name="keys">Private keys</param>
+		/// <param name="coin">Coin to sign</param>
+		public void Sign(Key[] keys, ICoin coin)
+		{
+			Sign(keys, new[] { coin });
 		}
 
 		/// <summary>


### PR DESCRIPTION
Having the params keyword meant that it was easy to shoot
yourself in the foot, as a newbie, by not providing any
element of the array at all, which would end up not signing
the transaction at all without throwing any exception (silent
failing). See discussion in:
https://github.com/MetacoSA/NBitcoin/pull/260

Also provide two new overloads for non-array variables, though
(this is harmless, as opposed to params keyword, because
we make sure at least there's one element provided).

As this is an API breaking change, version is bumped to 5.0.