### PR TITLE
Golomb rice filter performance improvement

### DIFF
--- a/NBitcoin.Tests/Bip158_tests.cs
+++ b/NBitcoin.Tests/Bip158_tests.cs
@@ -128,6 +128,7 @@ namespace NBitcoin.Tests
 			// Generation of data to be added into the filter
 			var random = new Random();
 			var sw = new Stopwatch();
+			sw.Start();
 				
 			var blocks = new List<BlockFilter>(blockCount);
 			for (var i = 0; i < blockCount; i++)
@@ -146,14 +147,14 @@ namespace NBitcoin.Tests
 
 				builder.AddEntries(txouts);
 
-				sw.Start();
 				var filter = builder.Build();
-				sw.Stop();
 
 				blocks.Add(new BlockFilter(filter, txouts));
 			}
-			sw.Reset();
+			sw.Stop();
+			Console.WriteLine($"Filters generation time: {sw.Elapsed}");
 
+			sw.Reset();
 
 			var walletAddresses = new List<byte[]>(walletAddressCount);
 			var falsePositiveCount = 0;
@@ -171,11 +172,13 @@ namespace NBitcoin.Tests
 				if (block.Filter.MatchAny(walletAddresses, testKey))
 					falsePositiveCount++;
 			}
-
 			sw.Stop();
+			Console.WriteLine($"Filters matching time: {sw.Elapsed}");
+
 			Assert.True(falsePositiveCount < 5);
 
 			// Filter has to mat existing values
+			sw.Reset();
 			sw.Start();
 			var falseNegativeCount = 0;
 			// Check that the filter can match every single txout in every block.
@@ -186,6 +189,7 @@ namespace NBitcoin.Tests
 			}
 
 			sw.Stop();
+			Console.WriteLine($"Filters matching false time: {sw.Elapsed}");
 
 			Assert.Equal(0, falseNegativeCount);
 		}

--- a/NBitcoin.Tests/Bip158_tests.cs
+++ b/NBitcoin.Tests/Bip158_tests.cs
@@ -127,8 +127,6 @@ namespace NBitcoin.Tests
 
 			// Generation of data to be added into the filter
 			var random = new Random();
-			var sw = new Stopwatch();
-			sw.Start();
 				
 			var blocks = new List<BlockFilter>(blockCount);
 			for (var i = 0; i < blockCount; i++)
@@ -151,10 +149,6 @@ namespace NBitcoin.Tests
 
 				blocks.Add(new BlockFilter(filter, txouts));
 			}
-			sw.Stop();
-			Console.WriteLine($"Filters generation time: {sw.Elapsed}");
-
-			sw.Reset();
 
 			var walletAddresses = new List<byte[]>(walletAddressCount);
 			var falsePositiveCount = 0;
@@ -165,21 +159,16 @@ namespace NBitcoin.Tests
 				walletAddresses.Add(walletAddress);
 			}
 
-			sw.Start();
 			// Check that the filter can match every single txout in every block.
 			foreach (var block in blocks)
 			{
 				if (block.Filter.MatchAny(walletAddresses, testKey))
 					falsePositiveCount++;
 			}
-			sw.Stop();
-			Console.WriteLine($"Filters matching time: {sw.Elapsed}");
 
 			Assert.True(falsePositiveCount < 5);
 
 			// Filter has to mat existing values
-			sw.Reset();
-			sw.Start();
 			var falseNegativeCount = 0;
 			// Check that the filter can match every single txout in every block.
 			foreach (var block in blocks)
@@ -187,9 +176,6 @@ namespace NBitcoin.Tests
 				if (!block.Filter.MatchAny(block.Data, testKey))
 					falseNegativeCount++;
 			}
-
-			sw.Stop();
-			Console.WriteLine($"Filters matching false time: {sw.Elapsed}");
 
 			Assert.Equal(0, falseNegativeCount);
 		}
@@ -311,15 +297,19 @@ namespace NBitcoin.Tests
 
 		[Fact]
 		[Trait("UnitTest", "UnitTest")]
