### PR TITLE
ECDSA Blinding signature protocol

### DIFF
--- a/NBitcoin.Tests/DeterministicSignatureTests.cs
+++ b/NBitcoin.Tests/DeterministicSignatureTests.cs
@@ -254,75 +254,75 @@ namespace NBitcoin.Tests
 		public void BlindingSignature()
 		{
 			// Test with known values 
-			var requester = new ECdsaBlinding.Requester();
-			var signingKey = new Key(Encoders.Hex.DecodeData("31E151628AED2A6ABF7155809CF4F3C762E7160F38B4DA56B784D9045190CFA0"));
-			var verificationKey = new Key(Encoders.Hex.DecodeData("B7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF"));
-			var signer = new ECdsaBlinding.Signer(signingKey, verificationKey);
+			var requester = new ECDSABlinding.Requester();
+			var r = new Key(Encoders.Hex.DecodeData("31E151628AED2A6ABF7155809CF4F3C762E7160F38B4DA56B784D9045190CFA0"));
+			var key = new Key(Encoders.Hex.DecodeData("B7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF"));
+			var signer = new ECDSABlinding.Signer(key, r);
 
 			var message = new uint256(Encoders.Hex.DecodeData("243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89"), false);
-			var blindedMessage = requester.BlindMessage(message, signer.SignerKey.PubKey, signer.VerificationKey.PubKey);
+			var blindedMessage = requester.BlindMessage(message, r.PubKey, key.PubKey);
 
 			var blindSignature = signer.Sign(blindedMessage);
 			var unblindedSignature = requester.UnblindSignature(blindSignature);
 
-			Assert.True( ECdsaBlinding.VerifySignature(message, unblindedSignature, verificationKey.PubKey) );
-			Assert.False(ECdsaBlinding.VerifySignature(uint256.One, unblindedSignature, verificationKey.PubKey) );
-			Assert.False(ECdsaBlinding.VerifySignature(uint256.One, unblindedSignature, verificationKey.PubKey) );
-			Assert.False(ECdsaBlinding.VerifySignature(
+			Assert.True( ECDSABlinding.VerifySignature(message, unblindedSignature, key.PubKey) );
+			Assert.False(ECDSABlinding.VerifySignature(uint256.One, unblindedSignature, key.PubKey) );
+			Assert.False(ECDSABlinding.VerifySignature(uint256.One, unblindedSignature, key.PubKey) );
+			Assert.False(ECDSABlinding.VerifySignature(
 				message, 
 				new BlindSignature(unblindedSignature.C, BigInteger.Zero.Subtract(unblindedSignature.S)), 
-				verificationKey.PubKey) );
-			Assert.False(ECdsaBlinding.VerifySignature(
+				key.PubKey) );
+			Assert.False(ECDSABlinding.VerifySignature(
 				message, 
 				new BlindSignature(BigInteger.Zero.Subtract(unblindedSignature.C), unblindedSignature.S), 
-				verificationKey.PubKey) );
-			Assert.False(ECdsaBlinding.VerifySignature(
+				key.PubKey) );
+			Assert.False(ECDSABlinding.VerifySignature(
 				message, 
 				new BlindSignature(BigInteger.Zero.Subtract(unblindedSignature.C), unblindedSignature.S), 
 				new Key().PubKey) );
 
 			// Test with unknown values 
-			requester = new ECdsaBlinding.Requester();
-			signer = new ECdsaBlinding.Signer(new Key(), new Key());
+			requester = new ECDSABlinding.Requester();
+			signer = new ECDSABlinding.Signer(new Key(), new Key());
 
 			message = Hashes.Hash256(Encoders.ASCII.DecodeData("Hello world!"));
-			blindedMessage = requester.BlindMessage(message, signer.SignerKey.PubKey, signer.VerificationKey.PubKey);
+			blindedMessage = requester.BlindMessage(message, signer.R.PubKey, signer.Key.PubKey);
 
 			blindSignature = signer.Sign(blindedMessage);
 			unblindedSignature = requester.UnblindSignature(blindSignature);
 
-			Assert.True( ECdsaBlinding.VerifySignature(message, unblindedSignature, signer.VerificationKey.PubKey) );
-			Assert.False(ECdsaBlinding.VerifySignature(uint256.One, unblindedSignature, signer.VerificationKey.PubKey) );
-			Assert.False(ECdsaBlinding.VerifySignature(uint256.One, unblindedSignature, signer.VerificationKey.PubKey) );
-			Assert.False(ECdsaBlinding.VerifySignature(
+			Assert.True( ECDSABlinding.VerifySignature(message, unblindedSignature, signer.Key.PubKey) );
+			Assert.False(ECDSABlinding.VerifySignature(uint256.One, unblindedSignature, signer.Key.PubKey) );
+			Assert.False(ECDSABlinding.VerifySignature(uint256.One, unblindedSignature, signer.Key.PubKey) );
+			Assert.False(ECDSABlinding.VerifySignature(
 				message, 
 				new BlindSignature(BigInteger.Zero, unblindedSignature.S), 
-				verificationKey.PubKey) );
-			Assert.False(ECdsaBlinding.VerifySignature(
+				signer.Key.PubKey) );
+			Assert.False(ECDSABlinding.VerifySignature(
 				message, 
 				new BlindSignature(unblindedSignature.C, BigInteger.Zero), 
-				verificationKey.PubKey) );
-			Assert.False(ECdsaBlinding.VerifySignature(
+				signer.Key.PubKey) );
+			Assert.False(ECDSABlinding.VerifySignature(
 				message, 
 				new BlindSignature(BigInteger.One, unblindedSignature.S), 
-				verificationKey.PubKey) );
-			Assert.False(ECdsaBlinding.VerifySignature(
+				signer.Key.PubKey) );
+			Assert.False(ECDSABlinding.VerifySignature(
 				message, 
 				new BlindSignature(unblindedSignature.C, BigInteger.One), 
-				verificationKey.PubKey) );
-			Assert.False(ECdsaBlinding.VerifySignature(
+				signer.Key.PubKey) );
+			Assert.False(ECDSABlinding.VerifySignature(
 				message, 
 				new BlindSignature(BigInteger.One, BigInteger.One), 
-				verificationKey.PubKey) );
-			Assert.False(ECdsaBlinding.VerifySignature(
+				signer.Key.PubKey) );
+			Assert.False(ECDSABlinding.VerifySignature(
 				message, 
 				new BlindSignature(unblindedSignature.C, BigInteger.Zero.Subtract(unblindedSignature.S)), 
-				verificationKey.PubKey) );
-			Assert.False(ECdsaBlinding.VerifySignature(
+				signer.Key.PubKey) );
+			Assert.False(ECDSABlinding.VerifySignature(
 				message, 
 				new BlindSignature(BigInteger.Zero.Subtract(unblindedSignature.C), unblindedSignature.S), 
-				verificationKey.PubKey) );
-			Assert.False(ECdsaBlinding.VerifySignature(
+				signer.Key.PubKey) );
+			Assert.False(ECDSABlinding.VerifySignature(
 				message, 
 				new BlindSignature(BigInteger.Zero.Subtract(unblindedSignature.C), unblindedSignature.S), 
 				new Key().PubKey) );

--- a/NBitcoin/Crypto/ECDSABlindSignature.cs
+++ b/NBitcoin/Crypto/ECDSABlindSignature.cs
@@ -1,0 +1,103 @@
+
+using NBitcoin.BouncyCastle.Asn1.X9;
+using NBitcoin.BouncyCastle.Crypto.Signers;
+using NBitcoin.BouncyCastle.Math;
+using NBitcoin.BouncyCastle.Security;
+
+namespace NBitcoin.Crypto
+{
+	public class BlindSignature
+	{
+		public BigInteger C { get; }
+		public BigInteger S { get; }
+
+		public BlindSignature(BigInteger c, BigInteger s)
+		{
+			C = c;
+			S = s;
+		}
+	}
+
+    public class ECdsaBlinding
+    {
+        private static X9ECParameters Secp256k1 = ECKey.Secp256k1;
+
+        public class Requester
+        {
+            private BigInteger _v;
+            private BigInteger _w;
+            private BigInteger _c;
+            private IDsaKCalculator _k;
+
+            public Requester()
+            {
+                _k = new RandomDsaKCalculator();
+                _k.Init(BigInteger.Arbitrary(256), new SecureRandom());
+            }
+
+            public uint256 BlindMessage(uint256 message, PubKey signerPubKey, PubKey verificationPubKey)
+            {
+                var P = new ECKey(verificationPubKey.ToBytes(), false).GetPublicKeyParameters().Q;
+                var R = new ECKey(signerPubKey.ToBytes(), false).GetPublicKeyParameters().Q;
+
+                var t = BigInteger.Zero;
+                while(t.SignValue == 0)
+                {
+                    _v = _k.NextK();
+                    _w = _k.NextK();
+
+                    var A1 = Secp256k1.G.Multiply(_v); 
+                    var A2 = P.Multiply(_w); 
+                    var A  = R.Add( A1.Add(A2) ).Normalize();
+                    t = A.AffineXCoord.ToBigInteger().Mod(Secp256k1.N);
+                }
+                _c = new BigInteger(1, Hashes.SHA256(message.ToBytes(false).Concat(Utils.BigIntegerToBytes(t, 32))));
+                var cp= _c.Subtract(_w).Mod(Secp256k1.N); // this is sent to the signer (blinded message)
+                return new uint256(Utils.BigIntegerToBytes(cp, 32)); 
+            }
+
+            public BlindSignature UnblindSignature(BigInteger sp)
+            {
+                var s = sp.Add(_v).Mod(Secp256k1.N);
+                return new BlindSignature(_c, s);
+            }
+        }
+
+        public class Signer
+        {
+            public Key SignerKey { get; }
+            public Key VerificationKey { get; }
+
+            public Signer(Key signerKey)
+                : this(signerKey, new Key())
+            {}
+
+            public Signer(Key signerKey, Key verificationKey)
+            {
+                SignerKey = signerKey;
+                VerificationKey = verificationKey;
+            }
+
+            public BigInteger Sign(uint256 message)
+            {
+                var r = new BigInteger(1, SignerKey.ToBytes());
+                var d = new BigInteger(1, VerificationKey.ToBytes());
+                var cp = new BigInteger(1, message.ToBytes());
+                var sp = r.Subtract(cp.Multiply(d)).Mod(ECKey.Secp256k1.N);
+                return sp;
+            }
+        }
+
+        internal static bool VerifySignature(uint256 message, BlindSignature signature, PubKey verificationPubKey)
+        {
+            var P = new ECKey(verificationPubKey.ToBytes(), false).GetPublicKeyParameters().Q;
+
+            var sG = Secp256k1.G.Multiply(signature.S);
+            var cP = P.Multiply(signature.C);
+            var R  = cP.Add(sG).Normalize();
+            var t = R.AffineXCoord.ToBigInteger().Mod(Secp256k1.N);
+            var c = new BigInteger(1, Hashes.SHA256(message.ToBytes(false).Concat(Utils.BigIntegerToBytes(t, 32))));
+            return c.Equals(signature.C);
+        }
+	}
+}


### PR DESCRIPTION
This PR is for proposing an Blinding Signature Algorithm over using ECC. 

## Goal
Blinding signatures are useful in many project involving cryptocurrencies (Wasabi wallet is one of those) and for that reason I propose to include this classes as part of NBitcoin.

## Protocol
```c#
// Requester represents the participant that requests the signature from the signer
var requester = new ECDSABlinding.Requester();

var signerKey = new Key();  // The key used for signing the message
var r = new Key();          // A value used to derivate a r.Pubkey that has to be sent to the requester 

// Signer represents the one that has to sign the message
var signer = new ECDSABlinding.Signer(signerKey, r);

// 1. Signer sends the r.Pubkey and the signer.Pubkey to the requester 
// 2. requester blinds the message and sends it to the signer
var blindedMessage = requester.BlindMessage(message, r.PubKey, signerKey.PubKey);

// 3. Signer signs the blinded message and returns that blindedSignature to the requester
var blindSignature = signer.Sign(blindedMessage);

// 4. The requester "unblinds" the blinded signature and gets the unblinded signature
var unblindedSignature = requester.UnblindSignature(blindSignature);

// 5. Anyone how konws the message, the and the signer.PubKey can verify the signature
var isValid = ECDSABlinding.VerifySignature(message, unblindedSignature, signerKey.PubKey);
```

## References
The algorithm details are specified on the following resources:
 * [A Blind Mixing Scheme for Bitcoin based on an Elliptic Curve Cryptography
Blind Digital Signature Algorithm](https://arxiv.org/pdf/1510.05833.pdf)
* [Blind ECDSA Signatures](https://en.wikipedia.org/wiki/Blind_signature#Blind_ECDSA_signatures[4])
* [A blind digital signature scheme using elliptic curve digital signature algorithm](https://pdfs.semanticscholar.org/399d/d5695dda5c730d58240e675f8b7823cd2adb.pdf)

