### PR TITLE
Add some OSS projects reference in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ NBitcoin is licensed under the [MIT License](https://opensource.org/licenses/MIT
 
 * [BlockExplorer](http://github.com/stratisproject/BlockExplorer): A set of projects that can index and query stratis blockchains on the fullnode. 
 
-* [BTCPay](http://github.com/btcpayserver/btcpayserver): A cross platform, self-hosted server compatible with Bitpay API 
+* [BTCPay Server](http://github.com/btcpayserver/btcpayserver): A cross platform, self-hosted server compatible with Bitpay API 
 
 * [NTumbleBit](http://github.com/NTumbleBit/NTumbleBit): TumbleBit Implementation in .NET Core 
 
@@ -131,9 +131,7 @@ NBitcoin is licensed under the [MIT License](https://opensource.org/licenses/MIT
 
 * [Nako](http://github.com/CoinVault/Nako): A Bitcoin and Altcoin server api that indexes blockchain transactions and addresses 
 
-* [NBXplorer](http://github.com/dgarage/NBXplorer): NBitcoin Explorer 
-
-* [NElements](http://github.com/NicolasDorier/NElements): Adapting NBitcoin for NElements 
+* [NBXplorer](http://github.com/dgarage/NBXplorer): A minimalist UTXO tracker for HD Wallets with bitcoin based altcoin support 
 
 * [UnitCurrency](http://github.com/unitcurrency/unitcurrency): UnitCoin - a hybrid scrypt PoW + PoS based cryptocurrency.
 
@@ -141,6 +139,7 @@ NBitcoin is licensed under the [MIT License](https://opensource.org/licenses/MIT
 
 * [BreezeProject](http://github.com/BreezeHub/BreezeProject): Breeze Masternode and Wallet with Breeze Privacy Protocol 
 
+* [Geewallet](https://github.com/diginex/geewallet): a minimalistic and pragmatist lightweight wallet for people that want to hold the most important cryptocurrencies in the same application without hassle
 
 ## Useful doc :
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,41 @@ NBitcoin is inspired by Bitcoin Core code but provides a simpler object oriented
 
 NBitcoin is licensed under the [MIT License](https://opensource.org/licenses/MIT) and we encourage you to use it to explore, learn, debug, play, share and create software for Bitcoin and with other Metaco services.
 
+## Some OSS projects using NBitcoin
+
+* [Wasabi](http://github.com/zkSNACKs/WalletWasabi): Privacy focused, ZeroLink compliant Bitcoin wallet.
+
+* [StratisBitcoinFullNode](http://github.com/stratisproject/StratisBitcoinFullNode): Bitcoin full node in C# https://stratisplatform.com
+
+* [Breeze](http://github.com/stratisproject/Breeze): Breeze Wallet, the first full-block SPV bitcoin wallet 
+
+* [BlockExplorer](http://github.com/stratisproject/BlockExplorer): A set of projects that can index and query stratis blockchains on the fullnode. 
+
+* [BTCPay](http://github.com/btcpayserver/btcpayserver): A cross platform, self-hosted server compatible with Bitpay API 
+
+* [NTumbleBit](http://github.com/NTumbleBit/NTumbleBit): TumbleBit Implementation in .NET Core 
+
+* [BitPoker](http://github.com/bitcoinbrisbane/BitPoker): Decentralised peer to peer poker, using bitcoin http://www.bitpoker.io
+
+* [Zen-Wallet](http://github.com/zenprotocol/zen-wallet): Node and GUI for the Zen Protocol. https://www.zenprotocol.com
+
+* [Metaco-Trader](http://github.com/MetacoSA/Metaco-Trader): Bitcoin Wallet for advanced user based on a NBitcoin.Server 
+
+* [Swarmops](http://github.com/Swarmops/Swarmops): Admin backend for any bitcoin-native or swarm organization http://sandbox.swarmops.com/
+
+* [Nako](http://github.com/CoinVault/Nako): A Bitcoin and Altcoin server api that indexes blockchain transactions and addresses 
+
+* [NBXplorer](http://github.com/dgarage/NBXplorer): NBitcoin Explorer 
+
+* [NElements](http://github.com/NicolasDorier/NElements): Adapting NBitcoin for NElements 
+
+* [UnitCurrency](http://github.com/unitcurrency/unitcurrency): UnitCoin - a hybrid scrypt PoW + PoS based cryptocurrency.
+
+* [Openchain](http://github.com/openchain/openchain): Openchain node reference implementation. https://www.openchain.org/
+
+* [BreezeProject](http://github.com/BreezeHub/BreezeProject): Breeze Masternode and Wallet with Breeze Privacy Protocol 
+
+
 ## Useful doc :
 
 * **Ebook** [Programming The Blockchain in C#](https://www.gitbook.com/book/programmingblockchain/programmingblockchain/details)


### PR DESCRIPTION
This PR is for adding some open-sourced projects that use (or are based on) NBitcoin. If well there are probably hundreds of projects referencing NBitcoin in Github, these are by sure the best known. I didn't include projects that I think are using NBitcoin but that I cannot find the source code as SmartBit (is it open source?)

I didn't included neither projects with few forks   or few starts like my BlockchainParser, HBitcoin and others. 