### PR TITLE
Add hex string constructor to ExtPubKey

### DIFF
--- a/NBitcoin.Tests/bip32_tests.cs
+++ b/NBitcoin.Tests/bip32_tests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using NBitcoin.DataEncoders;
 using Xunit;
 
 namespace NBitcoin.Tests
@@ -217,6 +218,22 @@ namespace NBitcoin.Tests
 			Assert.True(ExtKey.Parse(key.ToString(Network.Main)).ToString(Network.Main) == key.ToString(Network.Main));
 			Assert.True(ExtPubKey.Parse(pubkey.ToString(Network.Main)).ToString(Network.Main) == pubkey.ToString(Network.Main));
 		}
+
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void CanRecoverExtPubKeyFromHexString()
+		{
+		    var key = new ExtKey();
+		    var pubkeyBytes = key.Neuter().ToBytes();
+		    var pubkeyHexString = Encoders.Hex.EncodeData(pubkeyBytes);
+
+
+		    var pubKeyFromBytes = new ExtPubKey(pubkeyBytes);
+		    var pubKeyFromHexString = new ExtPubKey(pubkeyHexString);
+
+		    Assert.True(pubKeyFromBytes.Equals(pubKeyFromHexString));
+		}
+
 		[Fact]
 		[Trait("UnitTest", "UnitTest")]
 		public void CanCheckChildKey()

--- a/NBitcoin/BIP32/ExtPubKey.cs
+++ b/NBitcoin/BIP32/ExtPubKey.cs
@@ -72,11 +72,22 @@ namespace NBitcoin
 		{
 		}
 
+        	/// <summary>
+		/// Constructor. Creates a new extended public key from the specified extended public key bytes.
+		/// </summary>
 		public ExtPubKey(byte[] bytes)
 		{
 			if(bytes == null)
 				throw new ArgumentNullException(nameof(bytes));
 			this.ReadWrite(bytes);
+		}
+        
+		/// <summary>
+		/// Constructor. Creates a new extended public key from the specified extended public key bytes, from the given hex string.
+		/// </summary>
+		public ExtPubKey(string hex) 
+		    : this(Encoders.Hex.DecodeData(hex))
+		{
 		}
 
 		public ExtPubKey(PubKey pubkey, byte[] chainCode, byte depth, byte[] fingerprint, uint child)


### PR DESCRIPTION
Now you can construct `ExtPubKey` with a hex string in addition to the byte array constructor. This behavior is needed for the symmetry between `ExtPubKey` and `ExtKey`