-		public void GensTest()
+		public void WriteAndReadBitStreamTest()
 		{
-			var bs = new BitStream();
-			bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);
-			bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);
-			bs.WriteBit(true);bs.WriteBit(true);bs.WriteBit(true);bs.WriteBit(false);
-			bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);
-			bs.WriteBit(true);
+			var createBitStream = new Func<BitStream>(()=> {
+				var bsx = new BitStream();
+				bsx.WriteBit(false);bsx.WriteBit(true);bsx.WriteBit(false);bsx.WriteBit(true);
+				bsx.WriteBit(true);bsx.WriteBit(false);bsx.WriteBit(true);bsx.WriteBit(false);
+				bsx.WriteBit(true);bsx.WriteBit(true);bsx.WriteBit(true);bsx.WriteBit(false);
+				bsx.WriteBit(false);bsx.WriteBit(true);bsx.WriteBit(false);bsx.WriteBit(true);
+				bsx.WriteBit(true);
+				return bsx;
+			});
 
+			var bs = createBitStream();
 			bs.TryReadBit(out var bit); Assert.False(bit);
 			bs.TryReadBit(out bit); Assert.True(bit);
 			bs.TryReadBit(out bit); Assert.False(bit);
@@ -338,34 +328,18 @@ namespace NBitcoin.Tests
 			bs.TryReadBit(out bit); Assert.True(bit);
 			bs.TryReadBit(out bit); Assert.True(bit);
 
-			bs = new BitStream();
-			bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);
-			bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);
-			bs.WriteBit(true);bs.WriteBit(true);bs.WriteBit(true);bs.WriteBit(false);
-			bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);
-			bs.WriteBit(true);
-
+			bs = createBitStream();
 			bs.TryReadBits(17, out var bits);
 			Assert.Equal(46539U, bits);
 
-			bs = new BitStream();
-			bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);
-			bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);
-			bs.WriteBit(true);bs.WriteBit(true);bs.WriteBit(true);bs.WriteBit(false);
-			bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);
-			bs.WriteBit(true);
+			bs = createBitStream();
 
 			bs.TryReadByte(out var b);
 			Assert.Equal(90, b);
 			bs.TryReadByte(out b);
 			Assert.Equal(229, b);
 
-			bs = new BitStream();
-			bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);
-			bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);
-			bs.WriteBit(true);bs.WriteBit(true);bs.WriteBit(true);bs.WriteBit(false);
-			bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);
-			bs.WriteBit(true);
+			bs = createBitStream();
 
 			bs.TryReadBit(out bit);
 			bs.TryReadByte(out b);
@@ -373,12 +347,7 @@ namespace NBitcoin.Tests
 			bs.TryReadByte(out b);
 			Assert.Equal(203, b);
 
-			bs = new BitStream();
-			bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);
-			bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);
-			bs.WriteBit(true);bs.WriteBit(true);bs.WriteBit(true);bs.WriteBit(false);
-			bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);
-			bs.WriteBit(true);
+			bs = createBitStream();
 
 			bs.TryReadBit(out bit);
 			bs.TryReadBit(out bit);

--- a/NBitcoin.Tests/Bip158_tests.cs
+++ b/NBitcoin.Tests/Bip158_tests.cs
@@ -308,5 +308,84 @@ namespace NBitcoin.Tests
 				}
 			}
 		}
