### PR TITLE
Add WordList.GetWords overloaded version

### DIFF
--- a/NBitcoin.Tests/bip39_tests.cs
+++ b/NBitcoin.Tests/bip39_tests.cs
@@ -84,6 +84,25 @@ namespace NBitcoin.Tests
 			}
 		}
 
+		[Fact]
+		public void CanReturnTheListOfWords()
+		{
+			var lang = Wordlist.English;
+			var words = lang.GetWords();
+			int i;
+			foreach(var word in words)
+			{
+				Assert.True(lang.WordExists(word, out i));
+				Assert.True(i >=0 );
+			}
+
+			var modifiedWord = words[0];
+			words[0] = "modified";
+			Assert.True(lang.WordExists(modifiedWord, out i));
+			Assert.True(i == 0 );
+			Assert.False(lang.WordExists(words[0], out i));
+			Assert.True(i == -1);
+		}
 
 		[Fact]
 		[Trait("UnitTest", "UnitTest")]

--- a/NBitcoin.Tests/bip39_tests.cs
+++ b/NBitcoin.Tests/bip39_tests.cs
@@ -95,13 +95,6 @@ namespace NBitcoin.Tests
 				Assert.True(lang.WordExists(word, out i));
 				Assert.True(i >=0 );
 			}
-
-			var modifiedWord = words[0];
-			words[0] = "modified";
-			Assert.True(lang.WordExists(modifiedWord, out i));
-			Assert.True(i == 0 );
-			Assert.False(lang.WordExists(words[0], out i));
-			Assert.True(i == -1);
 		}
 
 		[Fact]

--- a/NBitcoin/BIP39/Wordlist.cs
+++ b/NBitcoin/BIP39/Wordlist.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -347,9 +348,9 @@ namespace NBitcoin
 			return _Name;
 		}
 
-		public string[] GetWords()
+		public ReadOnlyCollection<string> GetWords()
 		{
-			return (string[])_words.Clone();
+			return new ReadOnlyCollection<string>(_words);
 		}
 
 		public string[] GetWords(int[] indices)

--- a/NBitcoin/BIP39/Wordlist.cs
+++ b/NBitcoin/BIP39/Wordlist.cs
@@ -347,6 +347,11 @@ namespace NBitcoin
 			return _Name;
 		}
 
+		public string[] GetWords()
+		{
+			return (string[])_words.Clone();
+		}
+
 		public string[] GetWords(int[] indices)
 		{
 			return


### PR DESCRIPTION
This PR adds an `WordList.GetWords()` method overload that returns the full list of words. These words are needed to implement an user friendly way to introduce the seed in wallets through autocompletion. Without a way to retrieve the list of world, wallets have to keep their own list (hardcoded or downloaded from internet into a file) 

This is what I want to do in Wasabi Wallet:
https://github.com/zkSNACKs/WalletWasabi/issues/440#issuecomment-410120805
