### PR TITLE
Dystem support

### DIFF
--- a/NBitcoin.Altcoins/AltcoinNetworkSets.cs
+++ b/NBitcoin.Altcoins/AltcoinNetworkSets.cs
@@ -13,6 +13,7 @@ namespace NBitcoin.Altcoins
 		public static Dash Dash { get; } = Dash.Instance;
 		public static Mogwai Mogwai { get; } = Mogwai.Instance;
 		public static Dogecoin Dogecoin { get; } = Dogecoin.Instance;
+	    public static Dystem Dystem { get; } = Dystem.Instance;
 		public static Litecoin Litecoin { get; } = Litecoin.Instance;
 		public static Feathercoin Feathercoin { get; } = Feathercoin.Instance;
 		public static Viacoin Viacoin {get; } = Viacoin.Instance;
@@ -31,6 +32,7 @@ namespace NBitcoin.Altcoins
 			yield return Feathercoin;
 			yield return Viacoin;
 			yield return Dogecoin;
+			yield return Dystem;
 			yield return BCash;
 			yield return BGold;
 			yield return Polis;

--- a/NBitcoin.Altcoins/AltcoinNetworkSets.cs
+++ b/NBitcoin.Altcoins/AltcoinNetworkSets.cs
@@ -13,7 +13,7 @@ namespace NBitcoin.Altcoins
 		public static Dash Dash { get; } = Dash.Instance;
 		public static Mogwai Mogwai { get; } = Mogwai.Instance;
 		public static Dogecoin Dogecoin { get; } = Dogecoin.Instance;
-	    public static Dystem Dystem { get; } = Dystem.Instance;
+		public static Dystem Dystem { get; } = Dystem.Instance;
 		public static Litecoin Litecoin { get; } = Litecoin.Instance;
 		public static Feathercoin Feathercoin { get; } = Feathercoin.Instance;
 		public static Viacoin Viacoin {get; } = Viacoin.Instance;

