### PR TITLE
Golomb-compressed Sets

### DIFF
--- a/NBitcoin.Tests/Bip158_tests.cs
+++ b/NBitcoin.Tests/Bip158_tests.cs
@@ -10,6 +10,7 @@ namespace NBitcoin.Tests
 	public class GolombRiceFilterTest
 	{
 		[Fact]
+		[Trait("UnitTest", "UnitTest")]
 		public void BuildFilterAndMatchValues()
 		{
 			var names = from name in new[] { "New York", "Amsterdam", "Paris", "Buenos Aires", "La Habana" }
@@ -52,6 +53,7 @@ namespace NBitcoin.Tests
 		}
 
 		[Fact]
+		[Trait("UnitTest", "UnitTest")]
 		public void FalsePositivesTest()
 		{
 			// Given this library can be used for building and query filters for each block of 
@@ -139,6 +141,7 @@ namespace NBitcoin.Tests
 	public class FastBitArrayTest
 	{
 		[Fact]
+		[Trait("UnitTest", "UnitTest")]
 		public void GetBitsTest()
 		{
 			// 1 1 1 0 1 0 1 1 - 1 0 1 0 1 0 1 1 - 1 0 1 0 1 1 1 0 - 1 0 1 0 1 1 1 0 
@@ -169,6 +172,7 @@ namespace NBitcoin.Tests
 		}
 
 		[Fact]
+		[Trait("UnitTest", "UnitTest")]
 		public void SetRandomBitsTest()
 		{
 			var barr = new FastBitArray(new byte[0]);
@@ -201,6 +205,7 @@ namespace NBitcoin.Tests
 		}
 
 		[Fact]
+		[Trait("UnitTest", "UnitTest")]
 		public void SetBitAndGetBitsTest()
 		{
 			var barr = new FastBitArray(new byte[0]);
@@ -238,6 +243,8 @@ namespace NBitcoin.Tests
 			Assert.Equal(0b11001UL, barr.GetBits(29, 5));
 		}
 
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
 		public void SetBitsBigEndianTest()
 		{
 			var barr = new FastBitArray(new byte[0]);

--- a/NBitcoin.Tests/Bip158_tests.cs
+++ b/NBitcoin.Tests/Bip158_tests.cs
@@ -1,0 +1,257 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace NBitcoin.Tests
+{
+	public class GcsFilterTest
+	{
+		[Fact]
+		public void BuildFilterAndMatchValues()
+		{
+			var names = from name in new[] { "New York", "Amsterdam", "Paris", "Buenos Aires", "La Habana" }
+				select Encoding.ASCII.GetBytes(name);
+
+			var key = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+			var filter = GCSFilter.Build(key, 0x10, names);
+
+			// The filter should match all ther values that were added.
+			foreach (var name in names)
+			{
+				Assert.True(filter.Match(name, key));
+			}
+
+			// The filter should NOT match any extra value.
+			Assert.False(filter.Match(Encoding.ASCII.GetBytes("Porto Alegre"), key));
+			Assert.False(filter.Match(Encoding.ASCII.GetBytes("Madrid"), key));
+
+			// The filter should match because it has one element indexed: Buenos Aires.
+			var otherCities = new[] { "La Paz", "Barcelona", "El Cairo", "Buenos Aires", "Asunción" };
+			var otherNames = from name in otherCities select Encoding.ASCII.GetBytes(name);
+			Assert.True(filter.MatchAny(otherNames, key));
+
+			// The filter should NOT match because it doesn't have any element indexed.
+			var otherCities2 = new[] { "La Paz", "Barcelona", "El Cairo", "Córdoba", "Asunción" };
+			var otherNames2 = from name in otherCities2 select Encoding.ASCII.GetBytes(name);
+			Assert.False(filter.MatchAny(otherNames2, key));
+		}
+
+		class BlockFilter
+		{
+			public GCSFilter Filter { get; }
+			public List<byte[]> Data { get; }
+
+			public BlockFilter(GCSFilter filter, List<byte[]> data)
+			{
+				Filter = filter;
+				Data = data;
+			}
+		}
+
+		[Fact]
+		public void FalsePositivesTest()
+		{
+			// Given this library can be used for building and query filters for each block of 
+			// the bitcoin's blockchain, we must be sure it performs well, specially in the queries.
+
+			// Considering a 4MB block (overestimated) with an average transaction size of 250 bytes (underestimated)
+			// gives us 16000 transactions (this is about 27 tx/sec). Assuming 2.5 txouts per tx we have 83885 txouts 
+			// per block.
+			const byte P = 20;
+			const int blockCount = 100;
+			const int maxBlockSize = 4 * 1000 * 1000;
+			const int avgTxSize = 250;                  // Currently the average is around 1kb.
+			const int txoutCountPerBlock = maxBlockSize / avgTxSize;
+			const int avgTxoutPushDataSize = 20;        // P2PKH scripts has 20 bytes.
+			const int walletAddressCount = 1000;        // We estimate that our user will have 1000 addresses.
+
+			var key = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+
+			// Generation of data to be added into the filter
+			var random = new Random();
+			var sw = new Stopwatch();
+
+			var blocks = new List<BlockFilter>(blockCount);
+			for (var i = 0; i < blockCount; i++)
+			{
+				var txouts = new List<byte[]>(txoutCountPerBlock);
+				for (var j = 0; j < txoutCountPerBlock; j++)
+				{
+					var pushDataBuffer = new byte[avgTxoutPushDataSize];
+					random.NextBytes(pushDataBuffer);
+					txouts.Add(pushDataBuffer);
+				}
+
+				sw.Start();
+				var filter = GCSFilter.Build(key, P, txouts);
+				sw.Stop();
+
+				blocks.Add(new BlockFilter(filter, txouts));
+			}
+			Console.WriteLine("Block filter generation time (): {0}ms", sw.ElapsedMilliseconds);
+			sw.Reset();
+
+
+			var walletAddresses = new List<byte[]>(walletAddressCount);
+			var falsePositiveCount = 0;
+			for (var i = 0; i < walletAddressCount; i++)
+			{
+				var walletAddress = new byte[avgTxoutPushDataSize];
+				random.NextBytes(walletAddress);
+				walletAddresses.Add(walletAddress);
+			}
+
+			sw.Start();
+			// Check that the filter can match every single txout in every block.
+			foreach (var block in blocks)
+			{
+				if (block.Filter.MatchAny(walletAddresses, key))
+					falsePositiveCount++;
+			}
+
+			sw.Stop();
+
+			Console.WriteLine("MatchAny time (false positives): {0}ms", sw.ElapsedMilliseconds);
+			Console.WriteLine("   False positives             : {0}", falsePositiveCount);
+			Assert.Equal(0, falsePositiveCount);
+
+			// Filter has to mat existing values
+			sw.Start();
+			var falseNegativeCount = 0;
+			// Check that the filter can match every single txout in every block.
+			foreach (var block in blocks)
+			{
+				if (!block.Filter.MatchAny(block.Data, key))
+					falseNegativeCount++;
+			}
+
+			sw.Stop();
+
+			Console.WriteLine("MatchAny time (false Negatives): {0}ms", sw.ElapsedMilliseconds);
+			Console.WriteLine("   False negatives             : {0}", falseNegativeCount);
+			Assert.Equal(0, falseNegativeCount);
+		}
+	}
+
+	public class FastBitArrayTest
+	{
+		[Fact]
+		public void GetBitsTest()
+		{
+			// 1 1 1 0 1 0 1 1 - 1 0 1 0 1 0 1 1 - 1 0 1 0 1 1 1 0 - 1 0 1 0 1 1 1 0 
+			// 1 0 1 1 1 0 1 0 
+			var barr = new FastBitArray();
+			barr.Length = 50;
+			for (var i = 0; i < 40; i++)
+			{
+				if (i % 7 == 0)
+				{
+					barr[i] = true;
+					i++;
+					barr[i] = true;
+				}
+				else
+				{
+					barr[i] = i % 2 == 0;
+				}
+			}
+
+			// Get bits in the same int.
+			Assert.Equal((ulong)0b111, barr.GetBits(0, 3));
+			Assert.Equal((ulong)0b10111, barr.GetBits(0, 5));
+			Assert.Equal((ulong)0b01010111010, barr.GetBits(3, 11));
+
+			// Get bits in cross int
+			Assert.Equal((ulong)0b101110101110101, barr.GetBits(24, 16));
+		}
+
+		[Fact]
+		public void SetRandomBitsTest()
+		{
+			var barr = new FastBitArray(new byte[0]);
+			barr.Length = 150;
+			var values = new List<int>();
+			var lengths = new List<int>();
+			var rnd = new Random();
+			var pos = 0;
+
+			for (int i = 0; i < 10; i++)
+			{
+				var val = rnd.Next();
+				var len = rnd.Next(1, 20);
+				barr.SetBits(pos, (ulong)val, len);
+
+				values.Add(val);
+				lengths.Add(len);
+				pos += len;
+			}
+
+			pos = 0;
+			for (int i = 0; i < 10; i++)
+			{
+				var len = lengths[i];
+				var expectedValue = values[i];
+				var value = barr.GetBits(pos, len);
+				Assert.Equal(((ulong)expectedValue & value), value);
+				pos += len;
+			}
+		}
+
+		[Fact]
+		public void SetBitAndGetBitsTest()
+		{
+			var barr = new FastBitArray(new byte[0]);
+			barr.Length = 150;
+
+			var j = true;
+			for (int i = 0; i < 64; i += 2)
+			{
+				if (j)
+				{
+					barr.SetBit(i, true);
+					barr.SetBit(i + 1, true);
+				}
+				else
+				{
+					barr.SetBit(i, false);
+					barr.SetBit(i + 1, false);
+				}
+
+				j = !j;
+			}
+
+			for (var i = 0; i < 16; i++)
+			{
+				Assert.Equal(0b11UL, barr.GetBits(i * 4, 2));
+				Assert.Equal(0b00UL, barr.GetBits((i * 4) + 2, 2));
+			}
+
+			for (var i = 0; i < 8; i++)
+			{
+				Assert.Equal(0b0011UL, barr.GetBits(i * 8, 4));
+				Assert.Equal(0b0011UL, barr.GetBits((i * 8) + 4, 2));
+			}
+
+			Assert.Equal(0b11001UL, barr.GetBits(29, 5));
+		}
+
+		public void SetBitsBigEndianTest()
+		{
+			var barr = new FastBitArray(new byte[0]);
+			barr.Length = 5;
+			barr.SetBits(0, 14, 4);
+			var val = barr.GetBits(0, 4);
+
+			barr = new FastBitArray(new byte[0]);
+			barr.Length = 5;
+			barr.SetBit(0, false);
+			barr.SetBit(1, true);
+			barr.SetBit(2, true);
+			barr.SetBit(3, true);
+			val = barr.GetBits(0, 4);
+		}
+	}
+}

--- a/NBitcoin.Tests/Bip158_tests.cs
+++ b/NBitcoin.Tests/Bip158_tests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace NBitcoin.Tests
 {
-	public class GcsFilterTest
+	public class GolombRiceFilterTest
 	{
 		[Fact]
 		public void BuildFilterAndMatchValues()
@@ -16,7 +16,7 @@ namespace NBitcoin.Tests
 				select Encoding.ASCII.GetBytes(name);
 
 			var key = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
-			var filter = GCSFilter.Build(key, 0x10, names);
+			var filter = GolombRiceFilter.Build(key, names, 0x10);
 
 			// The filter should match all ther values that were added.
 			foreach (var name in names)
@@ -41,10 +41,10 @@ namespace NBitcoin.Tests
 
 		class BlockFilter
 		{
-			public GCSFilter Filter { get; }
+			public GolombRiceFilter Filter { get; }
 			public List<byte[]> Data { get; }
 
-			public BlockFilter(GCSFilter filter, List<byte[]> data)
+			public BlockFilter(GolombRiceFilter filter, List<byte[]> data)
 			{
 				Filter = filter;
 				Data = data;
@@ -86,7 +86,7 @@ namespace NBitcoin.Tests
 				}
 
 				sw.Start();
-				var filter = GCSFilter.Build(key, P, txouts);
+				var filter = GolombRiceFilter.Build(key, txouts, P);
 				sw.Stop();
 
 				blocks.Add(new BlockFilter(filter, txouts));
@@ -116,7 +116,7 @@ namespace NBitcoin.Tests
 
 			Console.WriteLine("MatchAny time (false positives): {0}ms", sw.ElapsedMilliseconds);
 			Console.WriteLine("   False positives             : {0}", falsePositiveCount);
-			Assert.Equal(0, falsePositiveCount);
+			Assert.True(falsePositiveCount < 5);
 
 			// Filter has to mat existing values
 			sw.Start();

--- a/NBitcoin.Tests/Bip158_tests.cs
+++ b/NBitcoin.Tests/Bip158_tests.cs
@@ -93,7 +93,6 @@ namespace NBitcoin.Tests
 
 				blocks.Add(new BlockFilter(filter, txouts));
 			}
-			Console.WriteLine("Block filter generation time (): {0}ms", sw.ElapsedMilliseconds);
 			sw.Reset();
 
 
@@ -115,9 +114,6 @@ namespace NBitcoin.Tests
 			}
 
 			sw.Stop();
-
-			Console.WriteLine("MatchAny time (false positives): {0}ms", sw.ElapsedMilliseconds);
-			Console.WriteLine("   False positives             : {0}", falsePositiveCount);
 			Assert.True(falsePositiveCount < 5);
 
 			// Filter has to mat existing values
@@ -132,8 +128,6 @@ namespace NBitcoin.Tests
 
 			sw.Stop();
 
-			Console.WriteLine("MatchAny time (false Negatives): {0}ms", sw.ElapsedMilliseconds);
-			Console.WriteLine("   False negatives             : {0}", falseNegativeCount);
 			Assert.Equal(0, falseNegativeCount);
 		}
 	}

--- a/NBitcoin/BIP158/BitStream.cs
+++ b/NBitcoin/BIP158/BitStream.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Collections;
+
+namespace NBitcoin
+{
+	/// <summary> Provides a view of an array of bits as a stream of bits. </summary>
+	internal class BitStream
+	{
+		private readonly FastBitArray _buffer;
+		private int _position;
+
+		internal int Position
+		{
+			get => _position;
+			set => _position = value;
+		}
+
+		public BitStream(FastBitArray bitArray)
+		{
+			_buffer = bitArray;
+			_position = 0;
+		}
+
+		public bool ReadBit()
+		{
+			return _buffer[_position++];
+		}
+
+		public ulong ReadBits(int count)
+		{
+			var ret = _buffer.GetBits(_position, count);
+			_position += count;
+			return ret;
+		}
+
+		public void WriteBit(bool bit)
+		{
+			if (_buffer.Length == _position)
+			{
+				_buffer.Length++;
+			}
+
+			_buffer[_position++] = bit;
+		}
+
+		public void WriteBits(ulong data, byte count)
+		{
+			_buffer.Length += count;
+			_buffer.SetBits(_position, data, count);
+			_position += count;
+		}
+
+		public byte[] ToByteArray()
+		{
+			var byteArray = new byte[(_position + (_position - 1)) / 8];
+			_buffer.CopyTo(byteArray, 0);
+			return byteArray;
+		}
+	}
+
+
+	internal class GRCodedStreamWriter
+	{
+		private readonly BitStream _stream;
+		private readonly byte _p;
+		private readonly ulong _modP;
+		private ulong _lastValue;
+
+		public GRCodedStreamWriter(BitStream stream, byte p)
+		{
+			_stream = stream;
+			_p = p;
+			_modP = (1UL << p);
+			_lastValue = 0UL;
+		}
+
+		public int Write(ulong value)
+		{
+			var diff = value - _lastValue;
+
+			var remainder = diff & (_modP - 1);
+			var quotient = (diff - remainder) >> _p;
+
+			while (quotient > 0)
+			{
+				_stream.WriteBit(true);
+				quotient--;
+			}
+			_stream.WriteBit(false);
+			_stream.WriteBits(remainder, _p);
+			_lastValue = value;
+			return _stream.Position;
+		}
+	}
+
+	internal class GRCodedStreamReader
+	{
+		private readonly BitStream _stream;
+		private readonly byte _p;
+		private readonly ulong _modP;
+		private ulong _lastValue;
+
+		public GRCodedStreamReader(BitStream stream, byte p, ulong lastValue)
+		{
+			_stream = stream;
+			_p = p;
+			_modP = (1UL << p);
+			_lastValue = lastValue;
+		}
+
+		public ulong Read()
+		{
+			var currentValue = _lastValue + ReadUInt64();
+			_lastValue = currentValue;
+			return currentValue;
+		}
+
+		private ulong ReadUInt64()
+		{
+			var count = 0UL;
+			var bit = _stream.ReadBit();
+			while (bit)
+			{
+				count++;
+				bit = _stream.ReadBit();
+			}
+
+			var remainder = _stream.ReadBits(_p);
+			var value = (count * _modP) + remainder;
+			return value;
+		}
+	}
+}

--- a/NBitcoin/BIP158/BitStream.cs
+++ b/NBitcoin/BIP158/BitStream.cs
@@ -45,7 +45,10 @@ namespace NBitcoin
 
 		public void WriteBits(ulong data, byte count)
 		{
-			_buffer.Length += count;
+			if (_buffer.Length < _position + count)
+			{
+				_buffer.Length = _position + count;
+			}
 			_buffer.SetBits(_position, data, count);
 			_position += count;
 		}

--- a/NBitcoin/BIP158/FastBitArray.cs
+++ b/NBitcoin/BIP158/FastBitArray.cs
@@ -38,20 +38,13 @@ namespace NBitcoin
 				                | (uint)(bytes[num2 + 3] & 255) << 24);
 				num2 += 4;
 			}
-			switch (bytes.Length - num2)
-			{
-				case 1:
-					_buffer[num] |= (uint)(bytes[num2] & 255);
-					return;
-				case 2:
-					_buffer[num] |= (uint)(bytes[num2 + 1] & 255) << 8;
-					return;
-				case 3:
-					_buffer[num] = (uint)(bytes[num2 + 2] & 255) << 16;
-					break;
-				default:
-					return;
-			}
+			var diff = bytes.Length - num2;
+			if (diff > 0)
+				_buffer[num] |= (uint)(bytes[num2 + 0] & 255);
+			if (diff > 1)
+				_buffer[num] |= (uint)(bytes[num2 + 1] & 255) << 8;
+			if (diff > 2)
+				_buffer[num] |= (uint)(bytes[num2 + 2] & 255) << 16;
 		}
 
 		public bool this[int index]

