### PR TITLE
New GetRawTransactionInfo method

### DIFF
--- a/NBitcoin.Tests/RPCClientTests.cs
+++ b/NBitcoin.Tests/RPCClientTests.cs
@@ -189,6 +189,34 @@ namespace NBitcoin.Tests
 		}
 
 		[Fact]
+		public void CanGetTransactionInfo()
+		{
+			using(var builder = NodeBuilderEx.Create())
+			{
+				var node = builder.CreateNode();
+				var rpc = node.CreateRPCClient();
+				builder.StartAll();
+
+				var blocks = node.Generate(5);
+				var secondBlockHash = blocks.First();
+				var secondBlock = rpc.GetBlock(secondBlockHash);
+				var firstTx =secondBlock.Transactions.First();
+				
+				var txInfo = rpc.GetRawTransactionInfo(firstTx.GetHash());
+
+				Assert.Equal(5U, txInfo.Confirmations);
+				Assert.Equal(secondBlockHash, txInfo.BlockHash);
+				Assert.Equal(firstTx.GetHash(), txInfo.TransactionId);
+				Assert.Equal(secondBlock.Header.BlockTime, txInfo.BlockTime);
+				Assert.Equal(firstTx.Version, txInfo.Version);
+				Assert.Equal(firstTx.LockTime, txInfo.LockTime);
+				Assert.Equal(firstTx.GetWitHash(), txInfo.Hash);
+				Assert.Equal((uint)firstTx.GetSerializedSize(), txInfo.Size);
+				Assert.Equal((uint)firstTx.GetVirtualSize(), txInfo.VirtualSize);
+			}
+		}
+
+		[Fact]
 		public void CanGetBlockFromRPC()
 		{
 			using(var builder = NodeBuilderEx.Create())

--- a/NBitcoin.Tests/RPCClientTests.cs
+++ b/NBitcoin.Tests/RPCClientTests.cs
@@ -197,14 +197,14 @@ namespace NBitcoin.Tests
 				var rpc = node.CreateRPCClient();
 				builder.StartAll();
 
-				var blocks = node.Generate(5);
+				var blocks = node.Generate(101);
 				var secondBlockHash = blocks.First();
 				var secondBlock = rpc.GetBlock(secondBlockHash);
 				var firstTx =secondBlock.Transactions.First();
 				
 				var txInfo = rpc.GetRawTransactionInfo(firstTx.GetHash());
 
-				Assert.Equal(5U, txInfo.Confirmations);
+				Assert.Equal(101U, txInfo.Confirmations);
 				Assert.Equal(secondBlockHash, txInfo.BlockHash);
 				Assert.Equal(firstTx.GetHash(), txInfo.TransactionId);
 				Assert.Equal(secondBlock.Header.BlockTime, txInfo.BlockTime);
@@ -213,6 +213,14 @@ namespace NBitcoin.Tests
 				Assert.Equal(firstTx.GetWitHash(), txInfo.Hash);
 				Assert.Equal((uint)firstTx.GetSerializedSize(), txInfo.Size);
 				Assert.Equal((uint)firstTx.GetVirtualSize(), txInfo.VirtualSize);
+
+				// unconfirmed tx doesn't have blockhash, blocktime nor transactiontime.
+				var mempoolTxId = rpc.SendToAddress(new Key().PubKey.GetAddress(builder.Network), Money.Coins(1));
+				txInfo = rpc.GetRawTransactionInfo(mempoolTxId);
+				Assert.Null(txInfo.TransactionTime);
+				Assert.Null(txInfo.BlockHash);
+				Assert.Null(txInfo.BlockTime);
+				Assert.Equal(0U, txInfo.Confirmations);
 			}
 		}
 

--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -1167,6 +1167,31 @@ namespace NBitcoin.RPC
 			return tx;
 		}
 
+		public TransactionInfo GetRawTransactionInfo(uint256 txid)
+		{
+			return GetRawTransactionInfoAsync(txid).GetAwaiter().GetResult();
+		}
+
+		public async Task<TransactionInfo> GetRawTransactionInfoAsync(uint256 txId)
+		{
+			var request = new RPCRequest(RPCOperations.getrawtransaction, new object[]{ txId.ToString(), true });
+			var response = await SendCommandAsync(request);
+			var json = response.Result;
+			return new TransactionInfo{
+				Transaction = Transaction.Parse(json.Value<string>("hex")),
+				TransactionId = uint256.Parse(json.Value<string>("txid")),
+				TransactionTime = NBitcoin.Utils.UnixTimeToDateTime(json.Value<long>("time")),
+				Hash = uint256.Parse(json.Value<string>("hash")),
+				Size = json.Value<uint>("size"),
+				VirtualSize = json.Value<uint>("vsize"),
+				Version = json.Value<uint>("version"),
+				LockTime = new LockTime(json.Value<uint>("locktime")),
+				BlockHash = uint256.Parse(json.Value<string>("blockhash")),
+				Confirmations = json.Value<uint>("confirmations"),
+				BlockTime = NBitcoin.Utils.UnixTimeToDateTime(json.Value<long>("blocktime"))
+			};
+		}
+
 		public void SendRawTransaction(Transaction tx)
 		{
 			SendRawTransaction(tx.ToBytes());
@@ -1562,6 +1587,21 @@ namespace NBitcoin.RPC
 		public List<Bip9SoftFork> Bip9SoftForks { get; set; }
 	}
 