--- a/NBitcoin.Altcoins/Dystem.cs
+++ b/NBitcoin.Altcoins/Dystem.cs
@@ -1,0 +1,226 @@
+﻿using System;
+using System.Linq;
+using NBitcoin.Altcoins.HashX11;
+using NBitcoin.Crypto;
+using NBitcoin.DataEncoders;
+using NBitcoin.Protocol;
+
+namespace NBitcoin.Altcoins
+{
+	// Reference: https://github.com/Dystem/Dystem/blob/master/src/chainparams.cpp
+	public class Dystem : NetworkSetBase
+	{
+		public static Dystem Instance { get; } = new Dystem();
+
+		public override string CryptoCode => "DTEM";
+
+		private Dystem()
+		{
+		}
+
+		public class DystemConsensusFactory : ConsensusFactory
+		{
+			private DystemConsensusFactory()
+			{
+			}
+
+			public static DystemConsensusFactory Instance { get; } = new DystemConsensusFactory();
+
+			public override BlockHeader CreateBlockHeader()
+			{
+				return new DystemBlockHeader();
+			}
+
+			public override Block CreateBlock()
+			{
+				return new DystemBlock(new DystemBlockHeader());
+			}
+		}
+
+#pragma warning disable CS0618 // Type or member is obsolete
+		public class DystemBlockHeader : BlockHeader
+		{
+			// https://github.com/Dystemp/Dystem/blob/e596762ca22d703a79c6880a9d3edb1c7c972fd3/src/primitives/block.cpp#L13
+			private static byte[] CalculateHash(byte[] data, int offset, int count)
+			{
+				var h = new Quark().ComputeBytes(data.Skip(offset).Take(count).ToArray());
+
+				return h;
+			}
+
+			protected override HashStreamBase CreateHashStream()
+			{
+				return BufferedHashStream.CreateFrom(CalculateHash);
+			}
+		}
+
+		public class DystemBlock : Block
+		{
+#pragma warning disable CS0612 // Type or member is obsolete
+			public DystemBlock(DystemBlockHeader h) : base(h)
+#pragma warning restore CS0612 // Type or member is obsolete
+			{
+			}
+
+			public override ConsensusFactory GetConsensusFactory()
+			{
+				return Instance.Mainnet.Consensus.ConsensusFactory;
+			}
+		}
+#pragma warning restore CS0618 // Type or member is obsolete
+
+		protected override void PostInit()
+		{
+			RegisterDefaultCookiePath(Mainnet, ".cookie");
+			RegisterDefaultCookiePath(Regtest, "regtest", ".cookie");
+			RegisterDefaultCookiePath(Testnet, "testnet3", ".cookie");
+		}
+
+		private static uint256 GetPoWHash(BlockHeader header)
+		{
+			var headerBytes = header.ToBytes();
+			var h = SCrypt.ComputeDerivedKey(headerBytes, headerBytes, 1024, 1, 1, null, 32);
+			return new uint256(h);
+		}
+
+		protected override NetworkBuilder CreateMainnet()
+		{
+			var builder = new NetworkBuilder();
+			builder.SetConsensus(new Consensus
+				{
+					SubsidyHalvingInterval = 210240,
+					MajorityEnforceBlockUpgrade = 750,
+					MajorityRejectBlockOutdated = 950,
+					MajorityWindow = 1000,
+					BIP34Hash = new uint256("00000f4fb42644a07735beea3647155995ab01cf49d05fdc082c08eb673433f9"),
+					PowLimit = new Target(0 >> 1),
+					MinimumChainWork = new uint256("000000000000000000000000000000000000000000000000010b219afffe4a8b"),
+					PowTargetTimespan = TimeSpan.FromSeconds(24 * 60 * 60),
+					PowTargetSpacing = TimeSpan.FromSeconds(1 * 60),
+					PowAllowMinDifficultyBlocks = false,
+					CoinbaseMaturity = 30,
+					PowNoRetargeting = false,
+					RuleChangeActivationThreshold = 1916,
+					MinerConfirmationWindow = 2016,
+					ConsensusFactory = DystemConsensusFactory.Instance,
+					SupportSegwit = false,
+					CoinType = 222
+				})
+				.SetBase58Bytes(Base58Type.PUBKEY_ADDRESS, new byte[] {30})
+				.SetBase58Bytes(Base58Type.SCRIPT_ADDRESS, new byte[] {68})
+				.SetBase58Bytes(Base58Type.SECRET_KEY, new byte[] {58})
+				.SetBase58Bytes(Base58Type.EXT_PUBLIC_KEY, new byte[] {0x04, 0x88, 0xB2, 0x1E})
+				.SetBase58Bytes(Base58Type.EXT_SECRET_KEY, new byte[] {0x04, 0x88, 0xAD, 0xE4})
+				.SetBech32(Bech32Type.WITNESS_PUBKEY_ADDRESS, Encoders.Bech32("Dystem"))
+				.SetBech32(Bech32Type.WITNESS_SCRIPT_ADDRESS, Encoders.Bech32("Dystem"))
+				.SetMagic(0x3595a329)
+				.SetPort(16443)
+				.SetRPCPort(17200)
+				.SetMaxP2PVersion(70912)
+				.SetName("Dystem-main")
+				.AddAlias("Dystem-mainnet")
+				.AddDNSSeeds(new[]
+				{
+					new DNSSeedData("seed.dystem.io", "seed.dystem.io"),
+					new DNSSeedData("seed2.dystem.io", "seed2.dystem.io"),
+					new DNSSeedData("seed3.dystem.io", "seed3.dystem.io"),
+					new DNSSeedData("seed.hashbeat.io", "seed.hashbeat.io")
+				})
+				.AddSeeds(new NetworkAddress[0])
+				.SetGenesis("01000000000000000000000000000000000000000000000000000000000000000000000027cc0d8f6a20e41f445b1045d1c73ba4b068ee60b5fd4aa34027cbbe5c2e161e1546db5af0ff0f1e18cb3f010101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff6704ffff001d01044c5e4120736c69702d75702062792073757065726d61726b6574204173646120696e20616e206f6e6c696e65206f7264657220736177206120776f6d616e206368617267656420c2a339333020666f7220612073696e676c652062616e616e61ffffffff010000000000000000434104575f641084f76b9e94aae509ce78f6213ee4855d5c245b76d931fa190a1b453edf3ecf2b28288a338ac186d07eedc6d99256838cb57322406edc697f239a0a6eac00000000");
+
+			return builder;
+		}
+
+		protected override NetworkBuilder CreateTestnet()
+		{
+			var builder = new NetworkBuilder();
+			builder.SetConsensus(new Consensus
+				{
+					SubsidyHalvingInterval = 210240,
+					MajorityEnforceBlockUpgrade = 51,
+					MajorityRejectBlockOutdated = 75,
+					MajorityWindow = 100,
+					BIP34Hash = new uint256("0x0000047d24635e347be3aaaeb66c26be94901a2f962feccd4f95090191f208c1"),
+					PowLimit = new Target(0 >> 1),
+					MinimumChainWork = new uint256("0x000000000000000000000000000000000000000000000000000924e924a21715"),
+					PowTargetTimespan = TimeSpan.FromSeconds(24 * 60 * 60),
+					PowTargetSpacing = TimeSpan.FromSeconds(1 * 60),
+					PowAllowMinDifficultyBlocks = true,
+					CoinbaseMaturity = 30,
+					PowNoRetargeting = false,
+					RuleChangeActivationThreshold = 1512,
+					MinerConfirmationWindow = 2016,
+					ConsensusFactory = DystemConsensusFactory.Instance,
+					SupportSegwit = false,
+					CoinType = 1
+				})
+				.SetBase58Bytes(Base58Type.PUBKEY_ADDRESS, new byte[] {30})
+				.SetBase58Bytes(Base58Type.SCRIPT_ADDRESS, new byte[] {68})
+				.SetBase58Bytes(Base58Type.SECRET_KEY, new byte[] {58})
+				.SetBase58Bytes(Base58Type.EXT_PUBLIC_KEY, new byte[] {0x04, 0x88, 0xB2, 0x1E})
+				.SetBase58Bytes(Base58Type.EXT_SECRET_KEY, new byte[] {0x04, 0x88, 0xAD, 0xE4})
+				.SetBech32(Bech32Type.WITNESS_PUBKEY_ADDRESS, Encoders.Bech32("tDystem"))
+				.SetBech32(Bech32Type.WITNESS_SCRIPT_ADDRESS, Encoders.Bech32("tDystem"))
+				.SetMagic(0x1d322dc2)
+				.SetPort(65444)
+				.SetRPCPort(17200)
+				.SetMaxP2PVersion(70912)
+				.SetName("dystem-test")
+				.AddAlias("dystem-testnet")
+				.AddDNSSeeds(new[]
+				{
+					new DNSSeedData("seed.dystem.io", "seed.dystem.io"),
+					new DNSSeedData("seed2.dystem.io", "seed2.dystem.io"),
+					new DNSSeedData("seed3.dystem.io", "seed3.dystem.io"),
+					new DNSSeedData("seed.hashbeat.io", "seed.hashbeat.io")
+				})
+				.AddSeeds(new NetworkAddress[0])
+				.SetGenesis("01000000000000000000000000000000000000000000000000000000000000000000000027cc0d8f6a20e41f445b1045d1c73ba4b068ee60b5fd4aa34027cbbe5c2e161e1546db5af0ff0f1e18cb3f010101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff6704ffff001d01044c5e4120736c69702d75702062792073757065726d61726b6574204173646120696e20616e206f6e6c696e65206f7264657220736177206120776f6d616e206368617267656420c2a339333020666f7220612073696e676c652062616e616e61ffffffff010000000000000000434104575f641084f76b9e94aae509ce78f6213ee4855d5c245b76d931fa190a1b453edf3ecf2b28288a338ac186d07eedc6d99256838cb57322406edc697f239a0a6eac00000000");
+
+			return builder;
+		}
+
+		protected override NetworkBuilder CreateRegtest()
+		{
+			var builder = new NetworkBuilder();
+			var res = builder.SetConsensus(new Consensus
+				{
+					SubsidyHalvingInterval = 210240,
+					MajorityEnforceBlockUpgrade = 750,
+					MajorityRejectBlockOutdated = 950,
+					MajorityWindow = 1000,
+					BIP34Hash = new uint256("0x000007d91d1254d60e2dd1ae580383070a4ddffa4c64c2eeb4a2f9ecc0414343"),
+					PowLimit = new Target(0 >> 1),
+					MinimumChainWork = new uint256("0x000000000000000000000000000000000000000000000100a308553b4863b755"),
+					PowTargetTimespan = TimeSpan.FromSeconds(24 * 60 * 60),
+					PowTargetSpacing = TimeSpan.FromSeconds(1 * 60),
+					PowAllowMinDifficultyBlocks = false,
+					CoinbaseMaturity = 10,
+					PowNoRetargeting = false,
+					RuleChangeActivationThreshold = 1916,
+					MinerConfirmationWindow = 2016,
+					ConsensusFactory = DystemConsensusFactory.Instance,
+					SupportSegwit = false
+				})
+				.SetBase58Bytes(Base58Type.PUBKEY_ADDRESS, new byte[] {30})
+				.SetBase58Bytes(Base58Type.SCRIPT_ADDRESS, new byte[] {68})
+				.SetBase58Bytes(Base58Type.SECRET_KEY, new byte[] {58})
+				.SetBase58Bytes(Base58Type.EXT_PUBLIC_KEY, new byte[] {0x04, 0x88, 0xB2, 0x1E})
+				.SetBase58Bytes(Base58Type.EXT_SECRET_KEY, new byte[] {0x04, 0x88, 0xAD, 0xE4})
+				.SetBech32(Bech32Type.WITNESS_PUBKEY_ADDRESS, Encoders.Bech32("tDystem"))
+				.SetBech32(Bech32Type.WITNESS_SCRIPT_ADDRESS, Encoders.Bech32("tDystem"))
+				.SetMagic(0x7d322ba2)
+				.SetPort(65445)
+				.SetRPCPort(17200)
+				.SetMaxP2PVersion(70912)
+				.SetName("dystem-reg")
+				.AddAlias("dystem-regtest")
+				.AddDNSSeeds(new DNSSeedData[0])
+				.AddSeeds(new NetworkAddress[0])
+				.SetGenesis("01000000000000000000000000000000000000000000000000000000000000000000000027cc0d8f6a20e41f445b1045d1c73ba4b068ee60b5fd4aa34027cbbe5c2e161e434fdb5af0ff0f1e4a6c51010101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff6704ffff001d01044c5e4120736c69702d75702062792073757065726d61726b6574204173646120696e20616e206f6e6c696e65206f7264657220736177206120776f6d616e206368617267656420c2a339333020666f7220612073696e676c652062616e616e61ffffffff010000000000000000434104575f641084f76b9e94aae509ce78f6213ee4855d5c245b76d931fa190a1b453edf3ecf2b28288a338ac186d07eedc6d99256838cb57322406edc697f239a0a6eac00000000");
+
+			return builder;
+		}
+	}
+}

