### PR TITLE
Expand SipHash::SIPROUND for gaining performance

### DIFF
--- a/NBitcoin/Crypto/Hashes.cs
+++ b/NBitcoin/Crypto/Hashes.cs
@@ -120,8 +120,37 @@ namespace NBitcoin.Crypto
 			{
 				ulong v0 = v_0, v1 = v_1, v2 = v_2, v3 = v_3;
 				v3 ^= data;
-				SIPROUND(ref v0, ref v1, ref v2, ref v3);
-				SIPROUND(ref v0, ref v1, ref v2, ref v3);
+				//SIPROUND(ref v0, ref v1, ref v2, ref v3);
+				v0 += v1;
+				v2 += v3;
+				v1 =  v1 << 13 | v1 >> 51;
+				v3 =  v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 =  v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 =  v1 << 17 | v1 >> 47;
+				v3 =  v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 =  v2 << 32 | v2 >> 32;
+
+				//SIPROUND(ref v0, ref v1, ref v2, ref v3);
+				v0 += v1;
+				v2 += v3;
+				v1 =  v1 << 13 | v1 >> 51;
+				v3 =  v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 =  v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 =  v1 << 17 | v1 >> 47;
+				v3 =  v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 =  v2 << 32 | v2 >> 32;
 				v0 ^= data;
 
 				v_0 = v0;
@@ -148,8 +177,37 @@ namespace NBitcoin.Crypto
 					if((c & 7) == 0)
 					{
 						v3 ^= t;
-						SIPROUND(ref v0, ref v1, ref v2, ref v3);
-						SIPROUND(ref v0, ref v1, ref v2, ref v3);
+						//SIPROUND(ref v0, ref v1, ref v2, ref v3);
+						v0 += v1;
+						v2 += v3;
+						v1 =  v1 << 13 | v1 >> 51;
+						v3 =  v3 << 16 | v3 >> 48;
+						v1 ^= v0;
+						v3 ^= v2;
+						v0 =  v0 << 32 | v0 >> 32;
+						v2 += v1;
+						v0 += v3;
+						v1 =  v1 << 17 | v1 >> 47;
+						v3 =  v3 << 21 | v3 >> 43;
+						v1 ^= v2;
+						v3 ^= v0;
+						v2 =  v2 << 32 | v2 >> 32;
+
+						//SIPROUND(ref v0, ref v1, ref v2, ref v3);
+						v0 += v1;
+						v2 += v3;
+						v1 =  v1 << 13 | v1 >> 51;
+						v3 =  v3 << 16 | v3 >> 48;
+						v1 ^= v0;
+						v3 ^= v2;
+						v0 =  v0 << 32 | v0 >> 32;
+						v2 += v1;
+						v0 += v3;
+						v1 =  v1 << 17 | v1 >> 47;
+						v3 =  v3 << 21 | v3 >> 43;
+						v1 ^= v2;
+						v3 ^= v0;
+						v2 =  v2 << 32 | v2 >> 32;
 						v0 ^= t;
 						t = 0;
 					}
@@ -172,14 +230,104 @@ namespace NBitcoin.Crypto
 				ulong t = tmp | (((ulong)count) << 56);
 
 				v3 ^= t;
-				SIPROUND(ref v0, ref v1, ref v2, ref v3);
-				SIPROUND(ref v0, ref v1, ref v2, ref v3);
+				//SIPROUND(ref v0, ref v1, ref v2, ref v3);
+				v0 += v1;
+				v2 += v3;
+				v1 =  v1 << 13 | v1 >> 51;
+				v3 =  v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 =  v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 =  v1 << 17 | v1 >> 47;
+				v3 =  v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 =  v2 << 32 | v2 >> 32;
+
+				//SIPROUND(ref v0, ref v1, ref v2, ref v3);
+				v0 += v1;
+				v2 += v3;
+				v1 =  v1 << 13 | v1 >> 51;
+				v3 =  v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 =  v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 =  v1 << 17 | v1 >> 47;
+				v3 =  v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 =  v2 << 32 | v2 >> 32;
+
 				v0 ^= t;
 				v2 ^= 0xFF;
-				SIPROUND(ref v0, ref v1, ref v2, ref v3);
-				SIPROUND(ref v0, ref v1, ref v2, ref v3);
-				SIPROUND(ref v0, ref v1, ref v2, ref v3);
-				SIPROUND(ref v0, ref v1, ref v2, ref v3);
+				//SIPROUND(ref v0, ref v1, ref v2, ref v3);
+				v0 += v1;
+				v2 += v3;
+				v1 =  v1 << 13 | v1 >> 51;
+				v3 =  v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 =  v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 =  v1 << 17 | v1 >> 47;
+				v3 =  v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 =  v2 << 32 | v2 >> 32;
+
+				//SIPROUND(ref v0, ref v1, ref v2, ref v3);
+				v0 += v1;
+				v2 += v3;
+				v1 =  v1 << 13 | v1 >> 51;
+				v3 =  v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 =  v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 =  v1 << 17 | v1 >> 47;
+				v3 =  v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 =  v2 << 32 | v2 >> 32;
+
+				//SIPROUND(ref v0, ref v1, ref v2, ref v3);
+				v0 += v1;
+				v2 += v3;
+				v1 =  v1 << 13 | v1 >> 51;
+				v3 =  v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 =  v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 =  v1 << 17 | v1 >> 47;
+				v3 =  v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 =  v2 << 32 | v2 >> 32;
+
+				//SIPROUND(ref v0, ref v1, ref v2, ref v3);
+				v0 += v1;
+				v2 += v3;
+				v1 =  v1 << 13 | v1 >> 51;
+				v3 =  v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 =  v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 =  v1 << 17 | v1 >> 47;
+				v3 =  v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 =  v2 << 32 | v2 >> 32;
+
 				return v0 ^ v1 ^ v2 ^ v3;
 			}
 
