### PR TITLE
Update fixing some spelling and typos. Conservative changes, done mai…

### DIFF
--- a/NBitcoin.Altcoins/BCash.cs
+++ b/NBitcoin.Altcoins/BCash.cs
@@ -817,7 +817,7 @@ namespace BCashAddr
 		}
 
 		/// <summary>
-		/// Converts an array of 8-bit integers into an array of 5-bit integers, right-padding with zeroes if necessary
+		/// Converts an array of 8-bit integers into an array of 5-bit integers, right-padding with zeros if necessary
 		/// </summary>
 		/// <param name="data"></param>
 		/// <returns></returns>
@@ -828,7 +828,7 @@ namespace BCashAddr
 
 		/// <summary>
 		/// Converts an array of 5-bit integers back into an array of 8-bit integers
-		/// removing extra zeroes left from padding if necessary.
+		/// removing extra zeros left from padding if necessary.
 		/// Throws a ValidationError if input is not a zero-padded array of 8-bit integers
 		/// </summary>
 		/// <param name="data"></param>
@@ -854,9 +854,9 @@ namespace BCashAddr
 		/// <returns></returns>
 		public static byte[] Convert(byte[] data, int from, int to, bool strictMode = false)
 		{
-			Validation.Validate(from > 0, "Invald 'from' parameter");
-			Validation.Validate(to > 0, "Invald 'to' parameter");
-			Validation.Validate(data.Length > 0, "Invald data");
+			Validation.Validate(from > 0, "Invalid 'from' parameter");
+			Validation.Validate(to > 0, "Invalid 'to' parameter");
+			Validation.Validate(data.Length > 0, "Invalid data");
 			var d = data.Length * from / (double)to;
 			var length = strictMode ? (int)Math.Floor(d) : (int)Math.Ceiling(d);
 			var mask = (1 << to) - 1;

--- a/NBitcoin.Altcoins/Groestlcoin.Internals/Digest.cs
+++ b/NBitcoin.Altcoins/Groestlcoin.Internals/Digest.cs
@@ -17,7 +17,7 @@ namespace NBitcoin.Altcoins.GroestlcoinInternals
  * function computation. Data is inserted with {@code update()} calls;
  * the result is obtained from a {@code digest()} method (where some
  * final data can be inserted as well). When a digest output has been
- * produced, the objet is automatically resetted, and can be used
+ * produced, the object is automatically reset, and can be used
  * immediately for another digest operation. The state of a computation
  * can be cloned with the {@link #copy} method; this can be used to get
  * a partial hash result without interrupting the complete
@@ -131,7 +131,7 @@ internal interface Digest {
   void reset();
 
   /**
-   * Clone the current state. The returned object evolves independantly
+   * Clone the current state. The returned object evolves independently
    * of this object.
    *
    * @return  the clone

--- a/NBitcoin.Altcoins/HashX11/Crypto/SHA3/CubeHash.cs
+++ b/NBitcoin.Altcoins/HashX11/Crypto/SHA3/CubeHash.cs
@@ -44,7 +44,7 @@ namespace NBitcoin.Altcoins.HashX11.Crypto.SHA3
         {
             int[] hashes = new int[] { 28, 32, 48, 64 };
             uint[][] inits = new uint[65][];
-            byte[] zeroes = new byte[32];
+            byte[] zeros = new byte[32];
 
             foreach (int hashsize in hashes)
             {
@@ -55,7 +55,7 @@ namespace NBitcoin.Altcoins.HashX11.Crypto.SHA3
                 ch.m_state[2] = 16;
 
                 for (int i = 0; i < 10; i++)
-                    ch.TransformBlock(zeroes, 0);
+                    ch.TransformBlock(zeros, 0);
 
                 inits[hashsize] = new uint[32];
                 Array.Copy(ch.m_state, inits[hashsize], 32);

--- a/NBitcoin.Altcoins/HashX11/Crypto/SHA3/Luffa.cs
+++ b/NBitcoin.Altcoins/HashX11/Crypto/SHA3/Luffa.cs
@@ -57,13 +57,13 @@ namespace NBitcoin.Altcoins.HashX11.Crypto.SHA3
 
         protected override byte[] GetResult()
         {
-            byte[] zeroes = new byte[BlockSize];
+            byte[] zeros = new byte[BlockSize];
             uint[] result = new uint[HashSize / 4];
 
             for (int i = 0; i < HashSize / 4; i++)
             {
                 if (i % 8 == 0)
-                    TransformBlock(zeroes, 0);
+                    TransformBlock(zeros, 0);
 
                 for (int j = 0; j < m_result_blocks; j++)
                     result[i] ^= m_state[(i % 8) + 8 * j];

--- a/NBitcoin.Altcoins/HashX11/Crypto/SHA3/SHAvite3Custom.cs
+++ b/NBitcoin.Altcoins/HashX11/Crypto/SHA3/SHAvite3Custom.cs
@@ -3,8 +3,8 @@ using System;
 namespace NBitcoin.Altcoins.HashX11.Crypto.SHA3.Custom
 {
     // a customized SHAvite implementation to fit the StratisX implementation
-    // only the 512 and 384 hash zizes are supported as only that is used by stratis.
-    // TODO: this codes needs to be tested against the StratisX blockchin data
+    // only the 512 and 384 hash sizes are supported as only that is used by stratis.
+    // TODO: this codes needs to be tested against the StratisX blockchain data
 
     //internal class SHAvite3_224 : SHAvite3_256Base
     //{

--- a/NBitcoin.Altcoins/HashX11/Extensions/ArrayExtensions.cs
+++ b/NBitcoin.Altcoins/HashX11/Extensions/ArrayExtensions.cs
@@ -8,7 +8,7 @@ namespace NBitcoin.Altcoins.HashX11
     internal static class ArrayExtensions
     {
         /// <summary>
-        /// Clear array with zeroes.
+        /// Clear array with zeros.
         /// </summary>
         /// <param name="a_array"></param>
         public static void Clear<T>(this T[] a_array, T a_value = default(T))
@@ -18,7 +18,7 @@ namespace NBitcoin.Altcoins.HashX11
         }
 
         /// <summary>
-        /// Clear array with zeroes.
+        /// Clear array with zeros.
         /// </summary>
         /// <param name="a_array"></param>
         public static void Clear<T>(this T[,] a_array, T a_value = default(T))
@@ -33,7 +33,7 @@ namespace NBitcoin.Altcoins.HashX11
         }
 
         /// <summary>
-        /// Return array stated from a_index and with a_count legth.
+        /// Return array stated from a_index and with a_count length.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="a_array"></param>

--- a/NBitcoin.Tests/Bip158_tests.cs
+++ b/NBitcoin.Tests/Bip158_tests.cs
@@ -71,7 +71,7 @@ namespace NBitcoin.Tests
 				.Build();
 
 			var testKey = key.ToBytes().SafeSubarray(0, 16);
-			// The filter should match all ther values that were added.
+			// The filter should match all the values that were added.
 			foreach (var name in names)
 			{
 				Assert.True(filter.Match(name, testKey));

--- a/NBitcoin.Tests/Generators/LegacyTransactionGenerators.cs
+++ b/NBitcoin.Tests/Generators/LegacyTransactionGenerators.cs
@@ -51,7 +51,7 @@ namespace NBitcoin.Tests.Generators
 			from locktime in PrimitiveGenerator.UInt32()
 			select ComposeTx(Transaction.Create(network), txin, txout, locktime);
 
-		// We need this since Tranaction is mutable.
+		// We need this since Transaction is mutable.
 		public static Transaction ComposeTx(Transaction tx, List<TxIn> inputs, List<TxOut> outputs, uint locktime)
 		{
 			tx.Inputs.AddRange(inputs);

--- a/NBitcoin.Tests/transaction_tests.cs
+++ b/NBitcoin.Tests/transaction_tests.cs
@@ -306,7 +306,7 @@ namespace NBitcoin.Tests
 				//Nobody knows your redeem script, so you add here the information
 				//This line is actually optional since 4.0.0.38, as the TransactionBuilder is smart enough to figure out
 				//the redeems from the keys added by AddKeys.
-				//However, explicitely having the redeem will make code more easy to update to other payment like 2-2
+				//However, explicitly having the redeem will make code more easy to update to other payment like 2-2
 				//.Select(c => c.ToScriptCoin(k.PubKey.WitHash.ScriptPubKey))
 				.ToArray();
 
@@ -1571,7 +1571,7 @@ namespace NBitcoin.Tests
 
 		[Fact]
 		[Trait("UnitTest", "UnitTest")]
-		public void CanSubstractFees()
+		public void CanSubtractFees()
 		{
 			var alice = new Key();
 			var bob = new Key();
@@ -1741,7 +1741,7 @@ namespace NBitcoin.Tests
 				.SignTransaction(partiallySigned);
 			Assert.True(txBuilder.Verify(tx));
 
-			//Test if signing separatly
+			//Test if signing separately
 			txBuilder = Network.CreateTransactionBuilder(0);
 			txBuilder.StandardTransactionPolicy = EasyPolicy;
 			tx = txBuilder

--- a/NBitcoin/BIP158/GolombRiceFilter.cs
+++ b/NBitcoin/BIP158/GolombRiceFilter.cs
@@ -267,7 +267,7 @@ namespace NBitcoin
 		private HashSet<byte[]> _values;
 		
 		/// <summary>
-		/// Helper class for making sure not two ideantical data elements are 
+		/// Helper class for making sure not two identical data elements are 
 		/// included in a filter.
 		/// </summary>
 		class ByteArrayComparer : IEqualityComparer<byte[]> {

--- a/NBitcoin/BIP32/KeyPath.cs
+++ b/NBitcoin/BIP32/KeyPath.cs
@@ -160,7 +160,7 @@ namespace NBitcoin
 			get
 			{
 				if(_Indexes.Length == 0)
-					throw new InvalidOperationException("No indice found in this KeyPath");
+					throw new InvalidOperationException("No index found in this KeyPath");
 				return (_Indexes[_Indexes.Length - 1] & 0x80000000u) != 0;
 			}
 		}

--- a/NBitcoin/BitcoinAddress.cs
+++ b/NBitcoin/BitcoinAddress.cs
@@ -5,7 +5,7 @@ using System.Linq;
 namespace NBitcoin
 {
 	/// <summary>
-	/// Base58 representaiton of a script hash
+	/// Base58 representation of a script hash
 	/// </summary>
 	public class BitcoinScriptAddress : BitcoinAddress, IBase58Data
 	{

--- a/NBitcoin/BouncyCastle/asn1/DerObjectIdentifier.cs
+++ b/NBitcoin/BouncyCastle/asn1/DerObjectIdentifier.cs
@@ -133,7 +133,7 @@ namespace NBitcoin.BouncyCastle.Asn1
 			{
 				char ch = branchID[pos];
 
-				// TODO Leading zeroes?
+				// TODO Leading zeros?
 				if('0' <= ch && ch <= '9')
 				{
 					periodAllowed = true;

--- a/NBitcoin/BouncyCastle/math/BigInteger.cs
+++ b/NBitcoin/BouncyCastle/math/BigInteger.cs
@@ -1007,10 +1007,10 @@ namespace NBitcoin.BouncyCastle.Math
 				yIndx++;
 			}
 
-			return CompareNoLeadingZeroes(xIndx, x, yIndx, y);
+			return CompareNoLeadingzeros(xIndx, x, yIndx, y);
 		}
 
-		private static int CompareNoLeadingZeroes(
+		private static int CompareNoLeadingzeros(
 			int xIndx,
 			int[] x,
 			int yIndx,
@@ -1043,7 +1043,7 @@ namespace NBitcoin.BouncyCastle.Math
 			return sign < value.sign ? -1
 				: sign > value.sign ? 1
 				: sign == 0 ? 0
-				: sign * CompareNoLeadingZeroes(0, magnitude, 0, value.magnitude);
+				: sign * CompareNoLeadingzeros(0, magnitude, 0, value.magnitude);
 		}
 
 		/**
@@ -1068,7 +1068,7 @@ namespace NBitcoin.BouncyCastle.Math
 
 			Debug.Assert(yStart < y.Length);
 
-			int xyCmp = CompareNoLeadingZeroes(xStart, x, yStart, y);
+			int xyCmp = CompareNoLeadingzeros(xStart, x, yStart, y);
 			int[] count;
 
 			if(xyCmp > 0)
@@ -1106,7 +1106,7 @@ namespace NBitcoin.BouncyCastle.Math
 				for(;;)
 				{
 					if(cBitLength < xBitLength
-						|| CompareNoLeadingZeroes(xStart, x, cStart, c) >= 0)
+						|| CompareNoLeadingzeros(xStart, x, cStart, c) >= 0)
 					{
 						Subtract(xStart, x, cStart, c);
 						AddMagnitudes(count, iCount);
@@ -1125,7 +1125,7 @@ namespace NBitcoin.BouncyCastle.Math
 							if(xBitLength < yBitLength)
 								return count;
 
-							xyCmp = CompareNoLeadingZeroes(xStart, x, yStart, y);
+							xyCmp = CompareNoLeadingzeros(xStart, x, yStart, y);
 
 							if(xyCmp <= 0)
 								break;
@@ -1618,12 +1618,12 @@ namespace NBitcoin.BouncyCastle.Math
 			//				for (;;)
 			//				{
 			//					// While F is even, do F=F/u, C=C*u, k=k+1.
-			//					int zeroes = F.GetLowestSetBit();
-			//					if (zeroes > 0)
+			//					int zeros = F.GetLowestSetBit();
+			//					if (zeros > 0)
 			//					{
-			//						F = F.ShiftRight(zeroes);
-			//						C = C.ShiftLeft(zeroes);
-			//						k += zeroes;
+			//						F = F.ShiftRight(zeros);
+			//						C = C.ShiftLeft(zeros);
+			//						k += zeros;
 			//					}
 			//
 			//					// If F = 1, then return B,k.
@@ -1849,13 +1849,13 @@ namespace NBitcoin.BouncyCastle.Math
 			Debug.Assert(windowList.Length > 0);
 
 			int window = windowList[0];
-			int mult = window & 0xFF, lastZeroes = window >> 8;
+			int mult = window & 0xFF, lastzeros = window >> 8;
 
 			BigInteger y;
 			if(mult == 1)
 			{
 				y = b2;
-				--lastZeroes;
+				--lastzeros;
 			}
 			else
 			{
@@ -1867,7 +1867,7 @@ namespace NBitcoin.BouncyCastle.Math
 			{
 				mult = window & 0xFF;
 
-				int bits = lastZeroes + BitLengthTable[mult];
+				int bits = lastzeros + BitLengthTable[mult];
 				for(int j = 0; j < bits; ++j)
 				{
 					y = ReduceBarrett(y.Square(), m, mr, yu);
@@ -1875,10 +1875,10 @@ namespace NBitcoin.BouncyCastle.Math
 
 				y = ReduceBarrett(y.Multiply(oddPowers[mult >> 1]), m, mr, yu);
 
-				lastZeroes = window >> 8;
+				lastzeros = window >> 8;
 			}
 
-			for(int i = 0; i < lastZeroes; ++i)
+			for(int i = 0; i < lastzeros; ++i)
 			{
 				y = ReduceBarrett(y.Square(), m, mr, yu);
 			}
@@ -1974,13 +1974,13 @@ namespace NBitcoin.BouncyCastle.Math
 			Debug.Assert(windowList.Length > 1);
 
 			int window = windowList[0];
-			int mult = window & 0xFF, lastZeroes = window >> 8;
+			int mult = window & 0xFF, lastzeros = window >> 8;
 
 			int[] yVal;
 			if(mult == 1)
 			{
 				yVal = zSquared;
-				--lastZeroes;
+				--lastzeros;
 			}
 			else
 			{
@@ -1992,7 +1992,7 @@ namespace NBitcoin.BouncyCastle.Math
 			{
 				mult = window & 0xFF;
 
-				int bits = lastZeroes + BitLengthTable[mult];
+				int bits = lastzeros + BitLengthTable[mult];
 				for(int j = 0; j < bits; ++j)
 				{
 					SquareMonty(yAccum, yVal, m.magnitude, mDash, smallMontyModulus);
@@ -2000,10 +2000,10 @@ namespace NBitcoin.BouncyCastle.Math
 
 				MultiplyMonty(yAccum, yVal, oddPowers[mult >> 1], m.magnitude, mDash, smallMontyModulus);
 
-				lastZeroes = window >> 8;
+				lastzeros = window >> 8;
 			}
 
-			for(int i = 0; i < lastZeroes; ++i)
+			for(int i = 0; i < lastzeros; ++i)
 			{
 				SquareMonty(yAccum, yVal, m.magnitude, mDash, smallMontyModulus);
 			}
@@ -2036,7 +2036,7 @@ namespace NBitcoin.BouncyCastle.Math
 			v <<= bitPos;
 
 			int mult = 1, multLimit = 1 << extraBits;
-			int zeroes = 0;
+			int zeros = 0;
 
 			int i = 0;
 			for(;;)
@@ -2049,13 +2049,13 @@ namespace NBitcoin.BouncyCastle.Math
 					}
 					else if(v < 0)
 					{
-						result[resultPos++] = CreateWindowEntry(mult, zeroes);
+						result[resultPos++] = CreateWindowEntry(mult, zeros);
 						mult = 1;
-						zeroes = 0;
+						zeros = 0;
 					}
 					else
 					{
-						++zeroes;
+						++zeros;
 					}
 
 					v <<= 1;
@@ -2063,7 +2063,7 @@ namespace NBitcoin.BouncyCastle.Math
 
 				if(++i == mag.Length)
 				{
-					result[resultPos++] = CreateWindowEntry(mult, zeroes);
+					result[resultPos++] = CreateWindowEntry(mult, zeros);
 					break;
 				}
 
@@ -2075,15 +2075,15 @@ namespace NBitcoin.BouncyCastle.Math
 			return result;
 		}
 
-		private static int CreateWindowEntry(int mult, int zeroes)
+		private static int CreateWindowEntry(int mult, int zeros)
 		{
 			while((mult & 1) == 0)
 			{
 				mult >>= 1;
-				++zeroes;
+				++zeros;
 			}
 
-			return mult | (zeroes << 8);
+			return mult | (zeros << 8);
 		}
 
 		/**
@@ -2606,7 +2606,7 @@ namespace NBitcoin.BouncyCastle.Math
 
 			Debug.Assert(yStart < y.Length);
 
-			int xyCmp = CompareNoLeadingZeroes(xStart, x, yStart, y);
+			int xyCmp = CompareNoLeadingzeros(xStart, x, yStart, y);
 
 			if(xyCmp > 0)
 			{
@@ -2633,7 +2633,7 @@ namespace NBitcoin.BouncyCastle.Math
 				for(;;)
 				{
 					if(cBitLength < xBitLength
-						|| CompareNoLeadingZeroes(xStart, x, cStart, c) >= 0)
+						|| CompareNoLeadingzeros(xStart, x, cStart, c) >= 0)
 					{
 						Subtract(xStart, x, cStart, c);
 
@@ -2651,7 +2651,7 @@ namespace NBitcoin.BouncyCastle.Math
 							if(xBitLength < yBitLength)
 								return x;
 
-							xyCmp = CompareNoLeadingZeroes(xStart, x, yStart, y);
+							xyCmp = CompareNoLeadingzeros(xStart, x, yStart, y);
 
 							if(xyCmp <= 0)
 								break;
@@ -2724,7 +2724,7 @@ namespace NBitcoin.BouncyCastle.Math
 				}
 			}
 
-			if(CompareNoLeadingZeroes(0, magnitude, 0, n.magnitude) < 0)
+			if(CompareNoLeadingzeros(0, magnitude, 0, n.magnitude) < 0)
 				return this;
 
 			int[] result;
@@ -3044,7 +3044,7 @@ namespace NBitcoin.BouncyCastle.Math
 			if(this.sign != n.sign)
 				return Add(n.Negate());
 
-			int compare = CompareNoLeadingZeroes(0, magnitude, 0, n.magnitude);
+			int compare = CompareNoLeadingzeros(0, magnitude, 0, n.magnitude);
 			if(compare == 0)
 				return Zero;
 

--- a/NBitcoin/BouncyCastle/math/ec/ECAlgorithms.cs
+++ b/NBitcoin/BouncyCastle/math/ec/ECAlgorithms.cs
@@ -301,7 +301,7 @@ namespace NBitcoin.BouncyCastle.Math.EC
 			ECPoint infinity = curve.Infinity;
 
 			ECPoint R = infinity;
-			int zeroes = 0;
+			int zeros = 0;
 
 			for(int i = len - 1; i >= 0; --i)
 			{
@@ -310,7 +310,7 @@ namespace NBitcoin.BouncyCastle.Math.EC
 
 				if((wiP | wiQ) == 0)
 				{
-					++zeroes;
+					++zeros;
 					continue;
 				}
 
@@ -328,18 +328,18 @@ namespace NBitcoin.BouncyCastle.Math.EC
 					r = r.Add(tableQ[nQ >> 1]);
 				}
 
-				if(zeroes > 0)
+				if(zeros > 0)
 				{
-					R = R.TimesPow2(zeroes);
-					zeroes = 0;
+					R = R.TimesPow2(zeros);
+					zeros = 0;
 				}
 
 				R = R.TwicePlus(r);
 			}
 
-			if(zeroes > 0)
+			if(zeros > 0)
 			{
-				R = R.TimesPow2(zeroes);
+				R = R.TimesPow2(zeros);
 			}
 
 			return R;
@@ -440,7 +440,7 @@ namespace NBitcoin.BouncyCastle.Math.EC
 			ECPoint infinity = curve.Infinity;
 
 			ECPoint R = infinity;
-			int zeroes = 0;
+			int zeros = 0;
 
 			for(int i = len - 1; i >= 0; --i)
 			{
@@ -461,22 +461,22 @@ namespace NBitcoin.BouncyCastle.Math.EC
 
 				if(r == infinity)
 				{
-					++zeroes;
+					++zeros;
 					continue;
 				}
 
-				if(zeroes > 0)
+				if(zeros > 0)
 				{
-					R = R.TimesPow2(zeroes);
-					zeroes = 0;
+					R = R.TimesPow2(zeros);
+					zeros = 0;
 				}
 
 				R = R.TwicePlus(r);
 			}
 
-			if(zeroes > 0)
+			if(zeros > 0)
 			{
-				R = R.TimesPow2(zeroes);
+				R = R.TimesPow2(zeros);
 			}
 
 			return R;

--- a/NBitcoin/BouncyCastle/math/ec/ECCurve.cs
+++ b/NBitcoin/BouncyCastle/math/ec/ECCurve.cs
@@ -793,7 +793,7 @@ namespace NBitcoin.BouncyCastle.Math.EC
          * D.1.6) The other solution is <code>z + 1</code>.
          *
          * @param beta
-         *            The value to solve the qradratic equation for.
+         *            The value to solve the quadratic equation for.
          * @return the solution for <code>z<sup>2</sup> + z = beta</code> or
          *         <code>null</code> if no solution exists.
          */

--- a/NBitcoin/BouncyCastle/math/ec/LongArray.cs
+++ b/NBitcoin/BouncyCastle/math/ec/LongArray.cs
@@ -269,7 +269,7 @@ namespace NBitcoin.BouncyCastle.Math.EC
 		};
 
 		// For toString(); must have length 64
-		private const string ZEROES = "0000000000000000000000000000000000000000000000000000000000000000";
+		private const string ZEROS = "0000000000000000000000000000000000000000000000000000000000000000";
 
 		internal static readonly byte[] BitLengths =
 		{
@@ -1248,7 +1248,7 @@ namespace NBitcoin.BouncyCastle.Math.EC
 				}
 				cTotal += cLen;
 			}
-			// NOTE: Provide a safe dump for "high zeroes" since we are adding 'bMax' and not 'bLen'
+			// NOTE: Provide a safe dump for "high zeros" since we are adding 'bMax' and not 'bLen'
 			++cTotal;
 
 			long[] c = new long[cTotal];
@@ -2204,11 +2204,11 @@ namespace NBitcoin.BouncyCastle.Math.EC
 			{
 				string s = Convert.ToString(m_ints[i], 2);
 
-				// Add leading zeroes, except for highest significant word
+				// Add leading zeros, except for highest significant word
 				int len = s.Length;
 				if(len < 64)
 				{
-					sb.Append(ZEROES.Substring(len));
+					sb.Append(ZEROS.Substring(len));
 				}
 
 				sb.Append(s);

--- a/NBitcoin/BouncyCastle/math/ec/abc/SimpleBigDecimal.cs
+++ b/NBitcoin/BouncyCastle/math/ec/abc/SimpleBigDecimal.cs
@@ -208,14 +208,14 @@ namespace NBitcoin.BouncyCastle.Math.EC.Abc
 			char[] fractCharArr = new char[scale];
 			string fractStr = fract.ToString(2);
 			int fractLen = fractStr.Length;
-			int zeroes = scale - fractLen;
-			for(int i = 0; i < zeroes; i++)
+			int zeros = scale - fractLen;
+			for(int i = 0; i < zeros; i++)
 			{
 				fractCharArr[i] = '0';
 			}
 			for(int j = 0; j < fractLen; j++)
 			{
-				fractCharArr[zeroes + j] = fractStr[j];
+				fractCharArr[zeros + j] = fractStr[j];
 			}
 			string rightOfPoint = new string(fractCharArr);
 

--- a/NBitcoin/BouncyCastle/math/ec/custom/sec/SecP256K1Point.cs
+++ b/NBitcoin/BouncyCastle/math/ec/custom/sec/SecP256K1Point.cs
@@ -25,7 +25,7 @@ namespace NBitcoin.BouncyCastle.Math.EC.Custom.Sec
 		}
 
 		/**
-         * Create a point that encodes with or without point compresion.
+         * Create a point that encodes with or without point compression.
          * 
          * @param curve
          *            the curve to use

--- a/NBitcoin/BouncyCastle/math/ec/multiplier/WNafL2RMultiplier.cs
+++ b/NBitcoin/BouncyCastle/math/ec/multiplier/WNafL2RMultiplier.cs
@@ -36,7 +36,7 @@ namespace NBitcoin.BouncyCastle.Math.EC.Multiplier
 			if(i > 1)
 			{
 				int wi = wnaf[--i];
-				int digit = wi >> 16, zeroes = wi & 0xFFFF;
+				int digit = wi >> 16, zeros = wi & 0xFFFF;
 
 				int n = System.Math.Abs(digit);
 				ECPoint[] table = digit < 0 ? preCompNeg : preComp;
@@ -54,27 +54,27 @@ namespace NBitcoin.BouncyCastle.Math.EC.Multiplier
 					int i2 = (lowBits << scale) + 1;
 					R = table[i1 >> 1].Add(table[i2 >> 1]);
 
-					zeroes -= scale;
+					zeros -= scale;
 				}
 				else
 				{
 					R = table[n >> 1];
 				}
 
-				R = R.TimesPow2(zeroes);
+				R = R.TimesPow2(zeros);
 			}
 
 			while(i > 0)
 			{
 				int wi = wnaf[--i];
-				int digit = wi >> 16, zeroes = wi & 0xFFFF;
+				int digit = wi >> 16, zeros = wi & 0xFFFF;
 
 				int n = System.Math.Abs(digit);
 				ECPoint[] table = digit < 0 ? preCompNeg : preComp;
 				ECPoint r = table[n >> 1];
 
 				R = R.TwicePlus(r);
-				R = R.TimesPow2(zeroes);
+				R = R.TimesPow2(zeros);
 			}
 
 			return R;

--- a/NBitcoin/BouncyCastle/math/ec/multiplier/WNafUtilities.cs
+++ b/NBitcoin/BouncyCastle/math/ec/multiplier/WNafUtilities.cs
@@ -26,22 +26,22 @@ namespace NBitcoin.BouncyCastle.Math.EC.Multiplier
 
 			BigInteger diff = _3k.Xor(k);
 
-			int highBit = bits - 1, length = 0, zeroes = 0;
+			int highBit = bits - 1, length = 0, zeros = 0;
 			for(int i = 1; i < highBit; ++i)
 			{
 				if(!diff.TestBit(i))
 				{
-					++zeroes;
+					++zeros;
 					continue;
 				}
 
 				int digit = k.TestBit(i) ? -1 : 1;
-				naf[length++] = (digit << 16) | zeroes;
-				zeroes = 1;
+				naf[length++] = (digit << 16) | zeros;
+				zeros = 1;
 				++i;
 			}
 
-			naf[length++] = (1 << 16) | zeroes;
+			naf[length++] = (1 << 16) | zeros;
 
 			if(naf.Length > length)
 			{
@@ -97,8 +97,8 @@ namespace NBitcoin.BouncyCastle.Math.EC.Multiplier
 					digit -= pow2;
 				}
 
-				int zeroes = length > 0 ? pos - 1 : pos;
-				wnaf[length++] = (digit << 16) | zeroes;
+				int zeros = length > 0 ? pos - 1 : pos;
+				wnaf[length++] = (digit << 16) | zeros;
 				pos = width;
 			}
 

--- a/NBitcoin/BouncyCastle/math/raw/Mod.cs
+++ b/NBitcoin/BouncyCastle/math/raw/Mod.cs
@@ -143,11 +143,11 @@ namespace NBitcoin.BouncyCastle.Math.Raw
 			}
 
 			{
-				int zeroes = GetTrailingZeroes(u[0]);
-				if(zeroes > 0)
+				int zeros = GetTrailingzeros(u[0]);
+				if(zeros > 0)
 				{
-					Nat.ShiftDownBits(uLen, u, zeroes, 0);
-					count += zeroes;
+					Nat.ShiftDownBits(uLen, u, zeros, 0);
+					count += zeros;
 				}
 			}
 
@@ -170,7 +170,7 @@ namespace NBitcoin.BouncyCastle.Math.Raw
 			}
 		}
 
-		private static int GetTrailingZeroes(uint x)
+		private static int GetTrailingzeros(uint x)
 		{
 			Debug.Assert(x != 0);
 			int count = 0;

--- a/NBitcoin/BouncyCastle/util/Arrays.cs
+++ b/NBitcoin/BouncyCastle/util/Arrays.cs
@@ -494,7 +494,7 @@ namespace NBitcoin.BouncyCastle.Utilities
 		/**
          * Make a copy of a range of bytes from the passed in data array. The range can
          * extend beyond the end of the input array, in which case the return array will
-         * be padded with zeroes.
+         * be padded with zeros.
          *
          * @param data the array from which the data is to be copied.
          * @param from the start index at which the copying should take place.

--- a/NBitcoin/BouncyCastle/util/BigIntegers.cs
+++ b/NBitcoin/BouncyCastle/util/BigIntegers.cs
@@ -29,7 +29,7 @@ namespace NBitcoin.BouncyCastle.Utilities
          *
          * @param length desired length of result array.
          * @param n value to be converted.
-         * @return a byte array of specified length, with leading zeroes as necessary given the size of n.
+         * @return a byte array of specified length, with leading zeros as necessary given the size of n.
          */
 		public static byte[] AsUnsignedByteArray(int length, BigInteger n)
 		{

--- a/NBitcoin/ConcurrentChain.cs
+++ b/NBitcoin/ConcurrentChain.cs
@@ -31,7 +31,7 @@ namespace NBitcoin
 			internal void AssertCoherent()
 			{
 				if(!SerializePrecomputedBlockHash && !SerializeBlockHeader)
-					throw new InvalidOperationException("The ChainSerializationFormat is invalid, SerializePrecomputedBlockHash or SerializeBlockHeader shoudl be true");
+					throw new InvalidOperationException("The ChainSerializationFormat is invalid, SerializePrecomputedBlockHash or SerializeBlockHeader should be true");
 			}
 		}
 		Dictionary<uint256, ChainedBlock> _BlocksById = new Dictionary<uint256, ChainedBlock>();

--- a/NBitcoin/DataEncoders/Base58Encoder.cs
+++ b/NBitcoin/DataEncoders/Base58Encoder.cs
@@ -108,7 +108,7 @@ namespace NBitcoin.DataEncoders
 				builder.Append(pszBase58[c]);
 			}
 
