### PR TITLE
Improve genreator

### DIFF
--- a/NBitcoin.Tests/Generators/CryptoGenerator.cs
+++ b/NBitcoin.Tests/Generators/CryptoGenerator.cs
@@ -16,6 +16,11 @@ namespace NBitcoin.Tests.Generators
       return Arb.From(PrivateKey());
     }
 
+    public static Arbitrary<ExtKey> ExtKeysArb()
+    {
+      return Arb.From(ExtKey());
+    }
+
     public static Arbitrary<List<Key>> KeysListArb()
     {
       return Arb.From(PrivateKeys(15));
@@ -24,25 +29,9 @@ namespace NBitcoin.Tests.Generators
     public static Gen<Key> PrivateKey() => Gen.Fresh(() => new Key());
 
     public static Gen<List<Key>> PrivateKeys(int n) =>
-      Gen.ListOf<Key>(n, PrivateKey()).Select(pk => pk.ToList());
+      from pk in Gen.ListOf<Key>(n, PrivateKey())
+      select pk.ToList();
 
-    public static Gen<Tuple<List<Key>, int>> PrivateKeysWithRequiredSigs(int n)
-    {
-      if (n <= 0)
-        return Gen.Constant(Tuple.Create<List<Key>, int>(new List<Key> { null, null }, 0));
-      else
-      {
-        var keys = PrivateKeys(n);
-        var sigs = Gen.Choose(0, n);
-        return keys.Zip(sigs);
-      }
-    }
-
-    public static Gen<Tuple<List<Key>, int>> PrivateKeysWithRequiredSigs()
-    {
-      var ng = Gen.Choose(0, 15);
-      return ng.SelectMany((n) => PrivateKeysWithRequiredSigs(n));
-    }
     #endregion
 
     public static Gen<PubKey> PublicKey() =>
@@ -64,10 +53,10 @@ namespace NBitcoin.Tests.Generators
     #endregion
 
     #region ECDSASignature
-    public static Gen<ECDSASignature> ECDSA()
-    {
-      return Hash256().SelectMany(h => PrivateKey().Select(p => p.Sign(h)));
-    }
+    public static Gen<ECDSASignature> ECDSA() =>
+      from hash in Hash256()
+      from priv in PrivateKey()
+      select priv.Sign(hash);
     #endregion
 
     #region TransactionSignature
@@ -87,8 +76,8 @@ namespace NBitcoin.Tests.Generators
       });
     #endregion
 
-    public static Gen<ExtKey> ExtPrivateKey() => Gen.Fresh(() => new ExtKey());
+    public static Gen<ExtKey> ExtKey() => Gen.Fresh(() => new ExtKey());
 
-    public static Gen<ExtPubKey> ExtPublicKey() => ExtPrivateKey().Select(ek => ek.Neuter());
+    public static Gen<ExtPubKey> ExtPubKey() => ExtKey().Select(ek => ek.Neuter());
   }
 }

--- a/NBitcoin.Tests/Generators/CryptoGenerator.cs
+++ b/NBitcoin.Tests/Generators/CryptoGenerator.cs
@@ -55,10 +55,12 @@ namespace NBitcoin.Tests.Generators
 
     #region hash
     public static Gen<uint256> Hash256() =>
-      PrimitiveGenerator.RandomBytes().Select(bs => Hashes.Hash256(bs));
+      from bytes in PrimitiveGenerator.RandomBytes(32)
+      select new uint256(bytes);
 
     public static Gen<uint160> Hash160() =>
-      PrimitiveGenerator.RandomBytes().Select(bs => Hashes.Hash160(bs));
+      from bytes in PrimitiveGenerator.RandomBytes(20)
+      select new uint160(bytes);
     #endregion
 
     #region ECDSASignature
@@ -78,7 +80,10 @@ namespace NBitcoin.Tests.Generators
       Gen.OneOf<SigHash>(new List<Gen<SigHash>> {
         Gen.Constant(SigHash.All),
         Gen.Constant(SigHash.Single),
-        Gen.Constant(SigHash.None)
+        Gen.Constant(SigHash.None),
+        Gen.Constant(SigHash.AnyoneCanPay | SigHash.All),
+        Gen.Constant(SigHash.AnyoneCanPay | SigHash.Single),
+        Gen.Constant(SigHash.AnyoneCanPay | SigHash.None)
       });
     #endregion
 

--- a/NBitcoin.Tests/Generators/LegacyTransactionGenerators.cs
+++ b/NBitcoin.Tests/Generators/LegacyTransactionGenerators.cs
@@ -23,7 +23,7 @@ namespace NBitcoin.Tests.Generators
                                               select new OutPoint(txid, vout);
 
     public static Gen<TxIn> Input() => from prevout in OutPoint()
-                                       from ss in ScriptGenerator.ScriptSig()
+                                       from ss in ScriptGenerator.RandomScriptSig()
                                        from nSequence in PrimitiveGenerator.UInt32()
                                        select new TxIn(prevout, ss) { Sequence = nSequence };
 

--- a/NBitcoin.Tests/Generators/SegwitTransactionGenerators.cs
+++ b/NBitcoin.Tests/Generators/SegwitTransactionGenerators.cs
@@ -52,7 +52,7 @@ namespace NBitcoin.Tests.Generators
       from outputs in NonEmptyOutputs()
       from locktime in PrimitiveGenerator.UInt32()
       let tx = LegacyTransactionGenerators.ComposeTx(Transaction.Create(network), inputs, outputs, locktime)
-	  where tx.HasWitness
-	  select tx;
+        where tx.HasWitness
+        select tx;
   }
 }

