### PR TITLE
[WIP] Compact Filter protocol messages

### DIFF
--- a/NBitcoin/Protocol/Payloads/CompactFilterCheckPointPayload.cs
+++ b/NBitcoin/Protocol/Payloads/CompactFilterCheckPointPayload.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NBitcoin.Protocol.Payloads
+{
+
+	[Payload("cfcheckpt")]
+	public class CompactFilterCheckPointPayload : Payload
+	{
+		private byte _filterType;
+		private byte[] _stopHash;
+		private byte[] _filterHeaders;
+
+		public CompactFilterCheckPointPayload(FilterType filterType, byte[] stopHash, byte[] filterHeaders)
+		{
+			if (filterType != FilterType.Basic)
+				throw new ArgumentException(nameof(filterType));
+			if (stopHash == null)
+				throw new ArgumentException(nameof(stopHash));
+			if (filterHeaders == null)
+				throw new ArgumentException(nameof(filterHeaders));
+
+			FilterType = filterType;
+			_stopHash = stopHash;
+			_filterHeaders = filterHeaders;
+		}
+
+		public FilterType FilterType
+		{
+			get => (FilterType)_filterType;
+			internal set => _filterType = (byte)value;
+		}
+
+
+
+		public void ReadWrite(BitcoinStream stream)
+		{
+			stream.ReadWrite(ref _filterType);
+			stream.ReadWrite(ref _stopHash);
+			stream.ReadWrite(ref _filterHeaders);
+		}
+	}
+}

--- a/NBitcoin/Protocol/Payloads/CompactFilterCheckPointPayload.cs
+++ b/NBitcoin/Protocol/Payloads/CompactFilterCheckPointPayload.cs
@@ -1,18 +1,24 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
-namespace NBitcoin.Protocol.Payloads
+namespace NBitcoin.Protocol
 {
 
 	[Payload("cfcheckpt")]
-	public class CompactFilterCheckPointPayload : Payload
+	public class CompactFilterCheckPointPayload : Payload, IBitcoinSerializable
 	{
-		private byte _filterType;
-		private byte[] _stopHash;
-		private byte[] _filterHeaders;
+		private byte _filterType = 0;
+		private uint256 _stopHash = new uint256();
+		private uint256[] _filterHeaders = { };
+		private VarInt _FilterHeadersLength = new VarInt(0);
+		public CompactFilterCheckPointPayload()
+		{
 
-		public CompactFilterCheckPointPayload(FilterType filterType, byte[] stopHash, byte[] filterHeaders)
+		}
+
+		public CompactFilterCheckPointPayload(FilterType filterType, uint256 stopHash, uint filtersHeaderLength, byte[] filterHeaders)
 		{
 			if (filterType != FilterType.Basic)
 				throw new ArgumentException(nameof(filterType));
@@ -23,7 +29,25 @@ namespace NBitcoin.Protocol.Payloads
 
 			FilterType = filterType;
 			_stopHash = stopHash;
-			_filterHeaders = filterHeaders;
+			_filterHeaders = GetHashes(filterHeaders);
+		}
+
+		private uint256[] GetHashes(byte[] filterHeaders)
+		{
+			int bytesToTake = 32;
+			int bytesTaken = 0;
+			List<uint256> temp = new List<uint256>();
+
+			List<BlockHeader> blockHeaders = new List<BlockHeader>();
+
+			for (; bytesTaken < filterHeaders.Length; bytesTaken += bytesToTake)
+			{
+				var subArray = filterHeaders.SafeSubarray(bytesTaken, bytesToTake);
+
+				temp.Add(new uint256(subArray));
+			}
+
+			return temp.ToArray();
 		}
 
 		public FilterType FilterType
@@ -31,14 +55,28 @@ namespace NBitcoin.Protocol.Payloads
 			get => (FilterType)_filterType;
 			internal set => _filterType = (byte)value;
 		}
-
-
+		public uint256 StopHash { get => _stopHash; set => _stopHash = value; }
+		public uint256[] FilterHeaders { get => _filterHeaders; set => _filterHeaders = value; }
+		public VarInt FilterHeadersLength { get => _FilterHeadersLength; set => _FilterHeadersLength = value; }
 
 		public void ReadWrite(BitcoinStream stream)
 		{
+			var length = stream.Inner.Length;
+
 			stream.ReadWrite(ref _filterType);
 			stream.ReadWrite(ref _stopHash);
-			stream.ReadWrite(ref _filterHeaders);
+			stream.ReadWrite(ref _FilterHeadersLength);
+			var _tempfilterHeaders = new byte[_FilterHeadersLength.ToLong() * 32];
+
+			stream.ReadWrite(ref _tempfilterHeaders);
+
+			_filterHeaders = GetHashes(_tempfilterHeaders);
+		}
+
+
+		public override string ToString()
+		{
+			return $"cfcheckpt - filter type: {this._filterType}| Stop Hash {this.StopHash}| # of checkpoints: {this._FilterHeadersLength.ToLong()}";
 		}
 	}
 }