--- a/NBitcoin/BIP158/FastBitArray.cs
+++ b/NBitcoin/BIP158/FastBitArray.cs
@@ -1,0 +1,191 @@
+﻿using System;
+
+namespace NBitcoin
+{
+	/// <summary> 
+	/// Manages an array of bits allowing making bit-level operations as a big array of bits. 
+	/// The System.Collections.BitArray class doesn't allow us to read/write more than one bit
+	/// at a time. 
+	/// </summary>
+	public sealed class FastBitArray
+	{
+		private uint[] _buffer;
+		private int _length;
+
+		public FastBitArray()
+			: this(new byte[0]) 
+		{
+		}
+
+		public FastBitArray(byte[] bytes)
+		{
+			if (bytes == null)
+				throw new ArgumentNullException(nameof(bytes));
+
+			if (bytes.Length > 268435455)
+			{
+				throw new ArgumentException("Array is too long", nameof(bytes));
+			}
+			_buffer = new uint[GetArrayLength(bytes.Length, 4)];
+			_length = bytes.Length * 8;
+			var num = 0;
+			var num2 = 0;
+			while (bytes.Length - num2 >= 4)
+			{
+				_buffer[num++] = ((uint)(bytes[num2] & 255) 
+				                | (uint)(bytes[num2 + 1] & 255) << 8 
+				                | (uint)(bytes[num2 + 2] & 255) << 16 
+				                | (uint)(bytes[num2 + 3] & 255) << 24);
+				num2 += 4;
+			}
+			switch (bytes.Length - num2)
+			{
+				case 1:
+					_buffer[num] |= (uint)(bytes[num2] & 255);
+					return;
+				case 2:
+					_buffer[num] |= (uint)(bytes[num2 + 1] & 255) << 8;
+					return;
+				case 3:
+					_buffer[num] = (uint)(bytes[num2 + 2] & 255) << 16;
+					break;
+				default:
+					return;
+			}
+		}
+
+		public bool this[int index]
+		{
+			get => GetBit(index);
+			set => SetBit(index, value);
+		}
+
+		public int Length
+		{
+			get => _length;
+			set
+			{
+				if (value < 0)
+					throw new ArgumentOutOfRangeException(nameof(value));
+
+				var arrayLength = GetArrayLength(value, 32);
+				if (arrayLength > _buffer.Length || arrayLength + 256 < _buffer.Length)
+				{
+					var array = new uint[arrayLength];
+					var count = ((arrayLength > _buffer.Length) ? _buffer.Length : arrayLength) * sizeof(uint);
+					Buffer.BlockCopy(_buffer, 0, array, 0, count);
+					_buffer = array;
+				}
+				if (value > _length)
+				{
+					var num = GetArrayLength(_length, 32) - 1;
+					var num2 = _length % 32;
+					if (num2 > 0)
+					{
+						_buffer[num] &= (uint)(1 << num2) - 1;
+					}
+					Array.Clear(_buffer, num + 1, arrayLength - num - 1);
+				}
+				_length = value;
+			}
+		}
+
+		public bool GetBit(int index)
+		{
+			if (index < 0 || index >= _length)
+				throw new ArgumentOutOfRangeException(nameof(index));
+
+			return (_buffer[index / 32] & 1 << index % 32) != 0;
+		}
+
+		public ulong GetBits(int index, int count)
+		{
+			var arrIndex = index / 32;
+			var bitIndex = index % 32;
+			var value = _buffer[arrIndex];
+
+			var mask = (ulong)((1 << count) - 1);
+			var ret = (ulong)(value >> bitIndex);
+
+			if (bitIndex + count > 32)
+			{
+				var rest = count - (32 - bitIndex);
+				ret |= (ulong)_buffer[arrIndex + 1] << (count - rest);
+			}
+			return ret & mask;
+		}
+
+		public void SetBit(int index, bool value)
+		{
+			if (index < 0 || index >= _length)
+				throw new ArgumentOutOfRangeException(nameof(index));
+
+			if (value)
+			{
+				_buffer[index / 32] |= (uint)(1 << index % 32);
+			}
+			else
+			{
+				_buffer[index / 32] &= (uint)(~(1 << index % 32));
+			}
+		}
+
+		public void SetBits(int index, ulong val, int count)
+		{
+			// TODO: improve this method. This is a very naive approach
+			for (var i = 0; i < count; i++)
+			{
+				SetBit(index+i, (val & (1UL << i)) != 0);
+			}
+		}
+
+		private static int GetArrayLength(int n, int div)
+		{
+			if (n <= 0)
+			{
+				return 0;
+			}
+			return (n - 1) / div + 1;
+		}
+
+		public void CopyTo(Array array, int index)
+		{
+			if (array == null)
+				throw new ArgumentNullException(nameof(array));
+
+			if (index < 0)
+				throw new ArgumentOutOfRangeException(nameof(index));
+
+			if (array is int[])
+			{
+				Array.Copy(_buffer, 0, array, index, GetArrayLength(_length, 32));
+				return;
+			}
+			if (array is byte[])
+			{
+				var arrayLength = GetArrayLength(_length, 8);
+				if (array.Length - index < arrayLength)
+					throw new ArgumentOutOfRangeException(nameof(index));
+				
+				var array2 = (byte[])array;
+				for (var i = 0; i < arrayLength; i++)
+				{
+					array2[index + i] = (byte)(_buffer[i / 4] >> i % 4 * 8 & 255);
+				}
+				return;
+			}
+
+			if (!(array is bool[]))
+				throw new ArgumentException("Dest array type is not supported");
+
+			if (array.Length - index < _length)
+				throw new ArgumentOutOfRangeException(nameof(index));
+
+			var array3 = (bool[])array;
+			for (var j = 0; j < _length; j++)
+			{
+				array3[index + j] = ((_buffer[j / 32] >> j % 32 & 1) != 0);
+			}
+		}
+	}
+}