--- a/NBitcoin.Tests/Generators/StandardTransactionGenerator.cs
+++ b/NBitcoin.Tests/Generators/StandardTransactionGenerator.cs
@@ -1,0 +1,14 @@
+using NBitcoin.Policy;
+
+namespace NBitcoin.Tests.Generators
+{
+  public class StandardTransactionGenerator
+  {
+    private static StandardTransactionPolicy _Policy;
+
+    static StandardTransactionGenerator()
+    {
+      _Policy = new StandardTransactionPolicy();
+    }
+  }
+}

--- a/NBitcoin.Tests/PropertyTest/ExtKeyTest.cs
+++ b/NBitcoin.Tests/PropertyTest/ExtKeyTest.cs
@@ -1,0 +1,33 @@
+using FsCheck;
+using FsCheck.Xunit;
+using NBitcoin.Tests.Generators;
+using Xunit;
+
+namespace NBitcoin.Tests.PropertyTest
+{
+  public class ExtKeyTest
+  {
+    public ExtKeyTest()
+    {
+      Arb.Register<CryptoGenerator>();
+      Arb.Register<ChainParamsGenerator>();
+    }
+
+    [Property]
+    [Trait("PropertyTest", "Immutability")]
+    public void ShouldNotChangeByCloneOrConstructor(ExtKey key)
+    {
+      Assert.Equal(key.Clone(), new ExtKey(key.Neuter(), key.PrivateKey));
+    }
+
+    [Property]
+    [Trait("PropertyTest", "BidirectionalConversion")]
+    public void ShouldRecoverNeuteredParentKeyIfNotHardened(ExtKey key, uint index)
+    {
+      var child = key.Derive((int)index, false);
+      Assert.Equal(child.Child, index);
+
+      Assert.Equal(key, child.GetParentExtKey(key.Neuter()));
+    }
+  }
+}

--- a/NBitcoin.Tests/PropertyTest/KeyTest.cs
+++ b/NBitcoin.Tests/PropertyTest/KeyTest.cs
@@ -3,6 +3,8 @@ using FsCheck.Xunit;
 using NBitcoin.Tests.Generators;
 using NBitcoin;
 using Xunit;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace NBitcoin.Tests.PropertyTest
 {
@@ -22,5 +24,13 @@ namespace NBitcoin.Tests.PropertyTest
       string wif = new BitcoinSecret(key, network).ToWif();
       return Key.Parse(wif, network).Equals(key);
     }
+
+    [Property(MaxTest = 10)]
+    [Trait("PropertyTest", "Verification")]
+    public bool ShouldNotGenerateSameKey(List<Key> keys)
+    {
+      return keys.Distinct().Count() == keys.Count();
+    }
+
   }
 }

--- a/NBitcoin.Tests/PropertyTest/LegacyTransactionTest.cs
+++ b/NBitcoin.Tests/PropertyTest/LegacyTransactionTest.cs
@@ -16,7 +16,7 @@ namespace NBitcoin.Tests.PropertyTest
       Arb.Register<LegacyTransactionGenerators>();
     }
 
-    [Property(MaxTest = 10)]
+    [Property(MaxTest = 100)]
     [Trait("PropertyTest", "BidirectionalConversion")]
     public bool CanConvertToRaw(Tuple<Transaction, Network> param)
     {
@@ -26,7 +26,7 @@ namespace NBitcoin.Tests.PropertyTest
 
       return tx.GetHash() == tx.GetHash();
     }
-    [Property(MaxTest = 10)]
+    [Property(MaxTest = 100)]
     [Trait("PropertyTest", "Commutativity")]
     public bool TxIdMustMatchHexSha256(Transaction tx)
     {

--- a/NBitcoin.Tests/PropertyTest/SegwitTransactionTest.cs
+++ b/NBitcoin.Tests/PropertyTest/SegwitTransactionTest.cs
@@ -14,7 +14,7 @@ namespace NBitcoin.Tests.PropertyTest
       Arb.Register<SegwitTransactionGenerators>();
     }
 
-    [Property(MaxTest = 10)]
+    [Property(MaxTest = 100)]
     [Trait("PropertyTest", "BidirectionalConversion")]
     [Trait("PropertyTest", "Commutativity")]
     public void WitnessTxIdProp(Tuple<Transaction, Network> testcase)

--- a/NBitcoin/BIP32/ExtKey.cs
+++ b/NBitcoin/BIP32/ExtKey.cs
@@ -9,7 +9,7 @@ namespace NBitcoin
 	/// <summary>
 	/// A private Hierarchical Deterministic key
 	/// </summary>
-	public class ExtKey : IBitcoinSerializable, IDestination, ISecret
+	public class ExtKey : IBitcoinSerializable, IDestination, ISecret, IEquatable<ExtKey>
 	{
 		/// <summary>
 		/// Parses the Base58 data (checking the network if specified), checks it represents the
@@ -366,5 +366,13 @@ namespace NBitcoin
 			return parentExtKey;
 		}
 
+    public bool Equals(ExtKey other)
+		{
+			return nChild == other.nChild && 
+			  nDepth == other.nDepth &&
+			  vchChainCode.SequenceEqual(other.vchChainCode) &&
+			  vchFingerprint.SequenceEqual(other.vchFingerprint) &&
+			  key.Equals(other.key);
+		}
 	}
 }


### PR DESCRIPTION
* Genrate `SIGHASH_ANYONECANPAY` sighash properly
* do not compute actual hash when genrating uint256 and u160
 * ~This was what causing error in SegwitTransaction property tests. (It seems some there were some odd behavior when pubkey in multisig scripts were exactly the same, which don't need any fix since it doesn't happen in the real world)~ I was wrong, It was simply because WitScript was empty, so revert to what you did before.
* run 100 tests as usual for tx property based tests.