### PR TITLE
Fix bug in `PaytoWitPubkeyHashTemplate.ExtractWitScriptParamters`

### DIFF
--- a/NBitcoin.Tests/script_tests.cs
+++ b/NBitcoin.Tests/script_tests.cs
@@ -1014,6 +1014,11 @@ namespace NBitcoin.Tests
 			});
 			Assert.Equal(expected, actual);
 
+			var witScriptWithoutSig = PayToWitPubKeyHashTemplate.Instance.GenerateWitScript(null, pubkey);
+			var actualParam = PayToWitPubKeyHashTemplate.Instance.ExtractWitScriptParameters(witScriptWithoutSig);
+			Assert.NotNull(actualParam);
+			Assert.Equal(pubkey, actualParam.PublicKey);
+
 			var scriptSig = new Script("304402206b782f095f52f12133a96c078b558458b84c925afdb620d96c5f5bbf483e28d502206206796ff45d80216b83c77bafc4e7951fdb10a5bf3e4041c0e6c0938079b22b01 2103");
 			var redeem = new Script(Encoders.Hex.DecodeData("2103a65786c1a48d4167aca08cf6eb8eed081e13f45c02dc6000fd8f3bb16242579aac"));
 			expected = new WitScript(new Script("304402206b782f095f52f12133a96c078b558458b84c925afdb620d96c5f5bbf483e28d502206206796ff45d80216b83c77bafc4e7951fdb10a5bf3e4041c0e6c0938079b22b01 2103 2103a65786c1a48d4167aca08cf6eb8eed081e13f45c02dc6000fd8f3bb16242579aac"));

--- a/NBitcoin.Tests/script_tests.cs
+++ b/NBitcoin.Tests/script_tests.cs
@@ -1014,10 +1014,16 @@ namespace NBitcoin.Tests
 			});
 			Assert.Equal(expected, actual);
 
+			// should be able to parse if signature is empty in p2wpkh.
 			var witScriptWithoutSig = PayToWitPubKeyHashTemplate.Instance.GenerateWitScript(null, pubkey);
 			var actualParam = PayToWitPubKeyHashTemplate.Instance.ExtractWitScriptParameters(witScriptWithoutSig);
 			Assert.NotNull(actualParam);
 			Assert.Equal(pubkey, actualParam.PublicKey);
+
+			var script = new Script("0 03a65786c1a48d4167aca08cf6eb8eed081e13f45c02dc6000fd8f3bb16242579a").ToWitScript();
+			var actualParam2 = PayToWitPubKeyHashTemplate.Instance.ExtractWitScriptParameters(script);
+			Assert.NotNull(actualParam2);
+			Assert.Equal(pubkey, actualParam2.PublicKey);
 
 			var scriptSig = new Script("304402206b782f095f52f12133a96c078b558458b84c925afdb620d96c5f5bbf483e28d502206206796ff45d80216b83c77bafc4e7951fdb10a5bf3e4041c0e6c0938079b22b01 2103");
 			var redeem = new Script(Encoders.Hex.DecodeData("2103a65786c1a48d4167aca08cf6eb8eed081e13f45c02dc6000fd8f3bb16242579aac"));

--- a/NBitcoin/Script.cs
+++ b/NBitcoin/Script.cs
@@ -834,6 +834,8 @@ namespace NBitcoin
 			return @unsafe ? _Script : _Script.ToArray();
 		}
 
+		public WitScript ToWitScript() => new WitScript(this);
+
 		public byte[] ToCompressedBytes()
 		{
 			var compressor = new ScriptCompressor(this);

--- a/NBitcoin/StandardScriptTemplate.cs
+++ b/NBitcoin/StandardScriptTemplate.cs
@@ -836,7 +836,7 @@ namespace NBitcoin
 			{
 				return new PayToWitPubkeyHashScriptSigParameters()
 				{
-					TransactionSignature = (witScript[0].Length == 1 && witScript[0][0] == 0) ? null : new TransactionSignature(witScript[0]),
+					TransactionSignature = (witScript[0].Length == 0) ? null : new TransactionSignature(witScript[0]),
 					PublicKey = new PubKey(witScript[1], true),
 				};
 			}
@@ -849,7 +849,7 @@ namespace NBitcoin
 		private bool CheckWitScriptCore(WitScript witScript)
 		{
 			return witScript.PushCount == 2 &&
-				   ((witScript[0].Length == 1 && witScript[0][0] == 0) || (TransactionSignature.IsValid(witScript[0], ScriptVerify.None))) &&
+				   ((witScript[0].Length == 0) || (TransactionSignature.IsValid(witScript[0], ScriptVerify.None))) &&
 				   PubKey.Check(witScript[1], false);
 		}
 


### PR DESCRIPTION
Currently, If a signature is empty in a p2wpkh witness, `ExtractWitScriptParameters` returns null.
This is because in p2wpkh case, "empty signature" is represented by "empty witness item", not by push of 0.
So fix the logic for determining an empty signature.
