### PR TITLE
Add a new public method "SetVersionBytes" to allow change the Network VersionBytes

### DIFF
--- a/NBitcoin/Network.cs
+++ b/NBitcoin/Network.cs
@@ -99,6 +99,11 @@ namespace NBitcoin
 				throw new NotImplementedException("The network " + this + " does not have any prefix for base58 " + Enum.GetName(typeof(Base58Type), type));
 			return prefix?.ToArray();
 		}
+		
+		public void SetVersionBytes(Base58Type type, byte[] bytes)
+		{
+			base58Prefixes[(int)type] = bytes;            
+		}
 
 		internal static string CreateBase58(Base58Type type, byte[] bytes, Network network)
 		{


### PR DESCRIPTION
Add a new public method "SetVersionBytes" to allow change the VersionBytes

Related issue:
https://github.com/MetacoSA/NBitcoin/issues/388

Usge:
```
BCash.EnsureRegistered(); 
BCash.Mainnet.SetVersionBytes(Base58Type.PUBKEY_ADDRESS, new byte[] { 0 });
BCash.Mainnet.SetVersionBytes(Base58Type.SCRIPT_ADDRESS, new byte[] { 5 });
```

Will that work?