### PR TITLE
Add rpc methods

### DIFF
--- a/NBitcoin.Tests/NodeBuilder.cs
+++ b/NBitcoin.Tests/NodeBuilder.cs
@@ -106,7 +106,9 @@ namespace NBitcoin.Tests
 				bitcoind = Path.Combine(dataDir,$"bitcoin-{version}", "bin", "bitcoind.exe");
 				if (File.Exists(bitcoind))
 					return bitcoind;
-				zip = Path.Combine(dataDir, $"bitcoin-{version}-win32.zip");
+				var environment = RuntimeInformation.ProcessArchitecture == Architecture.X64 ? "win64" : "win32";
+
+				zip = Path.Combine(dataDir, $"bitcoin-{version}-{environment}.zip");
 				string url = string.Format("https://bitcoin.org/bin/bitcoin-core-{0}/" + Path.GetFileName(zip), version);
 				HttpClient client = new HttpClient();
 				client.Timeout = TimeSpan.FromMinutes(10.0);

--- a/NBitcoin.Tests/RPCClientTests.cs
+++ b/NBitcoin.Tests/RPCClientTests.cs
@@ -146,6 +146,26 @@ namespace NBitcoin.Tests
 			}
 		}
 
+
+		[Fact]
+		public async Task CanGetBlockchainInfo()
+		{
+			using(var builder = NodeBuilder.Create())
+			{
+				var rpc = builder.CreateNode().CreateRPCClient();
+				builder.StartAll();
+				var response = await rpc.GetBlockchainInfoAsync();
+
+				Assert.Equal(Network.RegTest, response.Chain);
+				Assert.Equal(Network.RegTest.GetGenesis().GetHash(), response.BestBlockHash);
+				Assert.True(response.Bip9SoftForks.Any(x=>x.Name == "segwit"));
+				Assert.True(response.Bip9SoftForks.Any(x=>x.Name == "csv"));
+				Assert.True(response.SoftForks.Any(x=>x.Bip == "bip34"));
+				Assert.True(response.SoftForks.Any(x=>x.Bip == "bip65"));
+				Assert.True(response.SoftForks.Any(x=>x.Bip == "bip66"));
+			}
+		}
+
 		[Fact]
 		public void CanGetBlockFromRPC()
 		{

--- a/NBitcoin.Tests/RPCClientTests.cs
+++ b/NBitcoin.Tests/RPCClientTests.cs
@@ -146,6 +146,29 @@ namespace NBitcoin.Tests
 			}
 		}
 
+		[Fact]
+		public void CanRBFTransaction()
+		{
+			using(var builder = NodeBuilder.Create())
+			{
+				var node = builder.CreateNode();
+				var rpc = node.CreateRPCClient();
+				builder.StartAll();
+				node.CreateRPCClient().Generate(101);
+
+				var key = new Key();
+				var address = key.PubKey.GetAddress(rpc.Network);
+
+				var txid = rpc.SendToAddress(address, Money.Coins(2), null, null, false, true);
+				var txbumpid = rpc.BumpFee(txid);
+				var blocks = rpc.Generate(1); 
+
+				var block = rpc.GetBlock(blocks.First());
+				Assert.False( block.Transactions.Any(x=>x.GetHash() == txid) );
+				Assert.True( block.Transactions.Any(x=>x.GetHash() == txbumpid.TransactionId) );
+			}
+		}
+
 
 		[Fact]
 		public async Task CanGetBlockchainInfo()
@@ -234,6 +257,7 @@ namespace NBitcoin.Tests
 				Assert.False(getTxOutResponse.IsCoinBase);
 			}
 		}
+
 
 		[Fact]
 		public void EstimateSmartFee()

--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -1421,16 +1421,25 @@ namespace NBitcoin.RPC
 		/// <param name="amount">The amount to spend</param>
 		/// <param name="commentTx">A locally-stored (not broadcast) comment assigned to this transaction. Default is no comment</param>
 		/// <param name="commentDest">A locally-stored (not broadcast) comment assigned to this transaction. Meant to be used for describing who the payment was sent to. Default is no comment</param>
+		/// <param name="subtractFeeFromAmount">The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. </param>
+		/// <param name="replaceable">Allow this transaction to be replaced by a transaction with higher fees. </param>
 		/// <returns>The TXID of the sent transaction</returns>
-		public async Task<uint256> SendToAddressAsync(BitcoinAddress address, Money amount, string commentTx = null, string commentDest = null)
+		public async Task<uint256> SendToAddressAsync(
+			BitcoinAddress address, 
+			Money amount, 
+			string commentTx = null, 
+			string commentDest = null, 
+			bool subtractFeeFromAmount = false,
+			bool replaceable = false
+			)
 		{
 			List<object> parameters = new List<object>();
 			parameters.Add(address.ToString());
 			parameters.Add(amount.ToString());
-			if(commentTx != null)
-				parameters.Add(commentTx);
-			if(commentDest != null)
-				parameters.Add(commentDest);
+			parameters.Add($"{commentTx}");
+			parameters.Add($"{commentDest}");
+			parameters.Add(subtractFeeFromAmount);
+			parameters.Add(replaceable);
 			var resp = await SendCommandAsync(RPCOperations.sendtoaddress, parameters.ToArray()).ConfigureAwait(false);
 			return uint256.Parse(resp.Result.ToString());
 		}

--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -1633,6 +1633,8 @@ namespace NBitcoin.RPC
 			get; internal set;
 		}
 	}
+	
+#endif
 
 	public class BlockchainInfo
 	{
@@ -1669,9 +1671,6 @@ namespace NBitcoin.RPC
 		public List<SoftFork> SoftForks { get; set; } 
 		public List<Bip9SoftFork> Bip9SoftForks { get; set; }
 	}
-
-	
-#endif
 
 	public class BumpResponse
 	{

--- a/NBitcoin/RPC/RPCOperations.cs
+++ b/NBitcoin/RPC/RPCOperations.cs
@@ -97,6 +97,7 @@ namespace NBitcoin.RPC
 		gettxout,
 		verifychain,
 		getchaintips,
-		invalidateblock
+		invalidateblock,
+		bumpfee
 	}
 }


### PR DESCRIPTION
Adds RPC methods:

* getblockchaininfo
* bumpfee

Modifies the RPC methods:

* sendtoaddress

Also, includes two commits for allowing to run the tests on Linux and OSX