### PR TITLE
VerifyMessage method overloads

### DIFF
--- a/NBitcoin.Tests/key_tests.cs
+++ b/NBitcoin.Tests/key_tests.cs
@@ -69,21 +69,28 @@ namespace NBitcoin.Tests
 					Message = "this is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long message",
 					Signature = "HFKBHewleUsotk6fWG0OvWS/E2pP4o5hixdD6ui60in/x4376FBI4DvtJYrljXLNJTG1pBOZG+qRT/7S9WiIBfQ="
 				},
+				new
+				{
+					Address = "bc1q463gmsagg5u8wvqqcqj92yytt0pmevvg39h9jp",
+					PrivateKey = "5JEeah4w29axvf5Yg9v9PKv86zcCN9qVbizJDMHmiSUxBqDFoUT",
+					Message = "this is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long messagethis is a very long message",
+					Signature = "HFKBHewleUsotk6fWG0OvWS/E2pP4o5hixdD6ui60in/x4376FBI4DvtJYrljXLNJTG1pBOZG+qRT/7S9WiIBfQ="
+				},
 			};
-
 
 			foreach(var test in tests)
 			{
+				var address = BitcoinAddress.Create(test.Address, Network.Main);
+				var pkh = (address as IPubkeyHashUsable);
 				if(test.PrivateKey != null)
 				{
 					var secret = Network.Main.CreateBitcoinSecret(test.PrivateKey);
 					var signature = secret.PrivateKey.SignMessage(test.Message);
-					Assert.True(((BitcoinPubKeyAddress)Network.Main.CreateBitcoinAddress(test.Address)).VerifyMessage(test.Message, signature));
+					Assert.True(pkh.VerifyMessage(test.Message, signature));
 					Assert.True(secret.PubKey.VerifyMessage(test.Message, signature));
 				}
-				BitcoinPubKeyAddress address = (BitcoinPubKeyAddress)Network.Main.CreateBitcoinAddress(test.Address);
-				Assert.True(address.VerifyMessage(test.Message, test.Signature));
-				Assert.True(!address.VerifyMessage("bad message", test.Signature));
+				Assert.True(pkh.VerifyMessage(test.Message, test.Signature));
+				Assert.True(!pkh.VerifyMessage("bad message", test.Signature));
 			}
 		}
 

--- a/NBitcoin/BitcoinPubKeyAddress.cs
+++ b/NBitcoin/BitcoinPubKeyAddress.cs
@@ -69,6 +69,12 @@ namespace NBitcoin
 			return key.Hash == Hash;
 		}
 
+		public bool VerifyMessage(byte[] message, byte[] signature)
+		{
+			var key = PubKey.RecoverFromMessage(message, signature);
+			return key.Hash == Hash;
+		}
+
 		KeyId _KeyId;
 		public KeyId Hash
 		{

--- a/NBitcoin/BitcoinPubKeyAddress.cs
+++ b/NBitcoin/BitcoinPubKeyAddress.cs
@@ -8,9 +8,19 @@ using System.Threading.Tasks;
 namespace NBitcoin
 {
 	/// <summary>
+	/// Abstracts an object able to verify messages from which it is possible to extract public key.
+	/// </summary>
+	public interface IPubkeyHashUsable
+	{
+		bool VerifyMessage(string message, string signature);
+
+		bool VerifyMessage(byte[] message, byte[] signature);
+	}
+
+	/// <summary>
 	/// Base58 representation of a pubkey hash and base class for the representation of a script hash
 	/// </summary>
-	public class BitcoinPubKeyAddress : BitcoinAddress, IBase58Data
+	public class BitcoinPubKeyAddress : BitcoinAddress, IBase58Data, IPubkeyHashUsable
 	{
 		public BitcoinPubKeyAddress(string base58, Network expectedNetwork = null)
 			: base(Validate(base58, ref expectedNetwork), expectedNetwork)

--- a/NBitcoin/BitcoinSegwitAddress.cs
+++ b/NBitcoin/BitcoinSegwitAddress.cs
@@ -63,6 +63,12 @@ namespace NBitcoin
 			return key.WitHash == Hash;
 		}
 
+		public bool VerifyMessage(byte[] message, byte[] signature)
+		{
+			var key = PubKey.RecoverFromMessage(message, signature);
+			return key.WitHash == Hash;
+		}
+
 		WitKeyId _Hash;
 		public WitKeyId Hash
 		{

--- a/NBitcoin/BitcoinSegwitAddress.cs
+++ b/NBitcoin/BitcoinSegwitAddress.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace NBitcoin
 {
-	public class BitcoinWitPubKeyAddress : BitcoinAddress, IBech32Data
+	public class BitcoinWitPubKeyAddress : BitcoinAddress, IBech32Data, IPubkeyHashUsable
 	{
 		public BitcoinWitPubKeyAddress(string bech32, Network expectedNetwork = null)
 				: base(Validate(bech32, ref expectedNetwork), expectedNetwork)

--- a/NBitcoin/PubKey.cs
+++ b/NBitcoin/PubKey.cs
@@ -224,10 +224,20 @@ namespace NBitcoin
 		/// <returns>True if signatures is valid</returns>
 		public bool VerifyMessage(byte[] messageBytes, string signature)
 		{
-			var sig = DecodeSigString(signature);
-			var messageSigned = Utils.FormatMessageForSigning(messageBytes);
-			var hash = Hashes.Hash256(messageSigned);
-			return ECKey.Verify(hash, sig);
+			return VerifyMessage(messageBytes, DecodeSigString(signature));
+		}
+
+		/// <summary>
+		/// Verify message signed using signmessage from bitcoincore
+		/// </summary>
+		/// <param name="message">The message</param>
+		/// <param name="signature">The signature</param>
+		/// <returns>True if signatures is valid</returns>
+		public bool VerifyMessage(byte[] message, ECDSASignature signature)
+		{
+			var messageToSign = Utils.FormatMessageForSigning(message);
+			var hash = Hashes.Hash256(messageToSign);
+			return ECKey.Verify(hash, signature);
 		}
 
 		/// <summary>

--- a/NBitcoin/PubKey.cs
+++ b/NBitcoin/PubKey.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin.Crypto;
+using NBitcoin.Crypto;
 using NBitcoin.DataEncoders;
 using NBitcoin.Stealth;
 using NBitcoin.BouncyCastle.Math;
@@ -273,6 +273,12 @@ namespace NBitcoin
 			return RecoverCompact(hash, signatureEncoded);
 		}
 
+		public static PubKey RecoverFromMessage(byte[] messageBytes, byte[] signatureEncoded)
+		{
+			var message = Utils.FormatMessageForSigning(messageBytes);
+			var hash = Hashes.Hash256(message);
+			return RecoverCompact(hash, signatureEncoded);
+		}
 
 		public static PubKey RecoverCompact(uint256 hash, byte[] signatureEncoded)
 		{


### PR DESCRIPTION
Provides method overloads for verifying raw (`byte[]`) messages with raw signatures in both, `BitcoinPubkeyAddress` and `BitcoinWitPubkeyAddress` as follow:

Currently (before this PR) we have one method:
```c#
public bool VerifyMessage(string message, string signature)
```

Proposed (after this PR) we have an overload:
```c#
public bool VerifyMessage(byte[] message, byte[] signature)
```

The PR also introduces a new interface to abstract both type of addresses given that they both have `VerifyMessage` method. @NicolasDorier please take a look at this and let me know your feedback.

Finally, the already-existing `CanVerifySignature` unit test was extended in order to include also a test for verifying signatures from bech32 addresses. 