--- a/NBitcoin.Altcoins/HashX11/Quark.cs
+++ b/NBitcoin.Altcoins/HashX11/Quark.cs
@@ -1,0 +1,87 @@
+﻿using System.Linq;
+using NBitcoin.Altcoins.HashX11;
+
+namespace NBitcoin.Altcoins.Hash
+{
+	public class Quark
+	{
+		private readonly IHash blake512;
+		private readonly IHash bmw512;
+		private readonly IHash groestl512;
+		private readonly IHash skein512;
+		private readonly IHash jh512;
+		private readonly IHash keccak512;
+
+		public Quark()
+		{
+			blake512 = HashFactory.Crypto.SHA3.CreateBlake512();
+			bmw512 = HashFactory.Crypto.SHA3.CreateBlueMidnightWish512();
+			groestl512 = HashFactory.Crypto.SHA3.CreateGroestl512();
+		 skein512 = HashFactory.Crypto.SHA3.CreateSkein512_Custom();
+			jh512 = HashFactory.Crypto.SHA3.CreateJH512();
+			keccak512 = HashFactory.Crypto.SHA3.CreateKeccak512();
+		}
+
+
+		public byte[] ComputeBytes(byte[] input)
+		{
+
+			var hash = new byte[9][];
+
+			// ZBLAKE;
+
+			hash[0] = blake512.ComputeBytes(input).GetBytes();
+		
+			// ZBMW;
+			hash[1] = bmw512.ComputeBytes(hash[0]).GetBytes();
+
+			if((hash[1][0] & 8) != 0)
+			{
+				// ZGROESTL;
+				hash[2] = groestl512.ComputeBytes(hash[1]).GetBytes();
+			}
+			else
+			{
+				// ZSKEIN;
+				hash[2] = skein512.ComputeBytes(hash[1]).GetBytes();
+			}
+
+			// ZGROESTL;
+			hash[3] = groestl512.ComputeBytes(hash[2]).GetBytes();
+
+			// ZJH;
+			hash[4] = jh512.ComputeBytes(hash[3]).GetBytes();
+
+			if((hash[4][0] & 8) != 0)
+			{
+				// ZBLAKE;
+				hash[5] = blake512.ComputeBytes(hash[4]).GetBytes();
+			}
+			else
+			{
+				// ZBMW;
+				hash[5] = bmw512.ComputeBytes(hash[4]).GetBytes();
+			}
+
+			// ZKECCAK;
+			hash[6] = keccak512.ComputeBytes(hash[5]).GetBytes();
+
+			// SKEIN;
+			hash[7] = skein512.ComputeBytes(hash[6]).GetBytes();
+
+			if((hash[7][0] & 8) != 0)
+			{
+				// ZKECCAK;
+				hash[8] = keccak512.ComputeBytes(hash[7]).GetBytes();
+			}
+			else
+			{
+				// ZJH;
+				hash[8] = jh512.ComputeBytes(hash[7]).GetBytes();
+			}
+			
+			return hash[8].Take(32).ToArray();
+			
+		}
+	}
+}

