### PR TITLE
UPDATED: Comments and messages only. Removed all code changes.

### DIFF
--- a/NBitcoin.Altcoins/BCash.cs
+++ b/NBitcoin.Altcoins/BCash.cs
@@ -817,7 +817,7 @@ namespace BCashAddr
 		}
 
 		/// <summary>
-		/// Converts an array of 8-bit integers into an array of 5-bit integers, right-padding with zeroes if necessary
+		/// Converts an array of 8-bit integers into an array of 5-bit integers, right-padding with zeros if necessary
 		/// </summary>
 		/// <param name="data"></param>
 		/// <returns></returns>
@@ -828,7 +828,7 @@ namespace BCashAddr
 
 		/// <summary>
 		/// Converts an array of 5-bit integers back into an array of 8-bit integers
-		/// removing extra zeroes left from padding if necessary.
+		/// removing extra zeros left from padding if necessary.
 		/// Throws a ValidationError if input is not a zero-padded array of 8-bit integers
 		/// </summary>
 		/// <param name="data"></param>
@@ -854,9 +854,9 @@ namespace BCashAddr
 		/// <returns></returns>
 		public static byte[] Convert(byte[] data, int from, int to, bool strictMode = false)
 		{
-			Validation.Validate(from > 0, "Invald 'from' parameter");
-			Validation.Validate(to > 0, "Invald 'to' parameter");
-			Validation.Validate(data.Length > 0, "Invald data");
+			Validation.Validate(from > 0, "Invalid 'from' parameter");
+			Validation.Validate(to > 0, "Invalid 'to' parameter");
+			Validation.Validate(data.Length > 0, "Invalid data");
 			var d = data.Length * from / (double)to;
 			var length = strictMode ? (int)Math.Floor(d) : (int)Math.Ceiling(d);
 			var mask = (1 << to) - 1;

--- a/NBitcoin.Altcoins/Groestlcoin.Internals/Digest.cs
+++ b/NBitcoin.Altcoins/Groestlcoin.Internals/Digest.cs
@@ -17,7 +17,7 @@ namespace NBitcoin.Altcoins.GroestlcoinInternals
  * function computation. Data is inserted with {@code update()} calls;
  * the result is obtained from a {@code digest()} method (where some
  * final data can be inserted as well). When a digest output has been
- * produced, the objet is automatically resetted, and can be used
+ * produced, the object is automatically reset, and can be used
  * immediately for another digest operation. The state of a computation
  * can be cloned with the {@link #copy} method; this can be used to get
  * a partial hash result without interrupting the complete
@@ -131,7 +131,7 @@ internal interface Digest {
   void reset();
 
   /**
-   * Clone the current state. The returned object evolves independantly
+   * Clone the current state. The returned object evolves independently
    * of this object.
    *
    * @return  the clone

--- a/NBitcoin.Altcoins/HashX11/Crypto/SHA3/SHAvite3Custom.cs
+++ b/NBitcoin.Altcoins/HashX11/Crypto/SHA3/SHAvite3Custom.cs
@@ -3,8 +3,8 @@ using System;
 namespace NBitcoin.Altcoins.HashX11.Crypto.SHA3.Custom
 {
     // a customized SHAvite implementation to fit the StratisX implementation
-    // only the 512 and 384 hash zizes are supported as only that is used by stratis.
-    // TODO: this codes needs to be tested against the StratisX blockchin data
+    // only the 512 and 384 hash sizes are supported as only that is used by stratis.
+    // TODO: this codes needs to be tested against the StratisX blockchain data
 
     //internal class SHAvite3_224 : SHAvite3_256Base
     //{

--- a/NBitcoin.Altcoins/HashX11/Extensions/ArrayExtensions.cs
+++ b/NBitcoin.Altcoins/HashX11/Extensions/ArrayExtensions.cs
@@ -8,7 +8,7 @@ namespace NBitcoin.Altcoins.HashX11
     internal static class ArrayExtensions
     {
         /// <summary>
-        /// Clear array with zeroes.
+        /// Clear array with zeros.
         /// </summary>
         /// <param name="a_array"></param>
         public static void Clear<T>(this T[] a_array, T a_value = default(T))
@@ -18,7 +18,7 @@ namespace NBitcoin.Altcoins.HashX11
         }
 
         /// <summary>
-        /// Clear array with zeroes.
+        /// Clear array with zeros.
         /// </summary>
         /// <param name="a_array"></param>
         public static void Clear<T>(this T[,] a_array, T a_value = default(T))
@@ -33,7 +33,7 @@ namespace NBitcoin.Altcoins.HashX11
         }
 
         /// <summary>
-        /// Return array stated from a_index and with a_count legth.
+        /// Return array stated from a_index and with a_count length.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="a_array"></param>

--- a/NBitcoin.Tests/Bip158_tests.cs
+++ b/NBitcoin.Tests/Bip158_tests.cs
@@ -71,7 +71,7 @@ namespace NBitcoin.Tests
 				.Build();
 
 			var testKey = key.ToBytes().SafeSubarray(0, 16);
-			// The filter should match all ther values that were added.
+			// The filter should match all the values that were added.
 			foreach (var name in names)
 			{
 				Assert.True(filter.Match(name, testKey));

--- a/NBitcoin.Tests/Generators/LegacyTransactionGenerators.cs
+++ b/NBitcoin.Tests/Generators/LegacyTransactionGenerators.cs
@@ -51,7 +51,7 @@ namespace NBitcoin.Tests.Generators
 			from locktime in PrimitiveGenerator.UInt32()
 			select ComposeTx(Transaction.Create(network), txin, txout, locktime);
 
-		// We need this since Tranaction is mutable.
+		// We need this since Transaction is mutable.
 		public static Transaction ComposeTx(Transaction tx, List<TxIn> inputs, List<TxOut> outputs, uint locktime)
 		{
 			tx.Inputs.AddRange(inputs);

--- a/NBitcoin.Tests/transaction_tests.cs
+++ b/NBitcoin.Tests/transaction_tests.cs
@@ -306,7 +306,7 @@ namespace NBitcoin.Tests
 				//Nobody knows your redeem script, so you add here the information
 				//This line is actually optional since 4.0.0.38, as the TransactionBuilder is smart enough to figure out
 				//the redeems from the keys added by AddKeys.
-				//However, explicitely having the redeem will make code more easy to update to other payment like 2-2
+				//However, explicitly having the redeem will make code more easy to update to other payment like 2-2
 				//.Select(c => c.ToScriptCoin(k.PubKey.WitHash.ScriptPubKey))
 				.ToArray();
 
@@ -1741,7 +1741,7 @@ namespace NBitcoin.Tests
 				.SignTransaction(partiallySigned);
 			Assert.True(txBuilder.Verify(tx));
 
-			//Test if signing separatly
+			//Test if signing separately
 			txBuilder = Network.CreateTransactionBuilder(0);
 			txBuilder.StandardTransactionPolicy = EasyPolicy;
 			tx = txBuilder

--- a/NBitcoin/BIP158/GolombRiceFilter.cs
+++ b/NBitcoin/BIP158/GolombRiceFilter.cs
@@ -267,7 +267,7 @@ namespace NBitcoin
 		private HashSet<byte[]> _values;
 		
 		/// <summary>
-		/// Helper class for making sure not two ideantical data elements are 
+		/// Helper class for making sure not two identical data elements are 
 		/// included in a filter.
 		/// </summary>
 		class ByteArrayComparer : IEqualityComparer<byte[]> {

--- a/NBitcoin/BIP32/KeyPath.cs
+++ b/NBitcoin/BIP32/KeyPath.cs
@@ -160,7 +160,7 @@ namespace NBitcoin
 			get
 			{
 				if(_Indexes.Length == 0)
-					throw new InvalidOperationException("No indice found in this KeyPath");
+					throw new InvalidOperationException("No index found in this KeyPath");
 				return (_Indexes[_Indexes.Length - 1] & 0x80000000u) != 0;
 			}
 		}

--- a/NBitcoin/BitcoinAddress.cs
+++ b/NBitcoin/BitcoinAddress.cs
@@ -5,7 +5,7 @@ using System.Linq;
 namespace NBitcoin
 {
 	/// <summary>
-	/// Base58 representaiton of a script hash
+	/// Base58 representation of a script hash
 	/// </summary>
 	public class BitcoinScriptAddress : BitcoinAddress, IBase58Data
 	{

--- a/NBitcoin/BouncyCastle/asn1/DerObjectIdentifier.cs
+++ b/NBitcoin/BouncyCastle/asn1/DerObjectIdentifier.cs
@@ -133,7 +133,7 @@ namespace NBitcoin.BouncyCastle.Asn1
 			{
 				char ch = branchID[pos];
 
-				// TODO Leading zeroes?
+				// TODO Leading zeros?
 				if('0' <= ch && ch <= '9')
 				{
 					periodAllowed = true;

--- a/NBitcoin/BouncyCastle/math/ec/ECCurve.cs
+++ b/NBitcoin/BouncyCastle/math/ec/ECCurve.cs
@@ -793,7 +793,7 @@ namespace NBitcoin.BouncyCastle.Math.EC
          * D.1.6) The other solution is <code>z + 1</code>.
          *
          * @param beta
-         *            The value to solve the qradratic equation for.
+         *            The value to solve the quadratic equation for.
          * @return the solution for <code>z<sup>2</sup> + z = beta</code> or
          *         <code>null</code> if no solution exists.
          */

--- a/NBitcoin/BouncyCastle/math/ec/LongArray.cs
+++ b/NBitcoin/BouncyCastle/math/ec/LongArray.cs
@@ -1248,7 +1248,7 @@ namespace NBitcoin.BouncyCastle.Math.EC
 				}
 				cTotal += cLen;
 			}
-			// NOTE: Provide a safe dump for "high zeroes" since we are adding 'bMax' and not 'bLen'
+			// NOTE: Provide a safe dump for "high zeros" since we are adding 'bMax' and not 'bLen'
 			++cTotal;
 
 			long[] c = new long[cTotal];
@@ -2204,7 +2204,7 @@ namespace NBitcoin.BouncyCastle.Math.EC
 			{
 				string s = Convert.ToString(m_ints[i], 2);
 
-				// Add leading zeroes, except for highest significant word
+				// Add leading zeros, except for highest significant word
 				int len = s.Length;
 				if(len < 64)
 				{

--- a/NBitcoin/BouncyCastle/math/ec/custom/sec/SecP256K1Point.cs
+++ b/NBitcoin/BouncyCastle/math/ec/custom/sec/SecP256K1Point.cs
@@ -25,7 +25,7 @@ namespace NBitcoin.BouncyCastle.Math.EC.Custom.Sec
 		}
 
 		/**
-         * Create a point that encodes with or without point compresion.
+         * Create a point that encodes with or without point compression.
          * 
          * @param curve
          *            the curve to use

--- a/NBitcoin/BouncyCastle/util/Arrays.cs
+++ b/NBitcoin/BouncyCastle/util/Arrays.cs
@@ -494,7 +494,7 @@ namespace NBitcoin.BouncyCastle.Utilities
 		/**
          * Make a copy of a range of bytes from the passed in data array. The range can
          * extend beyond the end of the input array, in which case the return array will
-         * be padded with zeroes.
+         * be padded with zeros.
          *
          * @param data the array from which the data is to be copied.
          * @param from the start index at which the copying should take place.

--- a/NBitcoin/BouncyCastle/util/BigIntegers.cs
+++ b/NBitcoin/BouncyCastle/util/BigIntegers.cs
@@ -29,7 +29,7 @@ namespace NBitcoin.BouncyCastle.Utilities
          *
          * @param length desired length of result array.
          * @param n value to be converted.
-         * @return a byte array of specified length, with leading zeroes as necessary given the size of n.
+         * @return a byte array of specified length, with leading zeros as necessary given the size of n.
          */
 		public static byte[] AsUnsignedByteArray(int length, BigInteger n)
 		{

--- a/NBitcoin/ConcurrentChain.cs
+++ b/NBitcoin/ConcurrentChain.cs
@@ -31,7 +31,7 @@ namespace NBitcoin
 			internal void AssertCoherent()
 			{
 				if(!SerializePrecomputedBlockHash && !SerializeBlockHeader)
-					throw new InvalidOperationException("The ChainSerializationFormat is invalid, SerializePrecomputedBlockHash or SerializeBlockHeader shoudl be true");
+					throw new InvalidOperationException("The ChainSerializationFormat is invalid, SerializePrecomputedBlockHash or SerializeBlockHeader should be true");
 			}
 		}
 		Dictionary<uint256, ChainedBlock> _BlocksById = new Dictionary<uint256, ChainedBlock>();

--- a/NBitcoin/DataEncoders/Base58Encoder.cs
+++ b/NBitcoin/DataEncoders/Base58Encoder.cs
@@ -108,7 +108,7 @@ namespace NBitcoin.DataEncoders
 				builder.Append(pszBase58[c]);
 			}
 
-			// Leading zeroes encoded as base58 zeros
+			// Leading zeros encoded as base58 zeros
 			for(int i = offset; i < offset + count && data[i] == 0; i++)
 				builder.Append(pszBase58[0]);
 

--- a/NBitcoin/DataEncoders/Bech32Encoder.cs
+++ b/NBitcoin/DataEncoders/Bech32Encoder.cs
@@ -405,7 +405,7 @@ namespace NBitcoin.DataEncoders
 			var hrp = Encoders.ASCII.DecodeData(encoded.Substring(0, pos));
 			if(!hrp.SequenceEqual(_Hrp))
 			{
-				throw new FormatException("Mismatching human readeable part");
+				throw new FormatException("Mismatching human readable part");
 			}
 			var data = new byte[encoded.Length - pos - 1];
 			for(int j = 0, i = pos + 1; i < encoded.Length; i++, j++)
@@ -417,7 +417,7 @@ namespace NBitcoin.DataEncoders
 			if(!VerifyChecksum(data, encoded.Length, out error))
 			{
 				if(error.Length == 0)
-					throw new FormatException("Error while veriying Bech32 checksum");
+					throw new FormatException("Error while verifying Bech32 checksum");
 				else
 					throw new Bech32FormatException($"Error in Bech32 string at {String.Join(",", error)}", error);
 			}

--- a/NBitcoin/Money.cs
+++ b/NBitcoin/Money.cs
@@ -199,7 +199,7 @@ namespace NBitcoin
 		/// Get the Money corresponding to the input assetId
 		/// </summary>
 		/// <param name="assetId">The asset id, if null, will assume bitcoin amount</param>
-		/// <returns>Never returns null, eithers the AssetMoney or Money if assetId is null</returns>
+		/// <returns>Never returns null, either the AssetMoney or Money if assetId is null</returns>
 		public IMoney GetAmount(AssetId assetId = null)
 		{
 			if(assetId == null)
@@ -666,7 +666,7 @@ namespace NBitcoin
 		/// Returns a culture invariant string representation of Bitcoin amount
 		/// </summary>
 		/// <param name="fplus">True if show + for a positive amount</param>
-		/// <param name="trimExcessZero">True if trim excess zeroes</param>
+		/// <param name="trimExcessZero">True if trim excess zeros</param>
 		/// <returns></returns>
 		public string ToString(bool fplus, bool trimExcessZero = true)
 		{

--- a/NBitcoin/NetworkStringParser.cs
+++ b/NBitcoin/NetworkStringParser.cs
@@ -9,7 +9,7 @@ namespace NBitcoin
 {
 
 	/// <summary>
-	/// This class provide a hook for additionnal string format in altcoin network
+	/// This class provide a hook for additional string format in altcoin network
 	/// </summary>
     public class NetworkStringParser
     {

--- a/NBitcoin/PartialMerkleTree.cs
+++ b/NBitcoin/PartialMerkleTree.cs
@@ -198,7 +198,7 @@ namespace NBitcoin
 		}
 
 		/// <summary>
-		/// Remove superflous branches
+		/// Remove superfluous branches
 		/// </summary>
 		/// <param name="transaction"></param>
 		/// <returns></returns>

--- a/NBitcoin/Protocol/AddressManager.cs
+++ b/NBitcoin/Protocol/AddressManager.cs
@@ -948,7 +948,7 @@ namespace NBitcoin.Protocol
 		private static void assert(bool value)
 		{
 			if(!value)
-				throw new InvalidOperationException("Bug in AddressManager, should never happen, contact NBitcoin developpers if you see this exception");
+				throw new InvalidOperationException("Bug in AddressManager, should never happen, contact NBitcoin developers if you see this exception");
 		}
 		//! Mark an entry as connection attempted to.
 		public void Attempt(NetworkAddress addr)

--- a/NBitcoin/Protocol/Behaviors/AddressManagerBehavior.cs
+++ b/NBitcoin/Protocol/Behaviors/AddressManagerBehavior.cs
@@ -12,11 +12,11 @@ namespace NBitcoin.Protocol.Behaviors
 	public enum AddressManagerBehaviorMode
 	{
 		/// <summary>
-		/// Do not advertize nor discover new peers
+		/// Do not advertise or discover new peers
 		/// </summary>
 		None = 0,
 		/// <summary>
-		/// Only advertize known peers
+		/// Only advertise known peers
 		/// </summary>
 		Advertize = 1,
 		/// <summary>
@@ -24,7 +24,7 @@ namespace NBitcoin.Protocol.Behaviors
 		/// </summary>
 		Discover = 2,
 		/// <summary>
-		/// Advertize known peer and discover peer
+		/// Advertise known peer and discover peer
 		/// </summary>
 		AdvertizeDiscover = 3,
 	}

--- a/NBitcoin/Protocol/Node.cs
+++ b/NBitcoin/Protocol/Node.cs
@@ -279,7 +279,7 @@ namespace NBitcoin.Protocol
 					_ListenerThreadId = Thread.CurrentThread.ManagedThreadId;
 
 					
-					using (Logs.NodeServer.BeginScope("Thead scope {ThreadId}", _ListenerThreadId))
+					using (Logs.NodeServer.BeginScope("Thread scope {ThreadId}", _ListenerThreadId))
 					{
 						Logs.NodeServer.LogInformation("Start Listening");
 						
@@ -743,7 +743,7 @@ namespace NBitcoin.Protocol
 					_RemoteSocketPort = remoteEndpoint.Port;
 					State = NodeState.Connected;
 					ConnectedAt = DateTimeOffset.UtcNow;
-					Logs.NodeServer.LogInformation("Outbound connection successfull");
+					Logs.NodeServer.LogInformation("Outbound connection successful");
 					if(addrman != null)
 						addrman.Attempt(Peer);
 				}
@@ -995,7 +995,7 @@ namespace NBitcoin.Protocol
 		}
 
 		/// <summary>
-		/// Send addr unsollicited message of the AddressFrom peer when passing to Handshaked state
+		/// Send addr unsolicited message of the AddressFrom peer when passing to Handshaked state
 		/// </summary>
 		public bool Advertize
 		{
@@ -1352,7 +1352,7 @@ namespace NBitcoin.Protocol
 				return new ChainedBlock[0];
 			var newTip = headers[headers.Count - 1];
 			if(newTip.Height <= oldTip.Height)
-				throw new ProtocolException("No tip should have been recieved older than the local one");
+				throw new ProtocolException("No tip should have been received older than the local one");
 			chain.SetTip(newTip);
 			return headers;
 		}
@@ -1532,7 +1532,7 @@ namespace NBitcoin.Protocol
 		}
 
 		/// <summary>
-		/// Create a listener that will queue messages until diposed
+		/// Create a listener that will queue messages until disposed
 		/// </summary>
 		/// <returns>The listener</returns>
 		/// <exception cref="System.InvalidOperationException">Thrown if used on the listener's thread, as it would result in a deadlock</exception>

--- a/NBitcoin/Protocol/NodeConnectionParameters.cs
+++ b/NBitcoin/Protocol/NodeConnectionParameters.cs
@@ -51,7 +51,7 @@ namespace NBitcoin.Protocol
 		}
 
 		/// <summary>
-		/// Send addr unsollicited message of the AddressFrom peer when passing to Handshaked state
+		/// Send addr unsolicited message of the AddressFrom peer when passing to Handshaked state
 		/// </summary>
 		public bool Advertize
 		{

--- a/NBitcoin/Protocol/Payloads/AddrPayload.cs
+++ b/NBitcoin/Protocol/Payloads/AddrPayload.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 namespace NBitcoin.Protocol
 {
 	/// <summary>
-	/// An available peer address in the bitcoin network is announce (unsollicited or after a getaddr)
+	/// An available peer address in the bitcoin network is announce (unsolicited or after a getaddr)
 	/// </summary>
 	[Payload("addr")]
 	public class AddrPayload : Payload, IBitcoinSerializable

--- a/NBitcoin/TransactionBuilder.cs
+++ b/NBitcoin/TransactionBuilder.cs
@@ -989,7 +989,7 @@ namespace NBitcoin
 		Money _TotalFee = Money.Zero;
 
 		/// <summary>
-		/// Split the estimated fees accross the several groups (separated by Then())
+		/// Split the estimated fees across the several groups (separated by Then())
 		/// </summary>
 		/// <param name="feeRate"></param>
 		/// <returns></returns>


### PR DESCRIPTION
Update fixing some spelling and typos. Conservative changes, done mainly by hand. Two biggest single changes are zeroes -> zeros and advertize -> advertise (the only correct spelling in US and GB English). No changes from US->GB or GB->US.