### PR TITLE
Enable public function for GetBase58Type

### DIFF
--- a/NBitcoin/Network.cs
+++ b/NBitcoin/Network.cs
@@ -981,7 +981,7 @@ namespace NBitcoin
 			return new BitcoinScriptAddress(base58, this);
 		}
 
-		private Base58Type? GetBase58Type(string base58)
+		public Base58Type? GetBase58Type(string base58)
 		{
 			var bytes = Encoders.Base58Check.DecodeData(base58);
 			for(int i = 0; i < base58Prefixes.Length; i++)


### PR DESCRIPTION
 Useful when importing a string value from external support (ex qr code or NFC)