### PR TITLE
Rename Blinding signature clases and improves API

### DIFF
--- a/NBitcoin.Tests/DeterministicSignatureTests.cs
+++ b/NBitcoin.Tests/DeterministicSignatureTests.cs
@@ -14,6 +14,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Xunit;
 using NBitcoin.BouncyCastle.Asn1;
+using System.Security;
 
 namespace NBitcoin.Tests
 {
@@ -267,7 +268,7 @@ namespace NBitcoin.Tests
 			var unblindedSignature = requester.UnblindSignature(blindSignature);
 
 			Assert.True( SchnorrBlinding.VerifySignature(message, unblindedSignature, key.PubKey) );
-			Assert.False(SchnorrBlinding.VerifySignature(uint256.One, unblindedSignature, key.PubKey) );
+			Assert.False(SchnorrBlinding.VerifySignature(uint256.Zero, unblindedSignature, key.PubKey) );
 			Assert.False(SchnorrBlinding.VerifySignature(uint256.One, unblindedSignature, key.PubKey) );
 			Assert.False(SchnorrBlinding.VerifySignature(
 				message, 
@@ -340,6 +341,10 @@ namespace NBitcoin.Tests
 
 				Assert.True( signer.VerifyUnblindedSignature(unblindedSignature, newMessage) );
 			}
+
+
+			var ex = Assert.Throws<ArgumentException>(()=>signer.Sign(uint256.Zero));
+			Assert.StartsWith("Invalid blinded message.", ex.Message);
 		}
 
 		[Fact]

--- a/NBitcoin.Tests/DeterministicSignatureTests.cs
+++ b/NBitcoin.Tests/DeterministicSignatureTests.cs
@@ -255,10 +255,10 @@ namespace NBitcoin.Tests
 		public void BlindingSignature()
 		{
 			// Test with known values 
-			var requester = new ECDSABlinding.Requester();
+			var requester = new SchnorrBlinding.Requester();
 			var r = new Key(Encoders.Hex.DecodeData("31E151628AED2A6ABF7155809CF4F3C762E7160F38B4DA56B784D9045190CFA0"));
 			var key = new Key(Encoders.Hex.DecodeData("B7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF"));
-			var signer = new ECDSABlinding.Signer(key, r);
+			var signer = new SchnorrBlinding.Signer(key, r);
 
 			var message = new uint256(Encoders.Hex.DecodeData("243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89"), false);
 			var blindedMessage = requester.BlindMessage(message, r.PubKey, key.PubKey);
@@ -266,25 +266,25 @@ namespace NBitcoin.Tests
 			var blindSignature = signer.Sign(blindedMessage);
 			var unblindedSignature = requester.UnblindSignature(blindSignature);
 
-			Assert.True( ECDSABlinding.VerifySignature(message, unblindedSignature, key.PubKey) );
-			Assert.False(ECDSABlinding.VerifySignature(uint256.One, unblindedSignature, key.PubKey) );
-			Assert.False(ECDSABlinding.VerifySignature(uint256.One, unblindedSignature, key.PubKey) );
-			Assert.False(ECDSABlinding.VerifySignature(
+			Assert.True( SchnorrBlinding.VerifySignature(message, unblindedSignature, key.PubKey) );
+			Assert.False(SchnorrBlinding.VerifySignature(uint256.One, unblindedSignature, key.PubKey) );
+			Assert.False(SchnorrBlinding.VerifySignature(uint256.One, unblindedSignature, key.PubKey) );
+			Assert.False(SchnorrBlinding.VerifySignature(
 				message, 
-				new BlindSignature(unblindedSignature.C, BigInteger.Zero.Subtract(unblindedSignature.S)), 
+				new UnblindedSignature(unblindedSignature.C, BigInteger.Zero.Subtract(unblindedSignature.S)), 
 				key.PubKey) );
-			Assert.False(ECDSABlinding.VerifySignature(
+			Assert.False(SchnorrBlinding.VerifySignature(
 				message, 
-				new BlindSignature(BigInteger.Zero.Subtract(unblindedSignature.C), unblindedSignature.S), 
+				new UnblindedSignature(BigInteger.Zero.Subtract(unblindedSignature.C), unblindedSignature.S), 
 				key.PubKey) );
-			Assert.False(ECDSABlinding.VerifySignature(
+			Assert.False(SchnorrBlinding.VerifySignature(
 				message, 
-				new BlindSignature(BigInteger.Zero.Subtract(unblindedSignature.C), unblindedSignature.S), 
+				new UnblindedSignature(BigInteger.Zero.Subtract(unblindedSignature.C), unblindedSignature.S), 
 				new Key().PubKey) );
 
 			// Test with unknown values 
-			requester = new ECDSABlinding.Requester();
-			signer = new ECDSABlinding.Signer(new Key(), new Key());
+			requester = new SchnorrBlinding.Requester();
+			signer = new SchnorrBlinding.Signer(new Key(), new Key());
 
 			message = Hashes.Hash256(Encoders.ASCII.DecodeData("Hello world!"));
 			blindedMessage = requester.BlindMessage(message, signer.R.PubKey, signer.Key.PubKey);
@@ -292,41 +292,54 @@ namespace NBitcoin.Tests
 			blindSignature = signer.Sign(blindedMessage);
 			unblindedSignature = requester.UnblindSignature(blindSignature);
 
-			Assert.True( ECDSABlinding.VerifySignature(message, unblindedSignature, signer.Key.PubKey) );
-			Assert.False(ECDSABlinding.VerifySignature(uint256.One, unblindedSignature, signer.Key.PubKey) );
-			Assert.False(ECDSABlinding.VerifySignature(uint256.One, unblindedSignature, signer.Key.PubKey) );
-			Assert.False(ECDSABlinding.VerifySignature(
+			Assert.True( SchnorrBlinding.VerifySignature(message, unblindedSignature, signer.Key.PubKey) );
+			Assert.False(SchnorrBlinding.VerifySignature(uint256.One, unblindedSignature, signer.Key.PubKey) );
+			Assert.False(SchnorrBlinding.VerifySignature(uint256.One, unblindedSignature, signer.Key.PubKey) );
+			Assert.False(SchnorrBlinding.VerifySignature(
 				message, 
-				new BlindSignature(BigInteger.Zero, unblindedSignature.S), 
+				new UnblindedSignature(BigInteger.Zero, unblindedSignature.S), 
 				signer.Key.PubKey) );
-			Assert.False(ECDSABlinding.VerifySignature(
+			Assert.False(SchnorrBlinding.VerifySignature(
 				message, 
-				new BlindSignature(unblindedSignature.C, BigInteger.Zero), 
+				new UnblindedSignature(unblindedSignature.C, BigInteger.Zero), 
 				signer.Key.PubKey) );
-			Assert.False(ECDSABlinding.VerifySignature(
+			Assert.False(SchnorrBlinding.VerifySignature(
 				message, 
-				new BlindSignature(BigInteger.One, unblindedSignature.S), 
+				new UnblindedSignature(BigInteger.One, unblindedSignature.S), 
 				signer.Key.PubKey) );
-			Assert.False(ECDSABlinding.VerifySignature(
+			Assert.False(SchnorrBlinding.VerifySignature(
 				message, 
-				new BlindSignature(unblindedSignature.C, BigInteger.One), 
+				new UnblindedSignature(unblindedSignature.C, BigInteger.One), 
 				signer.Key.PubKey) );
-			Assert.False(ECDSABlinding.VerifySignature(
+			Assert.False(SchnorrBlinding.VerifySignature(
 				message, 
-				new BlindSignature(BigInteger.One, BigInteger.One), 
+				new UnblindedSignature(BigInteger.One, BigInteger.One), 
 				signer.Key.PubKey) );
-			Assert.False(ECDSABlinding.VerifySignature(
+			Assert.False(SchnorrBlinding.VerifySignature(
 				message, 
-				new BlindSignature(unblindedSignature.C, BigInteger.Zero.Subtract(unblindedSignature.S)), 
+				new UnblindedSignature(unblindedSignature.C, BigInteger.Zero.Subtract(unblindedSignature.S)), 
 				signer.Key.PubKey) );
-			Assert.False(ECDSABlinding.VerifySignature(
+			Assert.False(SchnorrBlinding.VerifySignature(
 				message, 
-				new BlindSignature(BigInteger.Zero.Subtract(unblindedSignature.C), unblindedSignature.S), 
+				new UnblindedSignature(BigInteger.Zero.Subtract(unblindedSignature.C), unblindedSignature.S), 
 				signer.Key.PubKey) );
-			Assert.False(ECDSABlinding.VerifySignature(
+			Assert.False(SchnorrBlinding.VerifySignature(
 				message, 
-				new BlindSignature(BigInteger.Zero.Subtract(unblindedSignature.C), unblindedSignature.S), 
+				new UnblindedSignature(BigInteger.Zero.Subtract(unblindedSignature.C), unblindedSignature.S), 
 				new Key().PubKey) );
+
+
+			var newMessage = Encoders.ASCII.DecodeData("Hello, World!");
+			for(var i=0; i < 1_000; i++)
+			{
+				requester = new SchnorrBlinding.Requester();
+				signer = new SchnorrBlinding.Signer(new Key());
+				blindedMessage = requester.BlindMessage(newMessage, signer.R.PubKey, signer.Key.PubKey);
+				blindSignature = signer.Sign(blindedMessage);
+				unblindedSignature = requester.UnblindSignature(blindSignature);
+
+				Assert.True( signer.VerifyUnblindedSignature(unblindedSignature, newMessage) );
+			}
 		}
 
 		[Fact]

--- a/NBitcoin/Crypto/SchnorrBlindSignature.cs
+++ b/NBitcoin/Crypto/SchnorrBlindSignature.cs
@@ -6,19 +6,19 @@ using NBitcoin.BouncyCastle.Security;
 
 namespace NBitcoin.Crypto
 {
-	public class BlindSignature
-	{
-		public BigInteger C { get; }
-		public BigInteger S { get; }
+    public class UnblindedSignature
+    {
+        public BigInteger C { get; }
+        public BigInteger S { get; }
 
-		public BlindSignature(BigInteger c, BigInteger s)
-		{
-			C = c;
-			S = s;
-		}
-	}
+        public UnblindedSignature(BigInteger c, BigInteger s)
+        {
+            C = c;
+            S = s;
+        }
+    }
 
-    public class ECDSABlinding
+    public class SchnorrBlinding
     {
         private static X9ECParameters Secp256k1 = ECKey.Secp256k1;
 
@@ -35,31 +35,38 @@ namespace NBitcoin.Crypto
                 _k.Init(BigInteger.Arbitrary(256), new SecureRandom());
             }
 
-            public uint256 BlindMessage(uint256 message, PubKey Rpubkey, PubKey signerPubKey)
+            public uint256 BlindMessage(uint256 message, PubKey rpubkey, PubKey signerPubKey)
             {
                 var P = signerPubKey.ECKey.GetPublicKeyParameters().Q;
-                var R = Rpubkey.ECKey.GetPublicKeyParameters().Q;
+                var R = rpubkey.ECKey.GetPublicKeyParameters().Q;
 
                 var t = BigInteger.Zero;
-                while(t.SignValue == 0)
+                while (t.SignValue == 0)
                 {
                     _v = _k.NextK();
                     _w = _k.NextK();
 
-                    var A1 = Secp256k1.G.Multiply(_v); 
-                    var A2 = P.Multiply(_w); 
-                    var A  = R.Add( A1.Add(A2) ).Normalize();
+                    var A1 = Secp256k1.G.Multiply(_v);
+                    var A2 = P.Multiply(_w);
+                    var A = R.Add(A1.Add(A2)).Normalize();
                     t = A.AffineXCoord.ToBigInteger().Mod(Secp256k1.N);
                 }
                 _c = new BigInteger(1, Hashes.SHA256(message.ToBytes(false).Concat(Utils.BigIntegerToBytes(t, 32))));
-                var cp= _c.Subtract(_w).Mod(Secp256k1.N); // this is sent to the signer (blinded message)
-                return new uint256(Utils.BigIntegerToBytes(cp, 32)); 
+                var cp = _c.Subtract(_w).Mod(Secp256k1.N); // this is sent to the signer (blinded message)
+                return new uint256(Utils.BigIntegerToBytes(cp, 32));
             }
 
-            public BlindSignature UnblindSignature(BigInteger sp)
+            public UnblindedSignature UnblindSignature(uint256 blindSignature)
             {
+                var sp = new BigInteger(1, blindSignature.ToBytes());
                 var s = sp.Add(_v).Mod(Secp256k1.N);
-                return new BlindSignature(_c, s);
+                return new UnblindedSignature(_c, s);
+            }
+
+            public uint256 BlindMessage(byte[] message, PubKey rpubKey, PubKey signerPubKey)
+            {
+                var msg = new uint256(Hashes.SHA256(message));
+                return BlindMessage(msg, rpubKey, signerPubKey);
             }
         }
 
@@ -75,7 +82,7 @@ namespace NBitcoin.Crypto
 
             public Signer(Key key)
                 : this(key, new Key())
-            {}
+            { }
 
             public Signer(Key key, Key r)
             {
@@ -83,26 +90,37 @@ namespace NBitcoin.Crypto
                 Key = key;
             }
 
-            public BigInteger Sign(uint256 blindedMessage)
+            public uint256 Sign(uint256 blindedMessage)
             {
                 var r = R._ECKey.PrivateKey.D;
                 var d = Key._ECKey.PrivateKey.D;
                 var cp = new BigInteger(1, blindedMessage.ToBytes());
                 var sp = r.Subtract(cp.Multiply(d)).Mod(ECKey.Secp256k1.N);
-                return sp;
+                return new uint256(Utils.BigIntegerToBytes(sp, 32));
+            }
+
+            public bool VerifyUnblindedSignature(UnblindedSignature signature, uint256 dataHash)
+            {
+                return SchnorrBlinding.VerifySignature(dataHash, signature, Key.PubKey);
+            }
+
+            public bool VerifyUnblindedSignature(UnblindedSignature signature, byte[] data)
+            {
+                var hash = new uint256(Hashes.SHA256(data));
+                return SchnorrBlinding.VerifySignature(hash, signature, Key.PubKey);
             }
         }
 
-        public static bool VerifySignature(uint256 message, BlindSignature signature, PubKey signerPubKey)
+        public static bool VerifySignature(uint256 message, UnblindedSignature signature, PubKey signerPubKey)
         {
             var P = signerPubKey.ECKey.GetPublicKeyParameters().Q;
 
             var sG = Secp256k1.G.Multiply(signature.S);
             var cP = P.Multiply(signature.C);
-            var R  = cP.Add(sG).Normalize();
+            var R = cP.Add(sG).Normalize();
             var t = R.AffineXCoord.ToBigInteger().Mod(Secp256k1.N);
             var c = new BigInteger(1, Hashes.SHA256(message.ToBytes(false).Concat(Utils.BigIntegerToBytes(t, 32))));
             return c.Equals(signature.C);
         }
-	}
+    }
 }

--- a/NBitcoin/Crypto/SchnorrBlindSignature.cs
+++ b/NBitcoin/Crypto/SchnorrBlindSignature.cs
@@ -1,4 +1,5 @@
 
+using System.Security;
 using NBitcoin.BouncyCastle.Asn1.X9;
 using NBitcoin.BouncyCastle.Crypto.Signers;
 using NBitcoin.BouncyCastle.Math;
@@ -92,6 +93,9 @@ namespace NBitcoin.Crypto
 
             public uint256 Sign(uint256 blindedMessage)
             {
+				// blind signature s = r - bs * d
+				if(blindedMessage == uint256.Zero)
+					throw new System.ArgumentException("Invalid blinded message.", nameof(blindedMessage));
                 var r = R._ECKey.PrivateKey.D;
                 var d = Key._ECKey.PrivateKey.D;
                 var cp = new BigInteger(1, blindedMessage.ToBytes());


### PR DESCRIPTION
This PR comes after dogfooding it in Wasabi Wallet. It does:

* Rename the whole system from **ECDSABlinding** to **SchnorrBlinding**.
* Rename **BlindSignature** to **UnblindedSignature** because it is the signature after being unblinded
* Uses **uint256** in API interface instead of **BigIntegers** because the numbers are always less than 2^256
* Simplifies the API thanks to new methods:
```c#
var message = Encoders.ASCII.DecodeData("Hello, World!");
var requester = new SchnorrBlinding.Requester();
var signer = new SchnorrBlinding.Signer(new Key());
var blindedMessage = requester.BlindMessage(message, signer.R.PubKey, signer.Key.PubKey);
var blindSignature = signer.Sign(blindedMessage);
var unblindedSignature = requester.UnblindSignature(blindSignature);

Assert.True( signer.VerifyUnblindedSignature(unblindedSignature, message) );
```

* Tests: I added a brute force test that runs in about a second (I think it will not delay the tests). I also ran that test in a 10_000_000 loop that took a couple of hours and it past green.