### PR TITLE
Null reference bug fix

### DIFF
--- a/NBitcoin/RPC/SatoshiFormatter.cs
+++ b/NBitcoin/RPC/SatoshiFormatter.cs
@@ -124,7 +124,7 @@ namespace NBitcoin.RPC
 					writer.WriteValue(destinations[0].GetAddress(Network).ToString());
 					writer.WriteEndArray();
 				}
-				else
+				else if(destinations.Count > 1)
 				{
 					var multi = PayToMultiSigTemplate.Instance.ExtractScriptPubKeyParameters(txout.ScriptPubKey);
 					WritePropertyValue(writer, "reqSigs", multi.SignatureCount);


### PR DESCRIPTION
Fixed null reference bug in Satoshi formatter when transaction output has no pub key destination.

Example of transaction that causes the null reference exception:

{
  "hash": "65e2c02c0fe3eaaa00a52dd46261eae0f6e3216f06364e8946b8c30e9c77b6ed",
  "ver": 2,
  "vin_sz": 1,
  "vout_sz": 2,
  "lock_time": 0,
  "size": 146,
  "in": [
    {
      "prev_out": {
        "hash": "0000000000000000000000000000000000000000000000000000000000000000",
        "n": 4294967295
      },
      "coinbase": "01690101"
    }
  ],
  "out": [
    {
      "value": "51.00000000",
      "scriptPubKey": "0277e8dedeae08ccd482ea7957fea53d05aaa72d73f0e031110c6046dd72ef82f8 OP_CHECKSIG"
    },
    {
      "value": "0.00000000",
      "scriptPubKey": "OP_RETURN aa21a9ed6f6f573022fbb76eeb5b7657326dbc9f4cb57557cca3cd48c491633558b28ba0"
    }
  ]
}