--- a/NBitcoin/Protocol/Payloads/CompactFilterCheckPointPayload.cs
+++ b/NBitcoin/Protocol/Payloads/CompactFilterCheckPointPayload.cs
@@ -20,7 +20,7 @@ namespace NBitcoin.Protocol
 
 		public CompactFilterCheckPointPayload(FilterType filterType, uint256 stopHash, uint filtersHeaderLength, byte[] filterHeaders)
 		{
-			if (filterType != FilterType.Basic)
+			if (filterType != FilterType.Basic /*&& filterType != FilterType.Extended*/) //Extended filters removed
 				throw new ArgumentException(nameof(filterType));
 			if (stopHash == null)
 				throw new ArgumentException(nameof(stopHash));

--- a/NBitcoin/Protocol/Payloads/CompactFilterHeadersPayload.cs
+++ b/NBitcoin/Protocol/Payloads/CompactFilterHeadersPayload.cs
@@ -1,4 +1,4 @@
-﻿#if !NOSOCKET
+#if !NOSOCKET
 using NBitcoin.Crypto;
 using NBitcoin.Protocol.Behaviors;
 using System;
@@ -11,17 +11,18 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace NBitcoin.Protocol.Payloads
+namespace NBitcoin.Protocol
 {
 	[Payload("cfheaders")]
-	public class CompactFilterHeadersPayload: Payload
+	public class CompactFilterHeadersPayload: Payload, IBitcoinSerializable
 	{
-		private byte _filterType;
-		private byte[] _stopHash;
-		private byte[] _previousFilterHeader;
-		private byte[] _filterHashes;
+		private byte _filterType = 0;
+		private uint256 _stopHash = new uint256();
+		private uint256 _previousFilterHeader = new uint256();
+		private VarInt _filterHashesLength = new VarInt(0);
+		private uint256[] _filterHashes = { };
 
-		public CompactFilterHeadersPayload(FilterType filterType, byte[] stopHash, byte[] previousFilterHeader, byte[] filterHashes)
+		public CompactFilterHeadersPayload(FilterType filterType, uint256 stopHash, uint256 previousFilterHeader, byte[] filterHashes)
 		{
 			if (filterType != FilterType.Basic)
 				throw new ArgumentException(nameof(filterType));
@@ -36,8 +37,10 @@ namespace NBitcoin.Protocol.Payloads
 			FilterType = filterType;
 			_stopHash = stopHash;
 			_previousFilterHeader = previousFilterHeader;
-			_filterHashes = filterHashes;
+			_filterHashes = GetHashes(filterHashes);
 		}
+
+		public CompactFilterHeadersPayload() { }
 
 		public FilterType FilterType
 		{
@@ -50,13 +53,43 @@ namespace NBitcoin.Protocol.Payloads
 			stream.ReadWrite(ref _filterType);
 			stream.ReadWrite(ref _stopHash);
 			stream.ReadWrite(ref _previousFilterHeader);
-			stream.ReadWrite(ref _filterHashes);
+			stream.ReadWrite(ref _filterHashesLength);
+			var _tempfilterHeaders = new byte[_filterHashesLength.ToLong() * 32];
+
+			stream.ReadWrite(ref _tempfilterHeaders);
+
+			_filterHashes = GetHashes(_tempfilterHeaders);
+		}
+
+		private uint256[] GetHashes(byte[] filterHeaders)
+		{
+			int bytesToTake = 32;
+			int bytesTaken = 0;
+			List<uint256> temp = new List<uint256>();
+
+			List<BlockHeader> blockHeaders = new List<BlockHeader>();
+
+			for (; bytesTaken < filterHeaders.Length; bytesTaken += bytesToTake)
+			{
+				var subArray = filterHeaders.SafeSubarray(bytesTaken, bytesToTake);
+
+				temp.Add(new uint256(subArray));
+			}
+
+			return temp.ToArray();
 		}
 
 
-		public byte[] StopHash => _stopHash;
-		public byte[] PreviousFilterHeader => _previousFilterHeader;
-		public byte[] FilterHashes => _filterHashes;
+		public uint256 StopHash => _stopHash;
+		public uint256 PreviousFilterHeader => _previousFilterHeader;
+		public uint256[] FilterHashes => _filterHashes;
+
+
+
+		public override string ToString()
+		{
+			return $"Cheaders type: {this.FilterType}| # of headers: {this._filterHashesLength.ToLong()}| Stop Hash: {this.StopHash}| Previous Filter Header Hash: {this.PreviousFilterHeader}";
+		}
 	}
 }
 #endif

--- a/NBitcoin/Protocol/Payloads/CompactFilterHeadersPayload.cs
+++ b/NBitcoin/Protocol/Payloads/CompactFilterHeadersPayload.cs
@@ -1,0 +1,62 @@
+﻿#if !NOSOCKET
+using NBitcoin.Crypto;
+using NBitcoin.Protocol.Behaviors;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NBitcoin.Protocol.Payloads
+{
+	[Payload("cfheaders")]
+	public class CompactFilterHeadersPayload: Payload
+	{
+		private byte _filterType;
+		private byte[] _stopHash;
+		private byte[] _previousFilterHeader;
+		private byte[] _filterHashes;
+
+		public CompactFilterHeadersPayload(FilterType filterType, byte[] stopHash, byte[] previousFilterHeader, byte[] filterHashes)
+		{
+			if (filterType != FilterType.Basic)
+				throw new ArgumentException(nameof(filterType));
+			if (stopHash == null)
+				throw new ArgumentException(nameof(stopHash));
+			if (previousFilterHeader == null)
+				throw new ArgumentException(nameof(previousFilterHeader));
+			if (filterHashes == null)
+				throw new ArgumentException(nameof(filterHashes));
+
+
+			FilterType = filterType;
+			_stopHash = stopHash;
+			_previousFilterHeader = previousFilterHeader;
+			_filterHashes = filterHashes;
+		}
+
+		public FilterType FilterType
+		{
+			get => (FilterType)_filterType;
+			internal set => _filterType = (byte)value;
+		}
+
+		public void ReadWrite(BitcoinStream stream)
+		{
+			stream.ReadWrite(ref _filterType);
+			stream.ReadWrite(ref _stopHash);
+			stream.ReadWrite(ref _previousFilterHeader);
+			stream.ReadWrite(ref _filterHashes);
+		}
+
+
+		public byte[] StopHash => _stopHash;
+		public byte[] PreviousFilterHeader => _previousFilterHeader;
+		public byte[] FilterHashes => _filterHashes;
+	}
+}
+#endif

--- a/NBitcoin/Protocol/Payloads/CompactFilterHeadersPayload.cs
+++ b/NBitcoin/Protocol/Payloads/CompactFilterHeadersPayload.cs
@@ -24,8 +24,8 @@ namespace NBitcoin.Protocol
 
 		public CompactFilterHeadersPayload(FilterType filterType, uint256 stopHash, uint256 previousFilterHeader, byte[] filterHashes)
 		{
-			if (filterType != FilterType.Basic)
-				throw new ArgumentException(nameof(filterType));
+			if (filterType != FilterType.Basic /*&& filterType != FilterType.Extended*/) //Extended filters removed
+				throw new ArgumentException($"'{filterType}' is not a valid value. Try with Basic.", nameof(filterType));
 			if (stopHash == null)
 				throw new ArgumentException(nameof(stopHash));
 			if (previousFilterHeader == null)

--- a/NBitcoin/Protocol/Payloads/CompactFilterPayload.cs
+++ b/NBitcoin/Protocol/Payloads/CompactFilterPayload.cs
@@ -1,4 +1,4 @@
-﻿#if !NOSOCKET
+#if !NOSOCKET
 using NBitcoin.Crypto;
 using NBitcoin.Protocol.Behaviors;
 using System;
@@ -19,9 +19,10 @@ namespace NBitcoin.Protocol
 	[Payload("cfilter")]
 	public class CompactFilterPayload : Payload
 	{
-		private byte _filterType;
+		private byte _filterType = 0;
 		private byte[] _filterBytes;
-		private uint256 _blockHash;
+		private VarInt _numFilterBytes = new VarInt(0);
+		private uint256 _blockHash = new uint256();
 
 		/// <summary>
 		/// Gets the Filter type for which headers are requested  
@@ -56,15 +57,38 @@ namespace NBitcoin.Protocol
 			_filterBytes = filterBytes;
 		}
 
+		public CompactFilterPayload()
+		{
+		}
+
 		#region IBitcoinSerializable Members
+
 		public void ReadWrite(BitcoinStream stream)
 		{
 			stream.ReadWrite(ref _filterType);
 			stream.ReadWrite(ref _blockHash);
-			stream.ReadWriteAsVarString(ref _filterBytes);
+			stream.ReadWrite(ref _filterBytes);
 		}
 
 		#endregion
+
+		public override void ReadWriteCore(BitcoinStream stream)
+		{
+			stream.ReadWrite(ref _filterType);
+
+			stream.ReadWrite(ref _blockHash);
+
+			stream.ReadWrite(ref _numFilterBytes);
+
+			_filterBytes = new byte[_numFilterBytes.ToLong()];
+
+			stream.ReadWrite(ref _filterBytes);
+		}
+
+		public override string ToString()
+		{
+			return $"Cfilter type: {this.FilterType}| Block hash: {this.BlockHash}| cfilter bytes omitted.";
+		}
 	}
 }
 #endif

