### PR TITLE
Adds new AbandomTransaction RPC call

### DIFF
--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -1425,6 +1425,26 @@ namespace NBitcoin.RPC
 			await SendCommandAsync(RPCOperations.invalidateblock, blockhash.ToString()).ConfigureAwait(false);
 		}
 
+		/// <summary>
+		/// Marks a transaction and all its in-wallet descendants as abandoned which will allow
+		/// for their inputs to be respent.
+		/// </summary>
+		/// <param name="txId">the transaction id to be marked as abandoned.</param>
+		public void AbandonTransaction(uint256 txId)
+		{
+			SendCommand(RPCOperations.abandontransaction, txId.ToString());
+		}
+
+		/// <summary>
+		/// Marks a transaction and all its in-wallet descendants as abandoned which will allow
+		/// for their inputs to be respent.
+		/// </summary>
+		/// <param name="txId">the transaction id to be marked as abandoned.</param>
+		public async Task AbandonTransactionAsync(uint256 txId)
+		{
+			await SendCommandAsync(RPCOperations.abandontransaction, txId.ToString()).ConfigureAwait(false);
+		}
+
 #endregion
 	}
 

--- a/NBitcoin/RPC/RPCOperations.cs
+++ b/NBitcoin/RPC/RPCOperations.cs
@@ -98,6 +98,7 @@ namespace NBitcoin.RPC
 		verifychain,
 		getchaintips,
 		invalidateblock,
-		bumpfee
+		bumpfee,
+		abandontransaction
 	}
 }


### PR DESCRIPTION
This method is very useful in some scenarios. I've tested manually many many times and works okay. I don't include a unit test for it because it use to fail with _"Transaction not eligible for abandonment"_.

The following test half of the times: 

```c#
[Fact]
public void CanAbandonTransactions()
{
	using(var builder = NodeBuilderEx.Create())
	{
		var rpc = builder.CreateNode().CreateRPCClient();
		builder.StartAll();
		var generatedBlockHashes = rpc.Generate(102);

		var originalBalance = rpc.GetBalance();
		var txId = rpc.SendToAddress(new Key().PubKey.GetAddress(builder.Network), Money.Coins(1));
		var tx = rpc.GetRawTransaction(txId);
		var fee = builder.Network.GetReward(1) - tx.Outputs.AsCoins().Sum(c=>c.Amount);
		var currentBalance = rpc.GetBalance();
		Assert.Equal(currentBalance + Money.Coins(1) + fee, originalBalance);
		rpc.AbandonTransaction(txId);
		currentBalance = rpc.GetBalance();
		Assert.Equal(currentBalance, originalBalance);
	}
}
```
