### PR TITLE
Prevent loosing money by parsing small values

### DIFF
--- a/NBitcoin.Tests/util_tests.cs
+++ b/NBitcoin.Tests/util_tests.cs
@@ -352,6 +352,9 @@ namespace NBitcoin.Tests
 
 				// Attempted 63 bit overflow should fail
 				Assert.False(Money.TryParse(prefix + "92233720368.54775808", out ret));
+
+				// Attempted parsing a very small value (loosing money)  should fail
+				Assert.False(Money.TryParse(prefix + "0.00000000000001", out ret));
 			}
 		}
 

--- a/NBitcoin.Tests/util_tests.cs
+++ b/NBitcoin.Tests/util_tests.cs
@@ -355,6 +355,9 @@ namespace NBitcoin.Tests
 
 				// Attempted parsing a very small value (loosing money)  should fail
 				Assert.False(Money.TryParse(prefix + "0.00000000000001", out ret));
+				Assert.False(Money.TryParse(prefix + "0.000000001", out ret));
+				Assert.True(Money.TryParse(prefix + "0.00000000", out ret));
+				Assert.True(Money.TryParse(prefix + "0.00000000000", out ret));
 			}
 		}
 

--- a/NBitcoin/FeeRate.cs
+++ b/NBitcoin/FeeRate.cs
@@ -65,7 +65,7 @@ namespace NBitcoin
 		{
 			if(satoshiPerByte < 0)
 				throw new ArgumentOutOfRangeException("satoshiPerByte");
-			_FeePerK = Money.Satoshis(satoshiPerByte * 1000);
+			_FeePerK = Money.Satoshis((long)(satoshiPerByte * 1000));
 		}
 
 		/// <summary>

--- a/NBitcoin/Money.cs
+++ b/NBitcoin/Money.cs
@@ -295,6 +295,10 @@ namespace NBitcoin
 				nRet = new Money(value, MoneyUnit.BTC);
 				return true;
 			}
+			catch(ArgumentOutOfRangeException)
+			{
+				return false;
+			}
 			catch(OverflowException)
 			{
 				return false;
@@ -372,6 +376,7 @@ namespace NBitcoin
 		{
 			// sanity check. Only valid units are allowed
 			CheckMoneyUnit(unit, "unit");
+			CheckMoneyLimits(amount, unit);
 			checked
 			{
 				var satoshi = amount * (int)unit;
@@ -751,6 +756,18 @@ namespace NBitcoin
 			if(!Enum.IsDefined(typeOfMoneyUnit, value))
 			{
 				throw new ArgumentException("Invalid value for MoneyUnit", paramName);
+			}
+		}
+
+		private static void CheckMoneyLimits(decimal amount, MoneyUnit unit)
+		{
+			checked
+			{
+				var satoshis = amount * (int)unit;
+				if(satoshis % 1 != 0 )
+				{
+					throw new ArgumentOutOfRangeException("Invalid value for amount. Min unit is one satoshi.");
+				}
 			}
 		}
 

--- a/NBitcoin/TransactionBuilder.cs
+++ b/NBitcoin/TransactionBuilder.cs
@@ -1010,7 +1010,7 @@ namespace NBitcoin
 			Money totalSent = Money.Zero;
 			foreach(var group in _BuilderGroups)
 			{
-				var groupFee = Money.Satoshis((group.FeeWeight / totalWeight) * fees.Satoshi);
+				var groupFee = Money.Satoshis((long)((group.FeeWeight / totalWeight) * fees.Satoshi));
 				totalSent += groupFee;
 				if(_BuilderGroups.Last() == group)
 				{


### PR DESCRIPTION
This PR is for fixing the issue https://github.com/zkSNACKs/WalletWasabi/issues/489 when someone parses values that involves fractions of satoshis. For example:

```
Money.Parse("0.00000000000001");  will be 0
Money.Parse("12.66548765432");  will be 12.6654876 loosing the 0.00000005432
```

This is a **breaking change** so, please review this and let us know if it okay for you @NicolasDorier   