--- a/NBitcoin.Altcoins/HashX11/Quark.cs
+++ b/NBitcoin.Altcoins/HashX11/Quark.cs
@@ -1,7 +1,6 @@
 ﻿using System.Linq;
-using NBitcoin.Altcoins.HashX11;
 
-namespace NBitcoin.Altcoins.Hash
+namespace NBitcoin.Altcoins.HashX11
 {
 	public class Quark
 	{

--- a/NBitcoin.Altcoins/README.md
+++ b/NBitcoin.Altcoins/README.md
@@ -7,6 +7,7 @@ Currently supported altcoins are:
 * BitCore
 * Dash
 * Dogecoin
+* Dystem
 * Feathercoin
 * Groestlcoin
 * Litecoin

--- a/NBitcoin.TestFramework/WellknownNodeDownloadData.cs
+++ b/NBitcoin.TestFramework/WellknownNodeDownloadData.cs
@@ -286,6 +286,35 @@ namespace NBitcoin.Tests
 			};
 		}
 
+		public class DystemNodeDownloadData
+		{
+			public NodeDownloadData v1_0_9_9 = new NodeDownloadData()
+			{
+				Version = "1.0.9.9",
+				Windows = new NodeOSDownloadData()
+				{//
+					DownloadLink = "https://github.com/Dystem/dystem-core/releases/download/v{0}/dystem-qt-v{0}.exe",
+					Archive = "",
+					Executable = "dystemd.exe",
+					Hash = "1cf1f317aaae6e8edf520d2439f9c950aafb01bd5b46c399c8582524c59273dc"
+				},
+				Linux = new NodeOSDownloadData()
+				{
+					DownloadLink = "https://github.com/Dystem/dystem-core/releases/download/v{0}/dystemd.tar.gz",
+					Archive = "dystemd.tar.gz",
+					Executable = "dystemd",
+					//Hash = "8b7c72197f87be1f5d988c274cac06f6539ddb4591a578bfb852a412022378f2"
+				},
+				Mac = new NodeOSDownloadData()
+				{
+					DownloadLink = "https://github.com/Dystem/dystem-core/releases/download/v{0}/DYSTEM-Qt.dmg",
+					Archive = "DYSTEM-Qt.dmg",
+					Executable = "dystemd",
+					//Hash = "90ca27d6733df6fc69b0fc8220f2315623fe5b0cbd1fe31f247684d51808cb81"
+				}
+			};
+		}
+
 		public class MogwaiNodeDownloadData
 		{
 			public NodeDownloadData v0_12_2 = new NodeDownloadData()

--- a/NBitcoin.Tests/NodeBuilderEx.cs
+++ b/NBitcoin.Tests/NodeBuilderEx.cs
@@ -40,7 +40,11 @@ namespace NBitcoin.Tests
 			//var builder = NodeBuilder.Create(NodeDownloadData.Groestlcoin.v2_16_0, Altcoins.AltNetworkSets.Groestlcoin.Regtest, caller);
 
 			//var builder = NodeBuilder.Create(NodeDownloadData.Mogwai.v0_12_2, Altcoins.AltNetworkSets.Mogwai.Regtest, caller);
+
+			//var builder = NodeBuilder.Create(NodeDownloadData.Dystem.v1_0_9_9, Altcoins.Dystem.Instance.Regtest, caller);
+
 			var builder = NodeBuilder.Create(NodeDownloadData.Bitcoin.v0_16_2, Altcoins.AltNetworkSets.Bitcoin.Regtest, caller);
+			
 			//var builder = NodeBuilder.Create(NodeDownloadData.Bitcore.v0_15_1, Altcoins.Bitcore.Instance.Regtest, caller);
 			
 			return builder;

--- a/NBitcoin.Tests/hash_tests.cs
+++ b/NBitcoin.Tests/hash_tests.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using NBitcoin.Altcoins.HashX11;
 using Xunit;
 
 namespace NBitcoin.Tests
@@ -146,5 +147,41 @@ namespace NBitcoin.Tests
 		{
 			Assert.Equal(Hashes.MurmurHash3(seed, Encoders.Hex.DecodeData(data)), expected);
 		}
+
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void quark()
+		{
+			var bytes = Encoders.Hex.DecodeData("01000000000000000000000000000000000000000000000000000000000000000000000027cc0d8f6a20e41f445b1045d1c73ba4b068ee60b5fd4aa34027cbbe5c2e161e1546db5af0ff0f1e18cb3f01");
+
+			Console.WriteLine(Encoders.Hex.EncodeData(bytes));
+
+			var hashBytes = new Quark().ComputeBytes(bytes).ToArray();
+
+			var hash = Encoders.Hex.EncodeData(hashBytes.Reverse().ToArray());
+
+			Console.WriteLine(hash);
+
+			Assert.Equal("00000f4fb42644a07735beea3647155995ab01cf49d05fdc082c08eb673433f9", hash);
+		}
+
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void x11()
+		{
+			var bytes = Encoders.Hex.DecodeData("010000000000000000000000000000000000000000000000000000000000000000000000c762a6567f3cc092f0684bb62b7e00a84890b990f07cc71a6bb58d64b98e02e0022ddb52f0ff0f1ec23fb901");
+
+			Console.WriteLine(Encoders.Hex.EncodeData(bytes));
+
+			var hashBytes = new X11().ComputeBytes(bytes).ToArray();
+
+			var hash = Encoders.Hex.EncodeData(hashBytes.Reverse().ToArray());
+
+			Console.WriteLine(hash);
+
+			Assert.Equal("00000ffd590b1485b3caadc19b22e6379c733355108f107a430458cdf3407ab6", hash);
+		}
+
+
 	}
 }

