### PR TITLE
Make sure ECDSA signatures use LowR values

### DIFF
--- a/NBitcoin.Tests/DeterministicSignatureTests.cs
+++ b/NBitcoin.Tests/DeterministicSignatureTests.cs
@@ -110,7 +110,7 @@ namespace NBitcoin.Tests
 
 		private void TestSig(ECPrivateKeyParameters key, DeterministicSigTest test)
 		{
-			var dsa = new DeterministicECDSA(GetHash(test.Hash));
+			var dsa = new DeterministicECDSA(GetHash(test.Hash), false);
 			dsa.setPrivateKey(key);
 			dsa.update(Encoding.UTF8.GetBytes(test.Message));
 			var result = dsa.sign();

--- a/NBitcoin.Tests/DeterministicSignatureTests.cs
+++ b/NBitcoin.Tests/DeterministicSignatureTests.cs
@@ -327,5 +327,21 @@ namespace NBitcoin.Tests
 				new BlindSignature(BigInteger.Zero.Subtract(unblindedSignature.C), unblindedSignature.S), 
 				new Key().PubKey) );
 		}
+
+		[Fact]
+		public void Signatures_use_low_R()
+		{
+			var rnd = new Random();
+			for(var i=0; i < 100; i++)
+			{
+				var key = new Key();
+				var msgLen = rnd.Next(10, 1000);
+				var msg = new byte[msgLen];
+				rnd.NextBytes(msg);
+
+				var sig = key.Sign(Hashes.Hash256(msg));
+				Assert.True(sig.IsLowR && sig.ToDER().Length <= 70);
+			}
+		}
 	}
 }

--- a/NBitcoin.Tests/key_tests.cs
+++ b/NBitcoin.Tests/key_tests.cs
@@ -217,7 +217,6 @@ namespace NBitcoin.Tests
 			Assert.True(addr2C.Hash == pubkey2C.Hash);
 
 
-
 			for(int n = 0; n < 16; n++)
 			{
 				string strMsg = String.Format("Very secret message {0}: 11", n);
@@ -292,9 +291,13 @@ namespace NBitcoin.Tests
 				Assert.True(rkey2.ToHex() == pubkey2.ToHex());
 				Assert.True(rkey1C.ToHex() == pubkey1C.ToHex());
 				Assert.True(rkey2C.ToHex() == pubkey2C.ToHex());
+
+				Assert.True(sign1.IsLowR && sign1.ToDER().Length <= 70);
+				Assert.True(sign2.IsLowR && sign2.ToDER().Length <= 70);
+				Assert.True(sign1C.IsLowR && sign1C.ToDER().Length <= 70);
+				Assert.True(sign2C.IsLowR && sign2C.ToDER().Length <= 70);
 			}
 		}
-
 
 		[Fact]
 		[Trait("Core", "Core")]

--- a/NBitcoin/BouncyCastle/crypto/signers/ECDsaSigner.cs
+++ b/NBitcoin/BouncyCastle/crypto/signers/ECDsaSigner.cs
@@ -1,3 +1,4 @@
+using System;
 using NBitcoin.BouncyCastle.Crypto.Parameters;
 using NBitcoin.BouncyCastle.Math;
 using NBitcoin.BouncyCastle.Math.EC;
@@ -19,9 +20,11 @@ namespace NBitcoin.BouncyCastle.Crypto.Signers
 		protected ECKeyParameters key = null;
 		protected SecureRandom random = null;
 
