### PR TITLE
Update xunit.runner.visualstudio

### DIFF
--- a/NBitcoin.Tests/NBitcoin.Tests.csproj
+++ b/NBitcoin.Tests/NBitcoin.Tests.csproj
@@ -23,7 +23,7 @@
 		<PackageReference Include="System.Net.Requests" Version="4.3.0" />
 		<PackageReference Include="System.Net.Http" Version="4.3.2" />
 		<PackageReference Include="xunit" Version="2.2.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
 		<PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
 		<PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
 	</ItemGroup>

--- a/NBitcoin.Tests/NBitcoin.Tests.csproj
+++ b/NBitcoin.Tests/NBitcoin.Tests.csproj
@@ -6,7 +6,7 @@
 		<Description>The C# Bitcoin Library</Description>
 	</PropertyGroup>
   <PropertyGroup>
-	  <TargetFrameworks>net461;netcoreapp1.1</TargetFrameworks>
+	  <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">
 		<DefineConstants>$(DefineConstants);WIN</DefineConstants>


### PR DESCRIPTION
Tests were not running. I updated the runner and now they are running properly.  

What I also tried:  

1. I installed .NET Framework development for VS, it still didn't work.

2. However I was able to make it work with the old runner version if I edited the following line in the test project's csproj:

```xml
<TargetFrameworks>net461;netcoreapp1.1</TargetFrameworks>
```

I added: `netcoreapp2.0` - did not work.  
I replaced `netcoreapp1.1` with `netcoreapp2.0` - did not work.  
I removed both `net461;netcoreapp1.1` and replaced with `netcoreapp2.0` - did work.