--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -935,13 +935,13 @@ namespace NBitcoin.RPC
 				ChainWork = new uint256(result.Value<string>("chainwork")), 
 				SizeOnDisk = result.Value<ulong>("size_on_disk"),
 				Pruned = result.Value<bool>("pruned"),
-				SoftForks = result["softforks"].Select(x=> 
+				SoftForks = result["softforks"]?.Select(x=> 
 					new BlockchainInfo.SoftFork {
 						Bip = (string)(x["id"]),
 						Version = (int)(x["version"]),
 						RejectStatus = bool.Parse((string)(x["reject"]["status"]))
 					}).ToList(),
-				Bip9SoftForks = result["bip9_softforks"].Select(x=> {
+				Bip9SoftForks = result["bip9_softforks"]?.Select(x=> {
 					var o = x.First();
 					return new BlockchainInfo.Bip9SoftFork {
 						Name = ((JProperty)x).Name,


### PR DESCRIPTION
Hi Nicolas,

I have added support for Dystem (https//dystem.io) - this appears to be the first PIVX fork added (which unfortunately is quite far behind Bitcoin Core & Dash).

This doesn't have the generate RPC command implemented, so most of the tests against regtest network are currently failing. I looking at implementing this in the core code base currently. However NBitcoin does appear to be working in the most part as I can connect to nodes across the network and issues commands.

Also to note the following:

I have added support for Quark hashing algorithm alongside X11.
Also modified the RPC client slightly to accept nulls on the fork flags.

Looking forward to hearing your thoughts?

Dan
dan@dystem.io

PS - Sorry made a bit of a faux pas with my previous PR.