### PR TITLE
Set regtest JSON-RPC port to 18443 to avoid conflict …

### DIFF
--- a/NBitcoin.Tests/NodeBuilder.cs
+++ b/NBitcoin.Tests/NodeBuilder.cs
@@ -74,9 +74,9 @@ namespace NBitcoin.Tests
 	}
 	public class NodeBuilder : IDisposable
 	{
-		public static NodeBuilder Create([CallerMemberNameAttribute]string caller = null, string version = "0.15.1")
+		public static NodeBuilder Create([CallerMemberNameAttribute]string caller = null, string version = "0.16.0")
 		{
-			version = version ?? "0.15.1";
+			version = version ?? "0.16.0";
 			var path = EnsureDownloaded(version);
 			try
 			{

--- a/NBitcoin/Network.cs
+++ b/NBitcoin/Network.cs
@@ -882,7 +882,7 @@ namespace NBitcoin
 			genesis = CreateGenesisBlock(1296688602, 2, 0x207fffff, 1, Money.Coins(50m));
 			consensus.HashGenesisBlock = genesis.GetHash();
 			nDefaultPort = 18444;
-			nRPCPort = 18332;
+			nRPCPort = 18443; // From Bitcoin Core 0.16: https://github.com/bitcoin/bitcoin/pull/10825
 			//strDataDir = "regtest";
 			assert(consensus.HashGenesisBlock == uint256.Parse("0x0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"));
 


### PR DESCRIPTION
…with testnet 18332.

Bitcoin Core changed the default RegTest port: https://github.com/bitcoin/bitcoin/pull/10825

I'm making this PR according to issue: https://github.com/MetacoSA/NBitcoin/issues/348#issuecomment-368732294