### PR TITLE
Fix default cookie paths

### DIFF
--- a/NBitcoin.Altcoins/Bitcore.cs
+++ b/NBitcoin.Altcoins/Bitcore.cs
@@ -82,10 +82,7 @@ namespace NBitcoin.Altcoins
 
 		protected override void PostInit()
 		{
-			//RegisterDefaultCookiePath("Bitcore", new FolderName() { TestnetFolder = "testnet3" });
-			RegisterDefaultCookiePath(Mainnet, ".cookie");
-                        RegisterDefaultCookiePath(Testnet, "testnet3", ".cookie");
-                        RegisterDefaultCookiePath(Regtest, "regtest", ".cookie");
+			RegisterDefaultCookiePath("Bitcore");
 		}
 
 		protected override NetworkBuilder CreateMainnet()

--- a/NBitcoin.Altcoins/Colossus.cs
+++ b/NBitcoin.Altcoins/Colossus.cs
@@ -71,9 +71,7 @@ namespace NBitcoin.Altcoins
 
 		protected override void PostInit()
 		{
-			RegisterDefaultCookiePath(Mainnet, ".cookie");
-			RegisterDefaultCookiePath(Regtest, "regtest", ".cookie");
-			RegisterDefaultCookiePath(Testnet, "testnet3", ".cookie");
+			RegisterDefaultCookiePath("COLX");
 		}
 
 		private static uint256 GetPoWHash(BlockHeader header)

--- a/NBitcoin.Altcoins/Dash.cs
+++ b/NBitcoin.Altcoins/Dash.cs
@@ -74,9 +74,7 @@ namespace NBitcoin.Altcoins
 
 		protected override void PostInit()
 		{
-			RegisterDefaultCookiePath(Mainnet, ".cookie");
-			RegisterDefaultCookiePath(Regtest, "regtest", ".cookie");
-			RegisterDefaultCookiePath(Testnet, "testnet3", ".cookie");
+			RegisterDefaultCookiePath("DashCore");
 		}
 
 		static uint256 GetPoWHash(BlockHeader header)

--- a/NBitcoin.Altcoins/Dogecoin.cs
+++ b/NBitcoin.Altcoins/Dogecoin.cs
@@ -356,9 +356,7 @@ namespace NBitcoin.Altcoins
 
 		protected override void PostInit()
 		{
-			RegisterDefaultCookiePath(Mainnet, ".cookie");
-			RegisterDefaultCookiePath(Testnet, "testnet3", ".cookie");
-			RegisterDefaultCookiePath(Regtest, "regtest", ".cookie");
+			RegisterDefaultCookiePath("Dogecoin");
 		}
 
 	}

--- a/NBitcoin.Altcoins/Dystem.cs
+++ b/NBitcoin.Altcoins/Dystem.cs
@@ -71,9 +71,7 @@ namespace NBitcoin.Altcoins
 
 		protected override void PostInit()
 		{
-			RegisterDefaultCookiePath(Mainnet, ".cookie");
-			RegisterDefaultCookiePath(Regtest, "regtest", ".cookie");
-			RegisterDefaultCookiePath(Testnet, "testnet3", ".cookie");
+			RegisterDefaultCookiePath("Dystem");
 		}
 
 		private static uint256 GetPoWHash(BlockHeader header)