+	public class TransactionInfo
+	{
+		public Transaction Transaction {get; internal set;}
+		public uint256 TransactionId {get; internal set;}
+		public uint256 Hash {get; internal set;}
+		public uint Size {get; internal set;}
+		public uint VirtualSize {get; internal set;}
+		public uint Version {get; internal set;}
+		public LockTime LockTime {get; internal set;}
+		public uint256 BlockHash {get; internal set;}
+		public uint Confirmations {get; internal set;}
+		public DateTimeOffset TransactionTime {get; internal set;}
+		public DateTimeOffset BlockTime {get; internal set;}
+	}
+	
 	public class BumpResponse
 	{
 		public uint256 TransactionId { get; set; }

--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -1167,28 +1167,28 @@ namespace NBitcoin.RPC
 			return tx;
 		}
 
-		public TransactionInfo GetRawTransactionInfo(uint256 txid)
+		public RawTransactionInfo GetRawTransactionInfo(uint256 txid)
 		{
 			return GetRawTransactionInfoAsync(txid).GetAwaiter().GetResult();
 		}
 
-		public async Task<TransactionInfo> GetRawTransactionInfoAsync(uint256 txId)
+		public async Task<RawTransactionInfo> GetRawTransactionInfoAsync(uint256 txId)
 		{
 			var request = new RPCRequest(RPCOperations.getrawtransaction, new object[]{ txId.ToString(), true });
 			var response = await SendCommandAsync(request);
 			var json = response.Result;
-			return new TransactionInfo{
+			return new RawTransactionInfo{
 				Transaction = Transaction.Parse(json.Value<string>("hex")),
 				TransactionId = uint256.Parse(json.Value<string>("txid")),
-				TransactionTime = NBitcoin.Utils.UnixTimeToDateTime(json.Value<long>("time")),
+				TransactionTime = json["time"] != null ? NBitcoin.Utils.UnixTimeToDateTime(json.Value<long>("time")): (DateTimeOffset?)null,
 				Hash = uint256.Parse(json.Value<string>("hash")),
 				Size = json.Value<uint>("size"),
 				VirtualSize = json.Value<uint>("vsize"),
 				Version = json.Value<uint>("version"),
 				LockTime = new LockTime(json.Value<uint>("locktime")),
-				BlockHash = uint256.Parse(json.Value<string>("blockhash")),
+				BlockHash = json["blockhash"] != null ? uint256.Parse(json.Value<string>("blockhash")): null,
 				Confirmations = json.Value<uint>("confirmations"),
-				BlockTime = NBitcoin.Utils.UnixTimeToDateTime(json.Value<long>("blocktime"))
+				BlockTime = json["blocktime"] != null ? NBitcoin.Utils.UnixTimeToDateTime(json.Value<long>("blocktime")) : (DateTimeOffset?)null
 			};
 		}
 
@@ -1587,7 +1587,7 @@ namespace NBitcoin.RPC
 		public List<Bip9SoftFork> Bip9SoftForks { get; set; }
 	}
 
-	public class TransactionInfo
+	public class RawTransactionInfo
 	{
 		public Transaction Transaction {get; internal set;}
 		public uint256 TransactionId {get; internal set;}
@@ -1598,8 +1598,8 @@ namespace NBitcoin.RPC
 		public LockTime LockTime {get; internal set;}
 		public uint256 BlockHash {get; internal set;}
 		public uint Confirmations {get; internal set;}
-		public DateTimeOffset TransactionTime {get; internal set;}
-		public DateTimeOffset BlockTime {get; internal set;}
+		public DateTimeOffset? TransactionTime {get; internal set;}
+		public DateTimeOffset? BlockTime {get; internal set;}
 	}
 	
 	public class BumpResponse


### PR DESCRIPTION
This PR adds a new `GetRawTransactionInfo` method to the `RpcClient`
class because the exisiting `GetRawTransaction` method returns simply a
`Transaction` instance and sometimes developers also need useful
informations such as `BlochHash` and/or `Confirmations` for checking
whether the tx is in the blockchain or not; in which block it is and how
mature it is.

Note this new method returns redundant information that can
be extracted directly from the also-returned transaction. IMO this is
not something wrong (I can remove it too)

Having two methods with similar names and porpouse doesn't sound a good
idea IMO, maybe we could mark `GetRawTransaction(Async)` as `Obsolete`
and remove them in some version in the future.