--- a/NBitcoin/BIP158/Filter.cs
+++ b/NBitcoin/BIP158/Filter.cs
@@ -1,0 +1,163 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NBitcoin.Crypto;
+
+namespace NBitcoin
+{
+	/// <summary>
+	/// Implements a Golomb-coded set to be use in the creation of client-side filter
+	/// for a new kind Bitcoin light clients. This code is based on the BIP:
+	/// https://github.com/Roasbeef/bips/blob/master/gcs_light_client.mediawiki
+	/// </summary>
+	public class GCSFilter
+	{
+		public byte P { get; }
+		public int N { get; }
+		public ulong ModulusP { get;  }
+		public ulong ModulusNP { get; }
+		public FastBitArray Data { get;  }
+
+		public GCSFilter(FastBitArray data, byte P, int N)
+		{
+			this.P = P;
+			this.N = N;
+
+			var modP = 1UL << P;
+			this.ModulusP = modP;
+			this.ModulusNP = ((ulong) N) * modP;
+			this.Data = data;
+		}
+
+		public static GCSFilter Build(byte[] k, byte P, IEnumerable<byte[]> data)
+		{
+			if (P == 0x00)
+				throw new ArgumentException("P cannot be zero", nameof(P));
+
+			var bytesData = data as byte[][] ?? data.ToArray();
+			if (data == null || !bytesData.Any())
+				throw new ArgumentException("data can not be null or empty array", nameof(data));
+
+
+			var N = bytesData.Length;
+			var hs = ConstructHashedSet(P, N, k, bytesData);
+			var filterData = Compress(hs, P);
+
+			return new GCSFilter(filterData, P, N);
+		}
+
+
+		internal static List<ulong> ConstructHashedSet(byte P, int N, byte[] key, IEnumerable<byte[]> data)
+		{
+			// N the number of items to be inserted into the set.
+			var dataArrayBytes = data as byte[][] ?? data.ToArray();
+
+			// The list of data item hashes.
+			var values = new List<ulong>();
+			var modP = 1UL << P;
+			var modNP = ((ulong)N) * modP;
+			var nphi = modNP >> 32;
+			var nplo = (ulong)((uint)modNP);
+
+			// Process the data items and calculate the 64 bits hash for each of them.
+			foreach(var item in dataArrayBytes )
+			{
+				var hash = SipHash(key, item);
+				var value = FastReduction(hash, nphi, nplo);
+				values.Add(value);
+			}
+
+			values.Sort();
+			return values;
+		}
+
+		private static ulong SipHash(byte[] key, byte[] data)
+		{
+			var k0 = BitConverter.ToUInt64(key, 0);
+			var k1 = BitConverter.ToUInt64(key, 8);
+
+			var hasher = new Hashes.SipHasher(k0, k1);
+			hasher.Write(data);
+			return hasher.Finalize();
+		}
+
+		private static FastBitArray Compress(List<ulong> values, byte P)
+		{
+			var bitArray = new FastBitArray();
+			var bitStream = new BitStream(bitArray);
+			var sw = new GRCodedStreamWriter(bitStream, P);
+
+			foreach (var value in values)
+			{
+				sw.Write(value);
+			}
+			return bitArray;
+		}
+
+
+		public bool Match(byte[] data, byte[] key)
+		{
+			return MatchAny(new []{data}, key);
+		}
+
+		public bool MatchAny(IEnumerable<byte[]> data, byte[] key)
+		{
+			if (data == null || !data.Any())
+				throw new ArgumentException("data can not be null or empty array", nameof(data));
+
+			var hs = ConstructHashedSet(P, N, key, data);
+
+			var lastValue1 = 0UL;
+			var lastValue2 = hs[0];
+			var i = 1;
+			var j = 0;
+
+			var bitStream = new BitStream(Data);
+			var sr = new GRCodedStreamReader(bitStream, P, 0);
+
+			while (lastValue1 != lastValue2 && j<N)
+			{
+				if (lastValue1 > lastValue2)
+				{
+					if (i < hs.Count)
+					{
+						lastValue2 = hs[i];
+						i++;
+					}
+					else
+					{
+						return false;
+					}
+				}
+				else if (lastValue2 > lastValue1)
+				{
+					var val = sr.Read();
+					lastValue1 = val;
+				}
+			}
+			return j<N;
+		}
+
+		internal static ulong FastReduction(ulong value, ulong nhi, ulong nlo)
+		{
+			// First, we'll spit the item we need to reduce into its higher and lower bits.
+			var vhi = value >> 32;
+			var vlo = (ulong)((uint)value);
+
+			// Then, we distribute multiplication over each part.
+			var vnphi = vhi * nhi;
+			var vnpmid = vhi * nlo;
+			var npvmid = nhi * vlo;
+			var vnplo = vlo * nlo;
+
+			// We calculate the carry bit.
+			var carry = ((ulong)((uint)vnpmid) + (ulong)((uint)npvmid) +
+			(vnplo >> 32)) >> 32;
+
+			// Last, we add the high bits, the middle bits, and the carry.
+			value = vnphi + (vnpmid >> 32) + (npvmid >> 32) + carry;
+
+			return value;
+		}
+	}
+}