--- a/NBitcoin.Altcoins/Gobyte.cs
+++ b/NBitcoin.Altcoins/Gobyte.cs
@@ -62,9 +62,7 @@ using System.Threading.Tasks;
 #pragma warning restore CS0618 // Type or member is obsolete
  		protected override void PostInit()
 		{
-			RegisterDefaultCookiePath(Mainnet, ".cookie");
-			RegisterDefaultCookiePath(Testnet, "testnet3", ".cookie");
-			RegisterDefaultCookiePath(Regtest, "regtest", ".cookie");
+			RegisterDefaultCookiePath("GoByteCore");
 		}
  		static uint256 GetPoWHash(BlockHeader header)
 		{

--- a/NBitcoin.Altcoins/Mogwai.cs
+++ b/NBitcoin.Altcoins/Mogwai.cs
@@ -62,9 +62,7 @@ namespace NBitcoin.Altcoins
 
 		protected override void PostInit()
 		{
-			RegisterDefaultCookiePath(Mainnet, ".cookie");
-			RegisterDefaultCookiePath(Regtest, "regtest", ".cookie");
-			RegisterDefaultCookiePath(Testnet, "testnet3", ".cookie");
+			RegisterDefaultCookiePath("MogwaiCore");
 		}
 
 		static uint256 GetPoWHash(BlockHeader header)

--- a/NBitcoin.Altcoins/Monoeci.cs
+++ b/NBitcoin.Altcoins/Monoeci.cs
@@ -75,9 +75,7 @@ namespace NBitcoin.Altcoins
 
 		protected override void PostInit()
 		{
-			RegisterDefaultCookiePath(Mainnet, ".cookie");
-			RegisterDefaultCookiePath(Testnet, "testnet3", ".cookie");
-			RegisterDefaultCookiePath(Regtest, "regtest", ".cookie");
+			RegisterDefaultCookiePath("MonoeciCore");
 		}
 
 

--- a/NBitcoin.Altcoins/Polis.cs
+++ b/NBitcoin.Altcoins/Polis.cs
@@ -75,9 +75,7 @@ namespace NBitcoin.Altcoins
 
 		protected override void PostInit()
 		{
-			RegisterDefaultCookiePath(Mainnet, ".cookie");
-			RegisterDefaultCookiePath(Testnet, "testnet3", ".cookie");
-			RegisterDefaultCookiePath(Regtest, "regtest", ".cookie");
+			RegisterDefaultCookiePath("PolisCore");
 		}
 
 

--- a/NBitcoin.Altcoins/Ufo.cs
+++ b/NBitcoin.Altcoins/Ufo.cs
@@ -217,9 +217,7 @@ namespace NBitcoin.Altcoins
 
         protected override void PostInit()
         {
-            RegisterDefaultCookiePath(Mainnet, ".cookie");
-            RegisterDefaultCookiePath(Testnet, "testnet3", ".cookie");
-            RegisterDefaultCookiePath(Regtest, "regtest", ".cookie");
+            RegisterDefaultCookiePath("Ufo");
         }
 
     }

--- a/NBitcoin/NetworkSet.cs
+++ b/NBitcoin/NetworkSet.cs
@@ -200,27 +200,6 @@ namespace NBitcoin
 			}
 		}
 
-		public static void RegisterDefaultCookiePath(Network network, params string[] subfolders)
-		{
-			var home = Environment.GetEnvironmentVariable("HOME");
-			var localAppData = Environment.GetEnvironmentVariable("APPDATA");
-			if(!string.IsNullOrEmpty(home) && string.IsNullOrEmpty(localAppData))
-			{
-				var pathList = new List<string> { home, ".dash" };
-				pathList.AddRange(subfolders);
-
-				var fullPath = Path.Combine(pathList.ToArray());
-				RPCClient.RegisterDefaultCookiePath(network, fullPath);
-			}
-			else if(!string.IsNullOrEmpty(localAppData))
-			{
-				var pathList = new List<string> { localAppData, "Dash" };
-				pathList.AddRange(subfolders);
-
-				var fullPath = Path.Combine(pathList.ToArray());
-				RPCClient.RegisterDefaultCookiePath(network, fullPath);
-			}
-		}
 #else
 		public static void RegisterDefaultCookiePath(Network network, params string[] subfolders) {}
 		protected void RegisterDefaultCookiePath(string folderName) {}


### PR DESCRIPTION
I fixed default cookie paths for Dash and Dogecoin. 

I also found that many altcoins implementations were referring to **RegisterDefaultCookiePath(Network network, params string[] subfolders)** method which generated wrong cookie path.

I have fixed them too, but I suggest developers who implemented that altcoins to check if I done everything correctly before this merged.

Ping: @dalijolijo @eabz @danystem @darkfriend77 @ChekaZ 