+
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void GensTest()
+		{
+			var bs = new BitStream();
+			bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);
+			bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);
+			bs.WriteBit(true);bs.WriteBit(true);bs.WriteBit(true);bs.WriteBit(false);
+			bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);
+			bs.WriteBit(true);
+
+			bs.TryReadBit(out var bit); Assert.False(bit);
+			bs.TryReadBit(out bit); Assert.True(bit);
+			bs.TryReadBit(out bit); Assert.False(bit);
+			bs.TryReadBit(out bit); Assert.True(bit);
+			bs.TryReadBit(out bit); Assert.True(bit);
+			bs.TryReadBit(out bit); Assert.False(bit);
+			bs.TryReadBit(out bit); Assert.True(bit);
+			bs.TryReadBit(out bit); Assert.False(bit);
+			bs.TryReadBit(out bit); Assert.True(bit);
+			bs.TryReadBit(out bit); Assert.True(bit);
+			bs.TryReadBit(out bit); Assert.True(bit);
+			bs.TryReadBit(out bit); Assert.False(bit);
+			bs.TryReadBit(out bit); Assert.False(bit);
+			bs.TryReadBit(out bit); Assert.True(bit);
+			bs.TryReadBit(out bit); Assert.False(bit);
+			bs.TryReadBit(out bit); Assert.True(bit);
+			bs.TryReadBit(out bit); Assert.True(bit);
+
+			bs = new BitStream();
+			bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);
+			bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);
+			bs.WriteBit(true);bs.WriteBit(true);bs.WriteBit(true);bs.WriteBit(false);
+			bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);
+			bs.WriteBit(true);
+
+			bs.TryReadBits(17, out var bits);
+			Assert.Equal(46539U, bits);
+
+			bs = new BitStream();
+			bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);
+			bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);
+			bs.WriteBit(true);bs.WriteBit(true);bs.WriteBit(true);bs.WriteBit(false);
+			bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);
+			bs.WriteBit(true);
+
+			bs.TryReadByte(out var b);
+			Assert.Equal(90, b);
+			bs.TryReadByte(out b);
+			Assert.Equal(229, b);
+
+			bs = new BitStream();
+			bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);
+			bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);
+			bs.WriteBit(true);bs.WriteBit(true);bs.WriteBit(true);bs.WriteBit(false);
+			bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);
+			bs.WriteBit(true);
+
+			bs.TryReadBit(out bit);
+			bs.TryReadByte(out b);
+			Assert.Equal(181, b);
+			bs.TryReadByte(out b);
+			Assert.Equal(203, b);
+
+			bs = new BitStream();
+			bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);
+			bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);
+			bs.WriteBit(true);bs.WriteBit(true);bs.WriteBit(true);bs.WriteBit(false);
+			bs.WriteBit(false);bs.WriteBit(true);bs.WriteBit(false);bs.WriteBit(true);
+			bs.WriteBit(true);
+
+			bs.TryReadBit(out bit);
+			bs.TryReadBit(out bit);
+			bs.TryReadBit(out bit);
+
+			bs.TryReadBits(14, out bits);
+			Assert.Equal(13771U, bits);
+		}
 	}
 }

--- a/NBitcoin/BIP158/BitStream.cs
+++ b/NBitcoin/BIP158/BitStream.cs
@@ -155,7 +155,7 @@ namespace NBitcoin
 		{
 			if ( (_writePos / 8) == (_buffer.Length - 1))
 			{
-				Array.Resize(ref _buffer, _buffer.Length + 100);
+				Array.Resize(ref _buffer, _buffer.Length + ( 4 * 1024 ));
 			}
 		}
 	}

--- a/NBitcoin/BIP158/BitStream.cs
+++ b/NBitcoin/BIP158/BitStream.cs
@@ -7,11 +7,11 @@ namespace NBitcoin
 	class BitStream
 	{
 		private byte[] _buffer;
-		private int _remainCount;
-		private int _remainBitsInBuffer;
+		private int _writePos;
+		private int _readPos;
 
 		public BitStream()
-			: this(new byte[10_000])
+			: this(new byte[8 * 1024])
 		{
 		}
 
@@ -20,26 +20,8 @@ namespace NBitcoin
 			var newBuffer = new byte[buffer.Length];
 			Buffer.BlockCopy(buffer, 0, newBuffer, 0, buffer.Length);
 			_buffer = newBuffer;
-			_remainCount = buffer.Length == 0 ? 0 : 8;
-			_remainBitsInBuffer = 8 * buffer.Length;
-		}
-
-		private void AddZeroByte()
-		{
-			Array.Resize(ref _buffer, _buffer.Length + 100);
-			_remainBitsInBuffer += 8 * 100;
-		}
-
-		private void EnsureCapacity()
-		{
-			if (_remainBitsInBuffer < 10)
-			{
-				AddZeroByte();
-			}
-			if(_remainCount == 0)
-			{
-				_remainCount = 8;
-			}
+			_writePos = 0;
+			_readPos = 0;
 		}
 
 		public void WriteBit(bool bit)
@@ -47,11 +29,9 @@ namespace NBitcoin
 			EnsureCapacity();
 			if (bit)
 			{
-				var lastIndex = GetLastIndex();
-				_buffer[lastIndex] |= (byte)(1 << (_remainCount - 1));
+				_buffer[_writePos / 8] |= (byte)(1 << ( 8 - (_writePos % 8) - 1));
 			}
-			_remainCount--;
-			_remainBitsInBuffer--;
+			_writePos++;
 		}
 
         public void WriteBits(ulong data, byte count)
