### PR TITLE
TX Inputs to be RBF-enabled by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,6 @@ project.lock.json
 *.zip
 /dotnet-tpl35/
 /dotnet-tpl35
+
+# folders in macOS
+.DS_Store

--- a/NBitcoin.Tests/transaction_tests.cs
+++ b/NBitcoin.Tests/transaction_tests.cs
@@ -2890,9 +2890,9 @@ namespace NBitcoin.Tests
 		[Trait("UnitTest", "UnitTest")]
 		public void SequenceStructParsedCorrectly()
 		{
-			Assert.True(new Sequence() == 0xFFFFFFFFU);
-			Assert.False(new Sequence().IsRelativeLock);
-			Assert.False(new Sequence().IsRBF);
+			Assert.True(new Sequence() == 0x000000000);
+			Assert.True(new Sequence().IsRelativeLock);
+			Assert.True(new Sequence().IsRBF);
 
 			Assert.True(new Sequence(1) == 1U);
 			Assert.True(new Sequence(1).IsRelativeLock);

--- a/NBitcoin/NBitcoin.csproj
+++ b/NBitcoin/NBitcoin.csproj
@@ -12,7 +12,7 @@
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>
 	<PropertyGroup>
-        <Version Condition=" '$(Version)' == '' ">4.0.0.59</Version>
+        <Version Condition=" '$(Version)' == '' ">4.0.0.60</Version>
     </PropertyGroup>
   <PropertyGroup>
     <TargetFrameworks>net461;net452;netstandard1.3;netstandard1.1</TargetFrameworks>

--- a/NBitcoin/Sequence.cs
+++ b/NBitcoin/Sequence.cs
@@ -59,15 +59,19 @@ namespace NBitcoin
 		/// </summary>
 		internal const int SEQUENCE_LOCKTIME_GRANULARITY = 9;
 
-
-		uint _ValueInv;
+		uint? _ValueInv;
 		public uint Value
 		{
 			get
 			{
-				return 0xFFFFFFFF - _ValueInv;
+				if (_ValueInv.HasValue)
+					return 0xFFFFFFFF - _ValueInv.Value;
+
+				// enable RBF by default (see BIP125)
+				return 0x00000000;
 			}
 		}
+
 		public Sequence(uint value)
 		{
 			_ValueInv = 0xFFFFFFFF - value;


### PR DESCRIPTION
When creating an input, there was a need to explicitly
use the Sequence property setter in order to enable RBF
on it.

Bitcoin Core has recently enabled RBF by default even
from the GUI [1], so it should be safe to assume that
this feature is stable enough to be enabled by default
in NBitcoin too.

The implementation to make this possible needs to use
a Nullable type for the backing field because the C#
compiler doesn't allow structs with parameterless ctors
or default values to be assigned to their fields.

[1] https://bitcoin.org/en/release/v0.16.0