+		protected bool forceLowR = false;
+
 		/**
-         * Default configuration, random K values.
-         */
+		* Default configuration, random K values.
+		*/
 		public ECDsaSigner()
 		{
 			this.kCalculator = new RandomDsaKCalculator();
@@ -32,9 +35,10 @@ namespace NBitcoin.BouncyCastle.Crypto.Signers
          *
          * @param kCalculator a K value calculator.
          */
-		public ECDsaSigner(IDsaKCalculator kCalculator)
+		public ECDsaSigner(IDsaKCalculator kCalculator, bool forceLowR=true)
 		{
 			this.kCalculator = kCalculator;
+			this.forceLowR = forceLowR;
 		}
 
 		public virtual string AlgorithmName
@@ -99,16 +103,22 @@ namespace NBitcoin.BouncyCastle.Crypto.Signers
 			do // Generate s
 			{
 				BigInteger k;
+				byte[] rBytes = null;
 				do // Generate r
 				{
-					k = kCalculator.NextK();
+					do 
+					{
+						k = kCalculator.NextK();
 
-					ECPoint p = basePointMultiplier.Multiply(ec.G, k).Normalize();
+						ECPoint p = basePointMultiplier.Multiply(ec.G, k).Normalize();
 
-					// 5.3.3
-					r = p.AffineXCoord.ToBigInteger().Mod(n);
+						// 5.3.3
+						r = p.AffineXCoord.ToBigInteger().Mod(n);
+					}
+					while(r.SignValue == 0);
+					rBytes = r.ToByteArrayUnsigned();
 				}
-				while(r.SignValue == 0);
+				while(forceLowR && rBytes[0] >= 0x80);
 
 				s = k.ModInverse(n).Multiply(e.Add(d.Multiply(r))).Mod(n);
 			}

--- a/NBitcoin/BouncyCastle/crypto/signers/ECDsaSigner.cs
+++ b/NBitcoin/BouncyCastle/crypto/signers/ECDsaSigner.cs
@@ -116,9 +116,8 @@ namespace NBitcoin.BouncyCastle.Crypto.Signers
 						r = p.AffineXCoord.ToBigInteger().Mod(n);
 					}
 					while(r.SignValue == 0);
-					rBytes = r.ToByteArrayUnsigned();
 				}
-				while(forceLowR && rBytes[0] >= 0x80);
+				while(forceLowR && r.ToByteArrayUnsigned()[0] >= 0x80);
 
 				s = k.ModInverse(n).Multiply(e.Add(d.Multiply(r))).Mod(n);
 			}

--- a/NBitcoin/Crypto/DeterministicECDSA.cs
+++ b/NBitcoin/Crypto/DeterministicECDSA.cs
@@ -41,14 +41,15 @@ namespace NBitcoin.Crypto
 		private byte[] _buffer = new byte[0];
 		private readonly IDigest _digest;
 
-		public DeterministicECDSA()
-			: base(new HMacDsaKCalculator(new Sha256Digest()))
+		public DeterministicECDSA(bool forceLowR=true)
+			: base(new HMacDsaKCalculator(new Sha256Digest()), forceLowR)
 
 		{
 			_digest = new Sha256Digest();
+			this.forceLowR = forceLowR;
 		}
-		public DeterministicECDSA(Func<IDigest> digest)
-			: base(new HMacDsaKCalculator(digest()))
+		public DeterministicECDSA(Func<IDigest> digest, bool forceLowR=true)
+			: base(new HMacDsaKCalculator(digest()), forceLowR)
 		{
 			_digest = digest();
 		}

--- a/NBitcoin/Crypto/ECDSASignature.cs
+++ b/NBitcoin/Crypto/ECDSASignature.cs
@@ -116,6 +116,14 @@ namespace NBitcoin.Crypto
 			}
 		}
 
+		public bool IsLowR
+		{
+			get
+			{
+				var rBytes = this.R.ToByteArrayUnsigned();
+				return rBytes[0] < 0x80;
+			}
+		}
 
 
 		public static bool IsValidDER(byte[] bytes)


### PR DESCRIPTION
This PR is for making sure ECDSA signatures use lor R values making the DER-formatted signature length = 70 bytes. This same change is based on [the Andrew Chow's PR](https://github.com/bitcoin/bitcoin/pull/13666) in bitcoin core code base. If well that PR is not merged yet, the discussion there is not about the correctness or security of this change but about implementation details and conflicts with other soon-to-be-merged PRs instead.

I think this change is safe but it would be good @NicolasDorier review it deeply. 

Btw, I've tested it with the test below but I didn't include it in this PR because I think it is unnecessary. Anyway, I can add it to the project if someone think it is a good idea.
```c#
[Fact]
public void Signatures_use_low_R()
{
    var rnd = new Random();
    for(var i=0; i < 1_000_000; i++)
    {
        var key = new Key();
        var msgLen = rnd.Next(10, 1000);
        var msg = new byte[msgLen];
        rnd.NextBytes(msg);

        var sig = key.Sign(Hashes.Hash256(msg));
        Assert.True(sig.IsLowR && sig.ToDER().Length <= 70);
    }
}
```