-			// Leading zeroes encoded as base58 zeros
+			// Leading zeros encoded as base58 zeros
 			for(int i = offset; i < offset + count && data[i] == 0; i++)
 				builder.Append(pszBase58[0]);
 

--- a/NBitcoin/DataEncoders/Bech32Encoder.cs
+++ b/NBitcoin/DataEncoders/Bech32Encoder.cs
@@ -405,7 +405,7 @@ namespace NBitcoin.DataEncoders
 			var hrp = Encoders.ASCII.DecodeData(encoded.Substring(0, pos));
 			if(!hrp.SequenceEqual(_Hrp))
 			{
-				throw new FormatException("Mismatching human readeable part");
+				throw new FormatException("Mismatching human readable part");
 			}
 			var data = new byte[encoded.Length - pos - 1];
 			for(int j = 0, i = pos + 1; i < encoded.Length; i++, j++)
@@ -417,7 +417,7 @@ namespace NBitcoin.DataEncoders
 			if(!VerifyChecksum(data, encoded.Length, out error))
 			{
 				if(error.Length == 0)
-					throw new FormatException("Error while veriying Bech32 checksum");
+					throw new FormatException("Error while verifying Bech32 checksum");
 				else
 					throw new Bech32FormatException($"Error in Bech32 string at {String.Join(",", error)}", error);
 			}

