### PR TITLE
Obsolate `estimatepriority` RPC

### DIFF
--- a/NBitcoin.Tests/RPCClientTests.cs
+++ b/NBitcoin.Tests/RPCClientTests.cs
@@ -912,21 +912,6 @@ namespace NBitcoin.Tests
 			}
 		}
 
-		[Fact]
-		public void CanEstimatePriority()
-		{
-			using(var builder = NodeBuilder.Create())
-			{
-				var node = builder.CreateNode();
-				node.Start();
-				var rpc = node.CreateRPCClient();
-				node.Generate(101);
-				var priority = rpc.EstimatePriority(10);
-				Assert.True(priority > 0 || priority == -1);
-			}
-		}
-
-
 		private void AssertJsonEquals(string json1, string json2)
 		{
 			foreach(var c in new[] { "\r\n", " ", "\t" })

--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -80,7 +80,6 @@ namespace NBitcoin.RPC
 		util			   validateaddress
 		util			   verifymessage
 		util			   estimatefee				  Yes
-		util			   estimatepriority			 Yes
 
 		------------------ Not shown in help
 		hidden			 invalidateblock
@@ -1240,6 +1239,7 @@ namespace NBitcoin.RPC
 			return new FeeRate(money);
 		}
 
+		[Obsolete("Removed by Bitcoin Core v0.15.0 Release")]
 		public decimal EstimatePriority(int nblock)
 		{
 			decimal priority = 0;
@@ -1254,6 +1254,7 @@ namespace NBitcoin.RPC
 			return priority;
 		}
 
+		[Obsolete("Removed by Bitcoin Core v0.15.0 Release")]
 		public async Task<decimal> EstimatePriorityAsync(int nblock)
 		{
 			if(nblock < 0)

--- a/NBitcoin/RPC/RPCOperations.cs
+++ b/NBitcoin/RPC/RPCOperations.cs
@@ -33,7 +33,6 @@ namespace NBitcoin.RPC
 		getblocktemplate,
 		submitblock,
 		estimatefee,
-		estimatepriority,
 
 		getnewaddress,
 		getaccountaddress,


### PR DESCRIPTION
With v0.15.0 the `estimatepriority` RPC has been removed. In this PR, I removed the tests, and marked the function obsolate.