--- a/NBitcoin/BIP158/GolombRiceFilter.cs
+++ b/NBitcoin/BIP158/GolombRiceFilter.cs
@@ -10,15 +10,17 @@ namespace NBitcoin
 	/// for a new kind Bitcoin light clients. This code is based on the BIP:
 	/// https://github.com/Roasbeef/bips/blob/master/gcs_light_client.mediawiki
 	/// </summary>
-	public class GCSFilter
+	public class GolombRiceFilter
 	{
+		private const byte DefaultP = 20;
+
 		public byte P { get; }
 		public int N { get; }
 		public ulong ModulusP { get;  }
 		public ulong ModulusNP { get; }
 		public FastBitArray Data { get;  }
 
-		public GCSFilter(FastBitArray data, byte P, int N)
+		public GolombRiceFilter(FastBitArray data, int N, byte P = DefaultP)
 		{
 			this.P = P;
 			this.N = N;
@@ -29,7 +31,7 @@ namespace NBitcoin
 			this.Data = data;
 		}
 
-		public static GCSFilter Build(byte[] k, byte P, IEnumerable<byte[]> data)
+		public static GolombRiceFilter Build(byte[] k, IEnumerable<byte[]> data, byte P = DefaultP)
 		{
 			if (P == 0x00)
 				throw new ArgumentException("P cannot be zero", nameof(P));
@@ -43,7 +45,7 @@ namespace NBitcoin
 			var hs = ConstructHashedSet(P, N, k, bytesData);
 			var filterData = Compress(hs, P);
 
-			return new GCSFilter(filterData, P, N);
+			return new GolombRiceFilter(filterData, N, P);
 		}
 
 

--- a/NBitcoin/BIP158/GolombRiceFilter.cs
+++ b/NBitcoin/BIP158/GolombRiceFilter.cs
@@ -112,12 +112,11 @@ namespace NBitcoin
 			var lastValue1 = 0UL;
 			var lastValue2 = hs[0];
 			var i = 1;
-			var j = 0;
 
 			var bitStream = new BitStream(Data);
 			var sr = new GRCodedStreamReader(bitStream, P, 0);
 
-			while (lastValue1 != lastValue2 && j<N)
+			while (lastValue1 != lastValue2)
 			{
 				if (lastValue1 > lastValue2)
 				{
@@ -137,7 +136,7 @@ namespace NBitcoin
 					lastValue1 = val;
 				}
 			}
-			return j<N;
+			return true;
 		}
 
 		internal static ulong FastReduction(ulong value, ulong nhi, ulong nlo)

