### PR TITLE
Dispose LinkedCancellationTokenSources

### DIFF
--- a/NBitcoin/Protocol/Node.cs
+++ b/NBitcoin/Protocol/Node.cs
@@ -614,9 +614,12 @@ namespace NBitcoin.Protocol
 				{
 					var timeout = new CancellationTokenSource(5000);
 					var param2 = parameters.Clone();
-					param2.ConnectCancellation = CancellationTokenSource.CreateLinkedTokenSource(parameters.ConnectCancellation, timeout.Token).Token;
-					var node = Node.Connect(network, addr.Endpoint, param2);
-					return node;
+					using(var cts = CancellationTokenSource.CreateLinkedTokenSource(parameters.ConnectCancellation, timeout.Token))
+					{
+						param2.ConnectCancellation = cts.Token;
+						var node = Node.Connect(network, addr.Endpoint, param2);
+						return node;
+					}
 				}
 				catch(OperationCanceledException ex)
 				{
@@ -1630,11 +1633,14 @@ namespace NBitcoin.Protocol
 						while(batchResult.Count < batch.Count)
 						{
 							CancellationTokenSource timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10.0));
-							var payload = listener.ReceivePayload<Payload>(CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeout.Token).Token);
-							if(payload is NotFoundPayload)
-								batchResult.Add(null);
-							else
-								batchResult.Add(((TxPayload)payload).Object);
+							using(var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeout.Token))
+							{
+								var payload = listener.ReceivePayload<Payload>(cts.Token);
+								if(payload is NotFoundPayload)
+									batchResult.Add(null);
+								else
+									batchResult.Add(((TxPayload)payload).Object);
+							}
 						}
 						result.AddRange(batchResult);
 					}

--- a/NBitcoin/Protocol/NodesGroup.cs
+++ b/NBitcoin/Protocol/NodesGroup.cs
@@ -161,10 +161,12 @@ namespace NBitcoin.Protocol
 								var groupSelector = CustomGroupSelector != null ? CustomGroupSelector :
 													AllowSameGroup ? WellKnownGroupSelectors.ByRandom : null;
 								node = Node.Connect(_Network, parameters, _ConnectedNodes.Select(n => n.RemoteSocketEndpoint).ToArray(), groupSelector);
-								var timeout = CancellationTokenSource.CreateLinkedTokenSource(_Disconnect.Token);
-								timeout.CancelAfter(5000);
-								node.VersionHandshake(_Requirements, timeout.Token);
-								NodeServerTrace.Information("Node successfully connected to and handshaked");
+								using(var timeout = CancellationTokenSource.CreateLinkedTokenSource(_Disconnect.Token))
+								{
+									timeout.CancelAfter(5000);
+									node.VersionHandshake(_Requirements, timeout.Token);
+									NodeServerTrace.Information("Node successfully connected to and handshaked");
+								}
 							}
 							catch(OperationCanceledException ex)
 							{


### PR DESCRIPTION
## Summary
There is one memory leak in NBitcoin because `LinkedTokenSource` instances have to be disposed when their `WaitHandle` instances are used.

## Details
Yesterday @nopara73 found a [memory leak in **Wasabi Wallet**](https://github.com/zkSNACKs/WalletWasabi/issues/704#issuecomment-427603271) after some user reported the wallet becomes slower and slower after running it for a couple of days.

The process heap dump showed an incredible huge amount of `CancellationTokenSource` instances and an also big number of `Linked2CancellationTokenSource` instances that combined were using more memory than all the `byte[]` instances together.

It looks pretty abnormal that plumbing types were listed at the top of the memory usage objects! See:

![image](https://user-images.githubusercontent.com/127973/46591628-53841080-ca92-11e8-9bc2-f6dbe273660a.png)

After disposing the `LinkedTokenSource` I build NBitcoin for debug and referenced it from Wasabi wallet to see the impact in the memory usage. I also was able to load the Wasabi and NBitcoin symbols in order to get a more descriptive list of objects.

Below you can see a better list of objects:

![image](https://user-images.githubusercontent.com/127973/46591804-88dd2e00-ca93-11e8-8556-1afebebf4698.png)

This makes a lot of sense for Wasabi, `GolombRiceFilters` are kept in memory and `byte[]` and `uint256` are among the top types consuming memory. Of course other applications could be not suffering this problem because it only affects those that connects to peers and basically use the peer-2-peer network capabilities.

@NicolasDorier please review it carefully and if well this is not urgent, we want to release Wasabi wallet in Oct 31 so, it would be great if you could release a new package version before.

