### PR TITLE
Extend KeyPath using a string

### DIFF
--- a/NBitcoin/BIP32/KeyPath.cs
+++ b/NBitcoin/BIP32/KeyPath.cs
@@ -79,6 +79,11 @@ namespace NBitcoin
 			return Derive(new KeyPath(realIndex));
 		}
 
+		public KeyPath Derive(string path)
+		{
+			return Derive(new KeyPath(path));
+		}
+
 		public KeyPath Derive(uint index)
 		{
 			return Derive(new KeyPath(index));


### PR DESCRIPTION
Given that you can create a new `KeyPath` using a `string` path, it would make sense to extend the KeyPath (`Derive`) using a string path as an input.