### PR TITLE
Add generatetoaddress RPC

### DIFF
--- a/NBitcoin/RPC/RPCCapabilities.cs
+++ b/NBitcoin/RPC/RPCCapabilities.cs
@@ -14,6 +14,7 @@ namespace NBitcoin.RPC
 		public bool SupportScanUTXOSet { get; set; }
 		public bool SupportGetNetworkInfo { get; set; }
 		public bool SupportEstimateSmartFee { get; set; }
+		public bool SupportGenerateToAddress { get; set; }
 
 		public RPCCapabilities Clone(int newVersion)
 		{
@@ -24,7 +25,8 @@ namespace NBitcoin.RPC
 				SupportSegwit = SupportSegwit,
 				SupportSignRawTransactionWith = SupportSignRawTransactionWith,
 				SupportGetNetworkInfo = SupportGetNetworkInfo,
-				SupportEstimateSmartFee = SupportEstimateSmartFee
+				SupportEstimateSmartFee = SupportEstimateSmartFee,
+				SupportGenerateToAddress = SupportGenerateToAddress
 			};
 		}
 
@@ -35,7 +37,8 @@ namespace NBitcoin.RPC
 				$"SupportSegwit: {SupportSegwit}{Environment.NewLine}" +
 				$"SupportSignRawTransactionWith: {SupportSignRawTransactionWith}{Environment.NewLine}" +
 				$"SupportGetNetworkInfo: {SupportGetNetworkInfo}{Environment.NewLine}" +
-				$"SupportEstimateSmartFee: {SupportEstimateSmartFee}{Environment.NewLine}";
+				$"SupportEstimateSmartFee: {SupportEstimateSmartFee}{Environment.NewLine}" +
+				$"SupportGenerateToAddress: {SupportGenerateToAddress}{Environment.NewLine}";
 		}
 	}
 }

--- a/NBitcoin/RPC/RPCOperations.cs
+++ b/NBitcoin/RPC/RPCOperations.cs
@@ -25,6 +25,7 @@ namespace NBitcoin.RPC
 		getgenerate,
 		setgenerate,
 		generate,
+		generatetoaddress,
 		getnetworkhashps,
 		gethashespersec,
 		getmininginfo,


### PR DESCRIPTION
This PR adds `GenerateToAddress` and `GenerateToAddressAsync` new methods. Also add this to the RPCCapabilities scan and uses the new methods by default when call the soon-to-be-deprecated `Generate` rpc method.

Closes #572