--- a/NBitcoin/Protocol/Payloads/CompactFilterPayload.cs
+++ b/NBitcoin/Protocol/Payloads/CompactFilterPayload.cs
@@ -45,7 +45,7 @@ namespace NBitcoin.Protocol
 		public CompactFilterPayload(FilterType filterType, uint256 blockhash, byte[] filterBytes)
 		{
 			if (filterType != FilterType.Basic /*&& filterType != FilterType.Extended*/) //Extended filters removed
-				throw new ArgumentException($"'{filterType}' is not a valid value. Try with Basic or Extended.", nameof(filterType));
+				throw new ArgumentException($"'{filterType}' is not a valid value. Try with Basic.", nameof(filterType));
 			if (blockhash == null)
 				throw new ArgumentNullException(nameof(blockhash));
 			if (filterBytes == null)

--- a/NBitcoin/Protocol/Payloads/CompactFilterPayload.cs
+++ b/NBitcoin/Protocol/Payloads/CompactFilterPayload.cs
@@ -1,0 +1,70 @@
+﻿#if !NOSOCKET
+using NBitcoin.Crypto;
+using NBitcoin.Protocol.Behaviors;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+namespace NBitcoin.Protocol
+{
+
+	/// <summary>
+	/// Represents the p2p message payload used for sharing a block's compact filter.
+	/// </summary>
+	[Payload("cfilter")]
+	public class CompactFilterPayload : Payload
+	{
+		private byte _filterType;
+		private byte[] _filterBytes;
+		private uint256 _blockHash;
+
+		/// <summary>
+		/// Gets the Filter type for which headers are requested  
+		/// </summary>
+		public FilterType FilterType
+		{
+			get => (FilterType)_filterType;
+			internal set => _filterType = (byte)value;
+		}
+		/// <summary>
+		/// Gets the serialized compact filter for this block 
+		/// </summary>
+		public byte[] FilterBytes => _filterBytes;
+
+
+		/// <summary>
+		/// Gets block hash of the Bitcoin block for which the filter is being returned  
+		/// </summary>
+		public uint256 BlockHash => _blockHash;
+		public CompactFilterPayload(FilterType filterType, uint256 blockhash, byte[] filterBytes)
+		{
+			if (filterType != FilterType.Basic /*&& filterType != FilterType.Extended*/) //Extended filters removed
+				throw new ArgumentException($"'{filterType}' is not a valid value. Try with Basic or Extended.", nameof(filterType));
+			if (blockhash == null)
+				throw new ArgumentNullException(nameof(blockhash));
+			if (filterBytes == null)
+				throw new ArgumentNullException(nameof(filterBytes));
+
+
+			FilterType = filterType;
+			_blockHash = blockhash;
+			_filterBytes = filterBytes;
+		}
+
+		#region IBitcoinSerializable Members
+		public void ReadWrite(BitcoinStream stream)
+		{
+			stream.ReadWrite(ref _filterType);
+			stream.ReadWrite(ref _blockHash);
+			stream.ReadWriteAsVarString(ref _filterBytes);
+		}
+
+		#endregion
+	}
+}
+#endif

--- a/NBitcoin/Protocol/Payloads/GetCompactFiltersPayload.cs
+++ b/NBitcoin/Protocol/Payloads/GetCompactFiltersPayload.cs
@@ -1,0 +1,123 @@
+﻿#if !NOSOCKET
+using NBitcoin.Crypto;
+using NBitcoin.Protocol.Behaviors;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+namespace NBitcoin.Protocol
+{
+	public enum FilterType : byte
+	{
+		Basic = (0x00),
+		//Extended = (0x01) Decison to remove extended filter due to increased filter size when doing recursive parsing.
+		//https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2018-May/016037.html
+	}
+
+	/// <summary>
+	/// Represents the p2p message payload used for requesting a range of compact filter/headers.
+	/// </summary>
+	public abstract class CompactFiltersQueryPayload : Payload
+	{
+		private byte _filterType;
+		private uint _startHeight;
+		private uint256 _stopHash;
+		/// <summary>
+		/// Gets the Filter type for which headers are requested  
+		/// </summary>
+		public FilterType FilterType
+		{
+			get => (FilterType)_filterType;
+			internal set => _filterType = (byte)value;
+		}
+		/// <summary>
+		/// Gets the height of the first block in the requested range
+		/// </summary>
+		public uint StartHeight => _startHeight;
+		/// <summary>
+		/// Gets the hash of the last block in the requested range 
+		/// </summary>
+		public uint256 StopHash => _stopHash;
+		protected CompactFiltersQueryPayload(FilterType filterType, uint startHeight, uint256 stopHash)
+		{
+			if (filterType != FilterType.Basic /*&& filterType != FilterType.Extended*/) //Extended Filter removed
+				throw new ArgumentException($"'{filterType}' is not a valid value. Try with Basic.", nameof(filterType));
+			if (stopHash == null)
+				throw new ArgumentNullException(nameof(stopHash));
+
+			FilterType = filterType;
+			_startHeight = startHeight;
+			_stopHash = stopHash;
+		}
+
+		#region IBitcoinSerializable Members
+		public void ReadWrite(BitcoinStream stream)
+		{
+			stream.ReadWrite(ref _filterType);
+			stream.ReadWrite(ref _startHeight);
+			stream.ReadWrite(ref _stopHash);
+		}
+
+		#endregion
+	}
+	/// <summary>
+	/// Represents the p2p message payload used for requesting a range of compact filter.
+	/// </summary>
+	[Payload("getcfilters")]
+	public class GetCompactFiltersPayload : CompactFiltersQueryPayload
+	{
+		public GetCompactFiltersPayload(FilterType filterType, uint startHeight, uint256 stopHash)
+			: base(filterType, startHeight, stopHash)
+		{
+		}
+	}
+	/// <summary>
+	/// Represents the p2p message payload used for requesting a range of compact filter headers.
+	/// </summary>
+	[Payload("getcfheaders")]
+	public class GetCompactFilterHeadersPayload : CompactFiltersQueryPayload
+	{
+		public GetCompactFilterHeadersPayload(FilterType filterType, uint startHeight, uint256 stopHash)
+			: base(filterType, startHeight, stopHash)
+		{
+		}
+	}
+
+	[Payload("getcfcheckpt")]
+	public class GetCompactFilterCheckPointPayload : Payload
+	{
+		private byte _filterType;
+		private uint256 _stopHash;
+
+		public GetCompactFilterCheckPointPayload(FilterType filterType, uint256 stopHash)
+		{
+
+		}
+
+
+		public FilterType FilterType
+		{
+			get => (FilterType)_filterType;
+			internal set => _filterType = (byte)value;
+		}
+		/// <summary>
+		/// Gets the height of the first block in the requested range
+		/// </summary>
+	
+			
+
+		/// <summary>
+		/// Gets the hash of the last block in the requested range 
+		/// </summary>
+		public uint256 StopHash => _stopHash;
+	}
+
+
+
+}
+#endif

--- a/NBitcoin/Protocol/Payloads/VersionPayload.cs
+++ b/NBitcoin/Protocol/Payloads/VersionPayload.cs
@@ -43,6 +43,11 @@ namespace NBitcoin.Protocol
 		/// </summary> 
 		NODE_WITNESS = (1 << 3),
 
+		/// <summary> Indicates that a node can be asked for compact filters.
+		/// If enabled, the node MUST respond to all BIP 157 messages for filter types 0x00 and 0x01 
+		/// </summary> 
+		NODE_COMPACT_FILTERS = (1 << 6),
+
 		/// <summary> NODE_NETWORK_LIMITED means the same as NODE_NETWORK with the limitation of only
 		/// serving the last 288 (2 day) blocks
 		/// See BIP159 for details on how this is implemented.


### PR DESCRIPTION
Hello, this is a work in progress for light client protocol messages. Still a WIP because of lack of proper tests. I would like to give credit to @lontivero for opening #401, getting the ball rolling on the issue, and giving me a solid place to start.

There has been a few changes regarding filter types, for now the only supported filter is "Basic". Therefore I have commented out the conditional checks for "Extended" filter type, also commented out the enum value.

For the payloads I have included all the fields included in [bip157](https://github.com/bitcoin/bips/blob/master/bip-0157.mediawiki). I included the "length" fields which are technically not necessary to save in the object, as far as I am concerned. 
 
I have overrode ToString() for testing purposes.

I appreciate all comments and feed back given.

The end goal is to eventually create a compact filter light client, similar to [neutrino](https://github.com/lightninglabs/neutrino) on top of Nbitcoin.
