### PR TITLE
Add invalidblock rpc hidden method

### DIFF
--- a/NBitcoin.Tests/RPCClientTests.cs
+++ b/NBitcoin.Tests/RPCClientTests.cs
@@ -740,6 +740,7 @@ namespace NBitcoin.Tests
 				Assert.Equal(tip, bestBlockHash);
 
 				rpc.InvalidateBlock(bestBlockHash);
+				tip = rpc.GetBestBlockHash();
 				Assert.NotEqual(tip, bestBlockHash);
 
 				bestBlockHash = generatedBlockHashes.First();

--- a/NBitcoin.Tests/RPCClientTests.cs
+++ b/NBitcoin.Tests/RPCClientTests.cs
@@ -725,6 +725,29 @@ namespace NBitcoin.Tests
 				AssertJsonEquals(tx.ToString(RawFormat.Satoshi), tx2.ToString(RawFormat.Satoshi));
 			}
 		}
+
+		[Fact]
+		public void InvalidateBlockToRPC()
+		{
+			using(var builder = NodeBuilder.Create())
+			{
+				var rpc = builder.CreateNode().CreateRPCClient();
+				builder.StartAll();
+				var generatedBlockHashes = rpc.Generate(2);
+				var tip = rpc.GetBestBlockHash();
+
+				var bestBlockHash = generatedBlockHashes.Last();
+				Assert.Equal(tip, bestBlockHash);
+
+				rpc.InvalidateBlock(bestBlockHash);
+				Assert.NotEqual(tip, bestBlockHash);
+
+				bestBlockHash = generatedBlockHashes.First();
+				Assert.Equal(tip, bestBlockHash);
+			}
+		}
+
+
 		[Fact]
 		public void CanUseBatchedRequests()
 		{

--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -1416,7 +1416,7 @@ namespace NBitcoin.RPC
 		/// <param name="blockhash">the hash of the block to mark as invalid</param>
 		public void InvalidateBlock(uint256 blockhash)
 		{
-			SendCommand(RPCOperations.invalidateblock, blockhash.ToString()).ConfigureAwait(false);
+			SendCommand(RPCOperations.invalidateblock, blockhash.ToString());
 		}
 
 		/// <summary>

--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -76,16 +76,16 @@ namespace NBitcoin.RPC
 		rawtransactions	fundrawtransaction
 
 		------------------ Utility functions
-		util			   createmultisig
-		util			   validateaddress
-		util			   verifymessage
-		util			   estimatefee				  Yes
-		util			   estimatesmartfee			  Yes
+		util			createmultisig
+		util			validateaddress
+		util			verifymessage
+		util			estimatefee				  Yes
+		util			estimatesmartfee			  Yes
 		------------------ Not shown in help
-		hidden			 invalidateblock
-		hidden			 reconsiderblock
-		hidden			 setmocktime
-		hidden			 resendwallettransactions
+		hidden			invalidateblock				Yes
+		hidden			reconsiderblock
+		hidden			setmocktime
+		hidden			resendwallettransactions
 
 		------------------ Wallet
 		wallet			 addmultisigaddress
@@ -1407,6 +1407,28 @@ namespace NBitcoin.RPC
 		{
 			return GenerateAsync(nBlocks).GetAwaiter().GetResult();
 		}
+
+#region Region Hidden Methods
+
+		/// <summary>
+		/// Permanently marks a block as invalid, as if it violated a consensus rule.
+		/// </summary>
+		/// <param name="blockhash">the hash of the block to mark as invalid</param>
+		public void InvalidateBlock(uint256 blockhash)
+		{
+			SendCommand(RPCOperations.invalidateblock, blockhash.ToString()).ConfigureAwait(false);
+		}
+
+		/// <summary>
+		/// Permanently marks a block as invalid, as if it violated a consensus rule.
+		/// </summary>
+		/// <param name="blockhash">the hash of the block to mark as invalid</param>
+		public async Task InvalidateBlockAsync(uint256 blockhash)
+		{
+			await SendCommandAsync(RPCOperations.invalidateblock, blockhash.ToString()).ConfigureAwait(false);
+		}
+
+#endregion
 	}
 
 #if !NOSOCKET

--- a/NBitcoin/RPC/RPCOperations.cs
+++ b/NBitcoin/RPC/RPCOperations.cs
@@ -96,6 +96,7 @@ namespace NBitcoin.RPC
 		gettxoutsetinfo,
 		gettxout,
 		verifychain,
-		getchaintips
+		getchaintips,
+		invalidateblock
 	}
 }


### PR DESCRIPTION
This `invalidateblock`  RPC method is useful for testing some reorgs scenarios.