@@ -78,37 +58,32 @@ namespace NBitcoin
 		{
 			EnsureCapacity();
 
-			var lastIndex = GetLastIndex(); 
-			_buffer[lastIndex] |= (byte)(b >> (8 - _remainCount));
+			var remainCount = (_writePos % 8);
+			var i = _writePos / 8;
+			_buffer[i] |= (byte)(b >> remainCount);
 
-			EnsureCapacity();
-			_buffer[lastIndex + 1] = (byte)(b << _remainCount);
-			_remainBitsInBuffer-=8;
+			if(remainCount > 0)
+			{
+				EnsureCapacity();
+				
+				_buffer[i+1] = (byte)(b << (8 - remainCount));
+			}
+			_writePos+=8;
 		}
 
 		public bool TryReadBit(out bool bit)
 		{
 			bit = false;
-			if (_buffer.Length == 0){
+			var i = _readPos / 8;
+			if ( i == _buffer.Length)
+			{
 				return false;
 			}
 
-			if(_remainCount == 0)
-			{
-				if (_buffer.Length == 1)
-					return false;
-				
-				var newBuffer = new byte[_buffer.Length - 1];
-				Buffer.BlockCopy(_buffer, 1, newBuffer, 0, _buffer.Length - 1);
-				_buffer = newBuffer;
-				_remainCount = 8;
-			}
+			var mask = 1 << (8 - (_readPos % 8) - 1); 
 
-			var curbit = _buffer[0] & 0x80;
-			_buffer[0] <<= 1;
-			_remainCount--;
-
-			bit = curbit != 0;
+			bit = (_buffer[i] & mask) == mask;
+			_readPos++;
 			return true;
 		}
 
@@ -146,52 +121,42 @@ namespace NBitcoin
 		public bool TryReadByte(out byte b)
 		{
 			b = 0;
-			if (_buffer.Length == 0)
-				return false;
-
-			if (_remainCount == 0)
+			var i = _readPos / 8;
+			if ( i == _buffer.Length)
 			{
-				if (_buffer.Length == 1)
+				return false;
+			}
+
+			var remainCount = _readPos % 8;
+			b = (byte)(_buffer[i] << remainCount);
+
+			if(remainCount > 0)
+			{
+				if(i+1 == _buffer.Length)
 				{
+					b = 0;
 					return false;
 				}
-				var newBuffer = new byte[_buffer.Length - 1];
-				Buffer.BlockCopy(_buffer, 1, newBuffer, 0, _buffer.Length - 1);
-				_buffer = newBuffer;
-				_remainCount = 8;
+				b |= (byte)(_buffer[i+1] >> (8 - remainCount));
 			}
-
-			b = _buffer[0];
-			var newBuffer1 = new byte[_buffer.Length - 1];
-			Buffer.BlockCopy(_buffer, 1, newBuffer1, 0, _buffer.Length - 1);
-			_buffer = newBuffer1;
-			if (_remainCount == 8)
-			{
-				return true;
-			}
-
-			if (_buffer.Length == 0)
-			{
-				b = 0;
-				return false;
-			}
-
-			b |= (byte)(_buffer[0] >> _remainCount);
-			_buffer[0] <<= (8 - _remainCount);
+			_readPos += 8;
 			return true;
 		}
 
 		public byte[] ToByteArray()
 		{
-			var arraySize = 1 + GetLastIndex();
+			var arraySize = (_writePos + 7) / 8;
 			var byteArray = new byte[arraySize];
 			Array.Copy(_buffer, byteArray, arraySize);
 			return byteArray;
 		}
 
-		private int GetLastIndex()
+		private void EnsureCapacity()
 		{
-			return _buffer.Length - ((_remainBitsInBuffer + 7) / 8);
+			if ( (_writePos / 8) == (_buffer.Length - 1))
+			{
+				Array.Resize(ref _buffer, _buffer.Length + 100);
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR fixes the allocation problem detected by @NicolasDorier which was hurting the performance. Just to have an idea about the improvement, these are the numbers.

**Before**
```
Filters generation time: 00:00:24.0559429
Filters matching time: 00:00:25.8740358
Filters matching false time: 00:00:01.5151029
```

**After**
```
Filters generation time: 00:00:02.9757793
Filters matching time: 00:00:00.4871420
Filters matching false time: 00:00:01.3413390
```