### PR TITLE
AltCoin testframework update download hash comparison to do case insensitive comparison

### DIFF
--- a/NBitcoin.TestFramework/NodeBuilder.cs
+++ b/NBitcoin.TestFramework/NodeBuilder.cs
@@ -1,5 +1,4 @@
-﻿using NBitcoin;
-using NBitcoin.Crypto;
+﻿using NBitcoin.Crypto;
 using NBitcoin.DataEncoders;
 using NBitcoin.Protocol;
 using NBitcoin.RPC;
@@ -148,7 +147,7 @@ namespace NBitcoin.Tests
 		private static void CheckHash(NodeOSDownloadData osDownloadData, byte[] data)
 		{
 			var actual = Encoders.Hex.EncodeData(Hashes.SHA256(data));
-			if(actual != osDownloadData.Hash)
+			if(!actual.Equals(osDownloadData.Hash, StringComparison.OrdinalIgnoreCase))
 				throw new Exception($"Hash of downloaded file does not match (Expected: {osDownloadData.Hash}, Actual: {actual})");
 		}
 


### PR DESCRIPTION
Depending upon what tool you use to compute the file hash, some of them return hex in uppercase. Powershell Get-FileHash for example. Just makes this a little more robust.