@@ -193,33 +341,248 @@ namespace NBitcoin.Crypto
 				ulong v2 = 0x6c7967656e657261UL ^ k0;
 				ulong v3 = 0x7465646279746573UL ^ k1 ^ d;
 
-				SIPROUND(ref v0, ref v1, ref v2, ref v3);
-				SIPROUND(ref v0, ref v1, ref v2, ref v3);
+				//SIPROUND(ref v0, ref v1, ref v2, ref v3);
+				v0 += v1;
+				v2 += v3;
+				v1 =  v1 << 13 | v1 >> 51;
+				v3 =  v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 =  v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 =  v1 << 17 | v1 >> 47;
+				v3 =  v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 =  v2 << 32 | v2 >> 32;
+
+				//SIPROUND(ref v0, ref v1, ref v2, ref v3);
+				v0 += v1;
+				v2 += v3;
+				v1 =  v1 << 13 | v1 >> 51;
+				v3 =  v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 =  v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 =  v1 << 17 | v1 >> 47;
+				v3 =  v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 =  v2 << 32 | v2 >> 32;
+
 				v0 ^= d;
 				d = GetULong(val, 1);
 				v3 ^= d;
-				SIPROUND(ref v0, ref v1, ref v2, ref v3);
-				SIPROUND(ref v0, ref v1, ref v2, ref v3);
+
+				//SIPROUND(ref v0, ref v1, ref v2, ref v3);
+				v0 += v1;
+				v2 += v3;
+				v1 =  v1 << 13 | v1 >> 51;
+				v3 =  v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 =  v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 =  v1 << 17 | v1 >> 47;
+				v3 =  v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 =  v2 << 32 | v2 >> 32;
+
+				//SIPROUND(ref v0, ref v1, ref v2, ref v3);
+				v0 += v1;
+				v2 += v3;
+				v1 =  v1 << 13 | v1 >> 51;
+				v3 =  v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 =  v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 =  v1 << 17 | v1 >> 47;
+				v3 =  v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 =  v2 << 32 | v2 >> 32;
+
 				v0 ^= d;
 				d = GetULong(val, 2);
 				v3 ^= d;
-				SIPROUND(ref v0, ref v1, ref v2, ref v3);
-				SIPROUND(ref v0, ref v1, ref v2, ref v3);
+
+				//SIPROUND(ref v0, ref v1, ref v2, ref v3);
+				v0 += v1;
+				v2 += v3;
+				v1 =  v1 << 13 | v1 >> 51;
+				v3 =  v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 =  v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 =  v1 << 17 | v1 >> 47;
+				v3 =  v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 =  v2 << 32 | v2 >> 32;
+
+				//SIPROUND(ref v0, ref v1, ref v2, ref v3);
+				v0 += v1;
+				v2 += v3;
+				v1 =  v1 << 13 | v1 >> 51;
+				v3 =  v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 =  v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 =  v1 << 17 | v1 >> 47;
+				v3 =  v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 =  v2 << 32 | v2 >> 32;
+
 				v0 ^= d;
 				d = GetULong(val, 3);
 				v3 ^= d;
-				SIPROUND(ref v0, ref v1, ref v2, ref v3);
-				SIPROUND(ref v0, ref v1, ref v2, ref v3);
+
+				//SIPROUND(ref v0, ref v1, ref v2, ref v3);
+				v0 += v1;
+				v2 += v3;
+				v1 =  v1 << 13 | v1 >> 51;
+				v3 =  v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 =  v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 =  v1 << 17 | v1 >> 47;
+				v3 =  v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 =  v2 << 32 | v2 >> 32;
+
+				//SIPROUND(ref v0, ref v1, ref v2, ref v3);
+				v0 += v1;
+				v2 += v3;
+				v1 =  v1 << 13 | v1 >> 51;
+				v3 =  v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 =  v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 =  v1 << 17 | v1 >> 47;
+				v3 =  v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 =  v2 << 32 | v2 >> 32;
+
 				v0 ^= d;
 				v3 ^= ((ulong)4) << 59;