--- a/NBitcoin/BIP158/GolombRiceFilter.cs
+++ b/NBitcoin/BIP158/GolombRiceFilter.cs
@@ -116,26 +116,34 @@ namespace NBitcoin
 			var bitStream = new BitStream(Data);
 			var sr = new GRCodedStreamReader(bitStream, P, 0);
 
-			while (lastValue1 != lastValue2)
+			try
 			{
-				if (lastValue1 > lastValue2)
+				while (lastValue1 != lastValue2)
 				{
-					if (i < hs.Count)
+					if (lastValue1 > lastValue2)
 					{
-						lastValue2 = hs[i];
-						i++;
+						if (i < hs.Count)
+						{
+							lastValue2 = hs[i];
+							i++;
+						}
+						else
+						{
+							return false;
+						}
 					}
-					else
+					else if (lastValue2 > lastValue1)
 					{
-						return false;
+						var val = sr.Read();
+						lastValue1 = val;
 					}
-				}
-				else if (lastValue2 > lastValue1)
-				{
-					var val = sr.Read();
-					lastValue1 = val;
 				}
 			}
+			catch (ArgumentOutOfRangeException) // end-of-stream 
+			{
+				return false;
+			}
+
 			return true;
 		}
 


### PR DESCRIPTION
Adds Golomb-compressed Sets which is needed for implementing the
BIP158 - Compact Block Filters for Light Clients. 