--- a/NBitcoin/Money.cs
+++ b/NBitcoin/Money.cs
@@ -199,7 +199,7 @@ namespace NBitcoin
 		/// Get the Money corresponding to the input assetId
 		/// </summary>
 		/// <param name="assetId">The asset id, if null, will assume bitcoin amount</param>
-		/// <returns>Never returns null, eithers the AssetMoney or Money if assetId is null</returns>
+		/// <returns>Never returns null, either the AssetMoney or Money if assetId is null</returns>
 		public IMoney GetAmount(AssetId assetId = null)
 		{
 			if(assetId == null)
@@ -666,7 +666,7 @@ namespace NBitcoin
 		/// Returns a culture invariant string representation of Bitcoin amount
 		/// </summary>
 		/// <param name="fplus">True if show + for a positive amount</param>
-		/// <param name="trimExcessZero">True if trim excess zeroes</param>
+		/// <param name="trimExcessZero">True if trim excess zeros</param>
 		/// <returns></returns>
 		public string ToString(bool fplus, bool trimExcessZero = true)
 		{

--- a/NBitcoin/NetworkStringParser.cs
+++ b/NBitcoin/NetworkStringParser.cs
@@ -9,7 +9,7 @@ namespace NBitcoin
 {
 
 	/// <summary>
-	/// This class provide a hook for additionnal string format in altcoin network
+	/// This class provide a hook for additional string format in altcoin network
 	/// </summary>
     public class NetworkStringParser
     {

--- a/NBitcoin/PartialMerkleTree.cs
+++ b/NBitcoin/PartialMerkleTree.cs
@@ -198,7 +198,7 @@ namespace NBitcoin
 		}
 
 		/// <summary>
-		/// Remove superflous branches
+		/// Remove superfluous branches
 		/// </summary>
 		/// <param name="transaction"></param>
 		/// <returns></returns>

--- a/NBitcoin/Protocol/AddressManager.cs
+++ b/NBitcoin/Protocol/AddressManager.cs
@@ -948,7 +948,7 @@ namespace NBitcoin.Protocol
 		private static void assert(bool value)
 		{
 			if(!value)
-				throw new InvalidOperationException("Bug in AddressManager, should never happen, contact NBitcoin developpers if you see this exception");
+				throw new InvalidOperationException("Bug in AddressManager, should never happen, contact NBitcoin developers if you see this exception");
 		}
 		//! Mark an entry as connection attempted to.
 		public void Attempt(NetworkAddress addr)

--- a/NBitcoin/Protocol/Behaviors/AddressManagerBehavior.cs
+++ b/NBitcoin/Protocol/Behaviors/AddressManagerBehavior.cs
@@ -12,21 +12,21 @@ namespace NBitcoin.Protocol.Behaviors
 	public enum AddressManagerBehaviorMode
 	{
 		/// <summary>
-		/// Do not advertize nor discover new peers
+		/// Do not advertise or discover new peers
 		/// </summary>
 		None = 0,
 		/// <summary>
-		/// Only advertize known peers
+		/// Only advertise known peers
 		/// </summary>
-		Advertize = 1,
+		Advertise = 1,
 		/// <summary>
 		/// Only discover peers
 		/// </summary>
 		Discover = 2,
 		/// <summary>
-		/// Advertize known peer and discover peer
+		/// Advertise known peer and discover peer
 		/// </summary>
-		AdvertizeDiscover = 3,
+		AdvertiseDiscover = 3,
 	}
 
 	/// <summary>
@@ -105,7 +105,7 @@ namespace NBitcoin.Protocol.Behaviors
 			if(manager == null)
 				throw new ArgumentNullException(nameof(manager));
 			_AddressManager = manager;
-			Mode = AddressManagerBehaviorMode.AdvertizeDiscover;
+			Mode = AddressManagerBehaviorMode.AdvertiseDiscover;
 		}
 
 		public AddressManagerBehaviorMode Mode
@@ -136,7 +136,7 @@ namespace NBitcoin.Protocol.Behaviors
 
 		void AttachedNode_MessageReceived(Node node, IncomingMessage message)
 		{
-			if((Mode & AddressManagerBehaviorMode.Advertize) != 0)
+			if((Mode & AddressManagerBehaviorMode.Advertise) != 0)
 			{
 				var getaddr = message.Message.Payload as GetAddrPayload;
 				if(getaddr != null)

--- a/NBitcoin/Protocol/Node.cs
+++ b/NBitcoin/Protocol/Node.cs
@@ -279,7 +279,7 @@ namespace NBitcoin.Protocol
 					_ListenerThreadId = Thread.CurrentThread.ManagedThreadId;
 
 					
-					using (Logs.NodeServer.BeginScope("Thead scope {ThreadId}", _ListenerThreadId))
+					using (Logs.NodeServer.BeginScope("Thread scope {ThreadId}", _ListenerThreadId))
 					{
 						Logs.NodeServer.LogInformation("Start Listening");
 						
@@ -743,7 +743,7 @@ namespace NBitcoin.Protocol
 					_RemoteSocketPort = remoteEndpoint.Port;
 					State = NodeState.Connected;
 					ConnectedAt = DateTimeOffset.UtcNow;
-					Logs.NodeServer.LogInformation("Outbound connection successfull");
+					Logs.NodeServer.LogInformation("Outbound connection successful");
 					if(addrman != null)
 						addrman.Attempt(Peer);
 				}
@@ -844,7 +844,7 @@ namespace NBitcoin.Protocol
 
 		private void InitDefaultBehaviors(NodeConnectionParameters parameters)
 		{
-			Advertize = parameters.Advertize;
+			Advertise = parameters.Advertise;
 			PreferredTransactionOptions = parameters.PreferredTransactionOptions;
 			_Behaviors.DelayAttach = true;
 			foreach(var behavior in parameters.TemplateBehaviors)
@@ -995,9 +995,9 @@ namespace NBitcoin.Protocol
 		}
 
 		/// <summary>
-		/// Send addr unsollicited message of the AddressFrom peer when passing to Handshaked state
+		/// Send addr unsolicited message of the AddressFrom peer when passing to Handshaked state
 		/// </summary>
-		public bool Advertize
+		public bool Advertise
 		{
 			get;
 			set;
@@ -1063,7 +1063,7 @@ namespace NBitcoin.Protocol
 				SendMessageAsync(new VerAckPayload());
 				listener.ReceivePayload<VerAckPayload>(cancellationToken);
 				State = NodeState.HandShaked;
-				if(Advertize && MyVersion.AddressFrom.Address.IsRoutable(true))
+				if(Advertise && MyVersion.AddressFrom.Address.IsRoutable(true))
 				{
 					SendMessageAsync(new AddrPayload(new NetworkAddress(MyVersion.AddressFrom)
 					{
@@ -1352,7 +1352,7 @@ namespace NBitcoin.Protocol
 				return new ChainedBlock[0];
 			var newTip = headers[headers.Count - 1];
 			if(newTip.Height <= oldTip.Height)
-				throw new ProtocolException("No tip should have been recieved older than the local one");
+				throw new ProtocolException("No tip should have been received older than the local one");
 			chain.SetTip(newTip);
 			return headers;
 		}
@@ -1532,7 +1532,7 @@ namespace NBitcoin.Protocol
 		}
 
 		/// <summary>
-		/// Create a listener that will queue messages until diposed
+		/// Create a listener that will queue messages until disposed
 		/// </summary>
 		/// <returns>The listener</returns>
 		/// <exception cref="System.InvalidOperationException">Thrown if used on the listener's thread, as it would result in a deadlock</exception>

--- a/NBitcoin/Protocol/NodeConnectionParameters.cs
+++ b/NBitcoin/Protocol/NodeConnectionParameters.cs
@@ -42,7 +42,7 @@ namespace NBitcoin.Protocol
 			UserAgent = other.UserAgent;
 			AddressFrom = other.AddressFrom;
 			Nonce = other.Nonce;
-			Advertize = other.Advertize;
+			Advertise = other.Advertise;
 			PreferredTransactionOptions = other.PreferredTransactionOptions;
 			foreach(var behavior in other.TemplateBehaviors)
 			{
@@ -51,9 +51,9 @@ namespace NBitcoin.Protocol
 		}
 
 		/// <summary>
-		/// Send addr unsollicited message of the AddressFrom peer when passing to Handshaked state
+		/// Send addr unsolicited message of the AddressFrom peer when passing to Handshaked state
 		/// </summary>
-		public bool Advertize
+		public bool Advertise
 		{
 			get;
 			set;

--- a/NBitcoin/Protocol/Payloads/AddrPayload.cs
+++ b/NBitcoin/Protocol/Payloads/AddrPayload.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 namespace NBitcoin.Protocol
 {
 	/// <summary>
-	/// An available peer address in the bitcoin network is announce (unsollicited or after a getaddr)
+	/// An available peer address in the bitcoin network is announce (unsolicited or after a getaddr)
 	/// </summary>
 	[Payload("addr")]
 	public class AddrPayload : Payload, IBitcoinSerializable

--- a/NBitcoin/TransactionBuilder.cs
+++ b/NBitcoin/TransactionBuilder.cs
@@ -989,7 +989,7 @@ namespace NBitcoin
 		Money _TotalFee = Money.Zero;
 
 		/// <summary>
-		/// Split the estimated fees accross the several groups (separated by Then())
+		/// Split the estimated fees across the several groups (separated by Then())
 		/// </summary>
 		/// <param name="feeRate"></param>
 		/// <returns></returns>


### PR DESCRIPTION
…nly by hand. Two biggest single changes are zeroes -> zeros and advertize -> advertise (the only correct spelling in US and GB English). No changes from US->GB or GB->US.