-				SIPROUND(ref v0, ref v1, ref v2, ref v3);
-				SIPROUND(ref v0, ref v1, ref v2, ref v3);
+
+				//SIPROUND(ref v0, ref v1, ref v2, ref v3);
+				v0 += v1;
+				v2 += v3;
+				v1 =  v1 << 13 | v1 >> 51;
+				v3 =  v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 =  v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 =  v1 << 17 | v1 >> 47;
+				v3 =  v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 =  v2 << 32 | v2 >> 32;
+
+				//SIPROUND(ref v0, ref v1, ref v2, ref v3);
+				v0 += v1;
+				v2 += v3;
+				v1 =  v1 << 13 | v1 >> 51;
+				v3 =  v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 =  v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 =  v1 << 17 | v1 >> 47;
+				v3 =  v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 =  v2 << 32 | v2 >> 32;
+
 				v0 ^= ((ulong)4) << 59;
 				v2 ^= 0xFF;
-				SIPROUND(ref v0, ref v1, ref v2, ref v3);
-				SIPROUND(ref v0, ref v1, ref v2, ref v3);
-				SIPROUND(ref v0, ref v1, ref v2, ref v3);
-				SIPROUND(ref v0, ref v1, ref v2, ref v3);
+
+				//SIPROUND(ref v0, ref v1, ref v2, ref v3);
+				v0 += v1;
+				v2 += v3;
+				v1 =  v1 << 13 | v1 >> 51;
+				v3 =  v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 =  v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 =  v1 << 17 | v1 >> 47;
+				v3 =  v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 =  v2 << 32 | v2 >> 32;
+
+				//SIPROUND(ref v0, ref v1, ref v2, ref v3);
+				v0 += v1;
+				v2 += v3;
+				v1 =  v1 << 13 | v1 >> 51;
+				v3 =  v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 =  v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 =  v1 << 17 | v1 >> 47;
+				v3 =  v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 =  v2 << 32 | v2 >> 32;
+
+				//SIPROUND(ref v0, ref v1, ref v2, ref v3);
+				v0 += v1;
+				v2 += v3;
+				v1 =  v1 << 13 | v1 >> 51;
+				v3 =  v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 =  v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 =  v1 << 17 | v1 >> 47;
+				v3 =  v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 =  v2 << 32 | v2 >> 32;
+
+				//SIPROUND(ref v0, ref v1, ref v2, ref v3);
+				v0 += v1;
+				v2 += v3;
+				v1 =  v1 << 13 | v1 >> 51;
+				v3 =  v3 << 16 | v3 >> 48;
+				v1 ^= v0;
+				v3 ^= v2;
+				v0 =  v0 << 32 | v0 >> 32;
+				v2 += v1;
+				v0 += v3;
+				v1 =  v1 << 17 | v1 >> 47;
+				v3 =  v3 << 21 | v3 >> 43;
+				v1 ^= v2;
+				v3 ^= v0;
+				v2 =  v2 << 32 | v2 >> 32;
+
 				return v0 ^ v1 ^ v2 ^ v3;
 			}
 
@@ -238,24 +601,6 @@ namespace NBitcoin.Crypto
 					default:
 						throw new ArgumentOutOfRangeException("position should be less than 4", "position");
 				}
-			}
-
-			static void SIPROUND(ref ulong v_0, ref ulong v_1, ref ulong v_2, ref ulong v_3)
-			{
-				v_0 += v_1;
-				v_1 = rotl64(v_1, 13);
-				v_1 ^= v_0;
-				v_0 = rotl64(v_0, 32);
-				v_2 += v_3;
-				v_3 = rotl64(v_3, 16);
-				v_3 ^= v_2;
-				v_0 += v_3;
-				v_3 = rotl64(v_3, 21);
-				v_3 ^= v_0;
-				v_2 += v_1;
-				v_1 = rotl64(v_1, 17);
-				v_1 ^= v_2;
-				v_2 = rotl64(v_2, 32);
 			}
 		}
 
@@ -298,10 +643,6 @@ namespace NBitcoin.Crypto
 		private static uint rotl32(uint x, byte r)
 		{
 			return (x << r) | (x >> (32 - r));
-		}
-		private static ulong rotl64(ulong x, byte b)
-		{
-			return (((x) << (b)) | ((x) >> (64 - (b))));
 		}
 
 		private static uint fmix(uint h)


### PR DESCRIPTION
This PR is for improve a bit the `SipHash` algorithm. This is something that would be good to have for those applications that use GolombRice filters (as Wasabi Wallet) because every item you want to match using GRfilters has to be siphashed first. This means if your wallet contains hundreds, or even thousands, addresses, they have to be siphash-ed.   