Classes for creating and querying Golomb-compressed Sets (GCS), a statistical compressed data-structure. The idea behind this implementation is using it in a new kind of Bitcoin light client that uses GCS instead of bloom filters.

This projects is based on the [original BIP (Bitcoin Improvement Proposal)](https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki)
and [the Olaoluwa Osuntokun's reference implementation](https://github.com/Roasbeef/btcutil/tree/gcs/gcs)

An standalone project which doesn't depend on NBitcoin is [available here](https://github.com/lontivero/gcs/)

## Motivation of the Pull Request
@nopara73 and I think this code should be part of NBitcoin in order to allow users to work with GCS. This is the first of a set of PRs that we will do as soon we have new funtionalities done.

## How to use it
The example below shows it can be used in a similar way that bloom filters.

```c#
var cities = new[] { "New York", "Amsterdam", "Paris", "Buenos Aires", "La Habana" }
var citiesAsByteArrar = from city in cities select Encoding.ASCII.GetBytes(city);

// A random key
var key = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };

// The false possitive rate (FPR) is calculated as: FPR = 1/(2**P)
var P = 16
var filter = GCSFilter.Build(key, P, citiesAsByteArrar);

// The filter should match all ther values that were added
foreach(var city cities)
{
	Assert.IsTrue(filter.Match(city, key));
}

// The filter should NOT match any extra value
Assert.IsFalse(filter.Match(Encoding.ASCII.GetBytes("Porto Alegre"), key));
Assert.IsFalse(filter.Match(Encoding.ASCII.GetBytes("Madrid"), key));
```
