### PR TITLE
Add two RPCs `getaddressinfo` and `walletcreatefundedpsbt`

### DIFF
--- a/NBitcoin.Tests/RPCClientTests.cs
+++ b/NBitcoin.Tests/RPCClientTests.cs
@@ -1434,6 +1434,8 @@ namespace NBitcoin.Tests
 		{
 			using (var builder = NodeBuilderEx.Create())
 			{
+				if (!builder.NodeImplementation.Version.Contains("0.17"))
+					throw new Exception("Test must be updated!");
 				var nodeAlice = builder.CreateNode();
 				var nodeBob = builder.CreateNode();
 				var nodeCarol = builder.CreateNode();
@@ -1555,6 +1557,8 @@ namespace NBitcoin.Tests
 		{
 			using (var builder = NodeBuilderEx.Create())
 			{
+				if (!builder.NodeImplementation.Version.Contains("0.17"))
+					throw new Exception("Test must be updated!");
 				var client = builder.CreateNode(true).CreateRPCClient();
 				var addrLegacy = client.GetNewAddress(new GetNewAddressRequest() { AddressType = AddressType.Legacy });
 				var addrBech32 = client.GetNewAddress(new GetNewAddressRequest() { AddressType = AddressType.Bech32 });

--- a/NBitcoin.Tests/RPCClientTests.cs
+++ b/NBitcoin.Tests/RPCClientTests.cs
@@ -1419,7 +1419,158 @@ namespace NBitcoin.Tests
 				result.PSBT.TryFinalize(out var errors3);
 				Assert.Empty(errors3);
 				var txResult = result.PSBT.ExtractTX();
-				client.TestMempoolAccept(txResult, true);
+				var acceptResult = client.TestMempoolAccept(txResult, true);
+				Assert.True(acceptResult.IsAllowed, acceptResult.RejectReason);
+			}
+		}
+
+		// refs: https://github.com/bitcoin/bitcoin/blob/df73c23f5fac031cc9b2ec06a74275db5ea322e3/doc/psbt.md#workflows
+		// with 2 difference.
+		// 1. one user (David) do not use bitcoin core (only NBitcoin)
+		// 2. 4-of-4 instead of 2-of-3
+		// 3. In version 0.17, `importmulti` can not handle witness script so only p2sh are considered here. TODO: fix
+		[Fact]
+		public void ShouldPerformMultisigProcessingWithCore()
+		{
+			using (var builder = NodeBuilderEx.Create())
+			{
+				var nodeAlice = builder.CreateNode();
+				var nodeBob = builder.CreateNode();
+				var nodeCarol = builder.CreateNode();
+				var nodeFunder = builder.CreateNode();
+				var david = new Key();
+				builder.StartAll();
+
+				// prepare multisig script and watch with node.
+				var nodes = new CoreNode[]{nodeAlice, nodeBob, nodeCarol};
+				var clients = nodes.Select(n => n.CreateRPCClient()).ToArray();
+				var addresses = clients.Select(c => c.GetNewAddress());
+				var addrInfos = addresses.Select((a, i) => clients[i].GetAddressInfo(a));
+				var pubkeys = new List<PubKey> { david.PubKey };
+				pubkeys.AddRange(addrInfos.Select(i => i.PubKey).ToArray());
+				var script = PayToMultiSigTemplate.Instance.GenerateScriptPubKey(4, pubkeys.ToArray());
+				var aMultiP2SH = script.Hash.ScriptPubKey;
+				// var aMultiP2WSH = script.WitHash.ScriptPubKey;
+				// var aMultiP2SH_P2WSH = script.WitHash.ScriptPubKey.Hash.ScriptPubKey;
+				var multiAddresses = new BitcoinAddress[] { aMultiP2SH.GetDestinationAddress(builder.Network) };
+				var importMultiObject = new ImportMultiAddress[] {
+						new ImportMultiAddress()
+						{
+							ScriptPubKey = new ImportMultiAddress.ScriptPubKeyObject(multiAddresses[0]),
+							RedeemScript = script.ToHex(),
+							Internal = true,
+						},
+						/*
+						new ImportMultiAddress()
+						{
+							ScriptPubKey = new ImportMultiAddress.ScriptPubKeyObject(aMultiP2WSH),
+							RedeemScript = script.ToHex(),
+							Internal = true,
+						},
+						new ImportMultiAddress()
+						{
+							ScriptPubKey = new ImportMultiAddress.ScriptPubKeyObject(aMultiP2SH_P2WSH),
+							RedeemScript = script.WitHash.ScriptPubKey.ToHex(),
+							Internal = true,
+						},
+						new ImportMultiAddress()
+						{
+							ScriptPubKey = new ImportMultiAddress.ScriptPubKeyObject(aMultiP2SH_P2WSH),
+							RedeemScript = script.ToHex(),
+							Internal = true,
+						}
+						*/
+					};
+
+				for (var i = 0; i < clients.Length; i++)
+				{
+					var c = clients[i];
+					Output.WriteLine($"Importing for {i}");
+					c.ImportMulti(importMultiObject, false);
+				}
+
+				// pay from funder
+				nodeFunder.Generate(103);
+				var funderClient = nodeFunder.CreateRPCClient();
+				funderClient.SendToAddress(aMultiP2SH, Money.Coins(40));
+				// funderClient.SendToAddress(aMultiP2WSH, Money.Coins(40));
+				// funderClient.SendToAddress(aMultiP2SH_P2WSH, Money.Coins(40));
+				nodeFunder.Generate(1);
+				foreach (var n in nodes)
+				{
+					nodeFunder.Sync(n, true);
+				}
+
+				// pay from multisig address
+				// first carol creates psbt
+				var carol = clients[2];
+				// check if we have enough balance
+				var info = carol.GetBlockchainInfoAsync().Result;
+				Assert.Equal((ulong)104, info.Blocks);
+				var balance = carol.GetBalance(0, true);
+				// Assert.Equal(Money.Coins(120), balance);
+				Assert.Equal(Money.Coins(40), balance);
+
+				var aSend = new Key().PubKey.GetAddress(nodeAlice.Network);
+				var outputs = new Dictionary<BitcoinAddress, Money>();
+				outputs.Add(aSend, Money.Coins(10));
+				var fundOptions = new FundRawTransactionOptions() { SubtractFeeFromOutputs = new int[] {0}, IncludeWatching = true };
+				PSBT psbt = carol.WalletCreateFundedPSBT(null, outputs, 0, fundOptions).PSBT;
+				psbt = carol.WalletProcessPSBT(psbt).PSBT;
+
+				// second, Bob checks and process psbt.
+				var bob = clients[1];
+				Assert.Contains(multiAddresses, a =>
+					psbt.inputs.Any(psbtin => psbtin.WitnessUtxo?.ScriptPubKey == a.ScriptPubKey) ||
+					psbt.inputs.Any(psbtin => (bool)psbtin.NonWitnessUtxo?.Outputs.Any(o => a.ScriptPubKey == o.ScriptPubKey))
+					);
+				var psbt1 = bob.WalletProcessPSBT(psbt.Clone()).PSBT;
+
+				// at the same time, David may do the ;
+				psbt.TrySignAll(david);
+				var alice = clients[0];
+				var psbt2 = alice.WalletProcessPSBT(psbt).PSBT;
+				psbt2.TryFinalize(out var errors);
+				Assert.NotEmpty(errors); // not enough signature.
+
+				// So let's combine.
+				var psbtCombined = psbt1.Combine(psbt2);
+
+				// Finally, anyone can finalize and broadcast the psbt.
+				var tx = psbtCombined.Finalize().ExtractTX();
+				var result = alice.TestMempoolAccept(tx);
+				Assert.True(result.IsAllowed, result.RejectReason);
+			}
+		}
+
+
+		[Fact]
+		/// <summary>
+		/// For p2sh, p2wsh, p2sh-p2wsh, we must also test the case for `solvable` to the wallet.
+		/// For that, both script and the address must be imported by `importmulti`.
+		/// but importmulti can not handle witness script(in v0.17).
+		/// TODO: add test for solvable scripts.
+		/// </summary>
+		public void ShouldGetAddressInfo()
+		{
+			using (var builder = NodeBuilderEx.Create())
+			{
+				var client = builder.CreateNode(true).CreateRPCClient();
+				var addrLegacy = client.GetNewAddress(new GetNewAddressRequest() { AddressType = AddressType.Legacy });
+				var addrBech32 = client.GetNewAddress(new GetNewAddressRequest() { AddressType = AddressType.Bech32 });
+				var addrP2SHSegwit = client.GetNewAddress(new GetNewAddressRequest() { AddressType = AddressType.P2SHSegwit });
+				var pubkeys = new PubKey[] { new Key().PubKey, new Key().PubKey, new Key().PubKey };
+				var redeem = PayToMultiSigTemplate.Instance.GenerateScriptPubKey(2, pubkeys);
+				client.ImportAddress(redeem.Hash);
+				client.ImportAddress(redeem.WitHash);
+				client.ImportAddress(redeem.WitHash.ScriptPubKey.Hash);
+
+				Assert.NotNull(client.GetAddressInfo(addrLegacy));
+				Assert.NotNull(client.GetAddressInfo(addrBech32));
+				Assert.NotNull(client.GetAddressInfo(addrP2SHSegwit));
+				Assert.NotNull(client.GetAddressInfo(redeem.Hash));
+				Assert.NotNull(client.GetAddressInfo(redeem.WitHash));
+				Assert.NotNull(client.GetAddressInfo(redeem.WitHash.ScriptPubKey.Hash));
 			}
 		}
 

--- a/NBitcoin/RPC/GetAddressInfoResponse.cs
+++ b/NBitcoin/RPC/GetAddressInfoResponse.cs
@@ -1,0 +1,104 @@
+#if !NOJSONNET
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace NBitcoin.RPC
+{
+	public class GetAddressInfoResponse : GetAddressInfoScriptInfoResponse
+	{
+		public bool IsMine { get; private set; }
+		public bool? Solvable { get; private set; }
+		public ScanTxoutDescriptor Desc { get; private set; }
+
+		// present only in p2sh-nested case
+		public GetAddressInfoScriptInfoResponse Embedded { get; private set; }
+		public string Label { get; private set; }
+		public bool? IsChange { get; private set; }
+		public bool IsWatchOnly { get; private set; }
+		public DateTimeOffset? Timestamp { get; private set; }
+		public KeyPath HDKeyPath { get; private set; }
+		public uint160 HDSeedID { get; private set; }
+		public uint160 HDMasterKeyID { get; private set; }
+		public List<Dictionary<string, string>> Labels { get; private set; } = new List<Dictionary<string, string>>();
+
+		public bool? IsCompressed { get; private set; }
+
+		public static GetAddressInfoResponse FromJsonResponse(JObject raw, Network network)
+		{
+			var result = new GetAddressInfoResponse();
+			SetSubInfo(result, raw, network);
+			result.IsMine = raw.Property("ismine").Value.Value<bool>();
+			result.Solvable = raw.Property("solvable")?.Value.Value<bool>();
+			result.Desc = raw.Property("desc") == null ? null : new ScanTxoutDescriptor(raw.Property("desc").Value.Value<string>());
+			result.IsWatchOnly = raw.Property("iswatchonly").Value.Value<bool>();
+			result.IsScript = raw.Property("isscript").Value.Value<bool>();
+			result.IsWitness = raw.Property("iswitness").Value.Value<bool>();
+			result.Script = raw.Property("script")?.Value.Value<string>();
+			result.Hex = raw.Property("hex")?.Value.Value<string>();
+			var jEmbedded = raw.Property("embedded");
+			if (jEmbedded != null)
+			{
+				var j = jEmbedded.Value.Value<JObject>();
+				var e = new GetAddressInfoScriptInfoResponse();
+				SetSubInfo(e, j, network);
+				result.Embedded = e;
+			}
+			result.IsCompressed = raw.Property("iscompressed")?.Value.Value<bool>();
+			result.Label = raw.Property("label").Value.Value<string>();
+			result.IsChange = raw.Property("ischange")?.Value.Value<bool>();
+			result.Timestamp = raw.Property("timestamp") == null ? (DateTimeOffset?)null : Utils.UnixTimeToDateTime(raw.Property("timestamp").Value.Value<ulong>());
+			result.HDKeyPath = raw.Property("hdkeypath") == null ? null : KeyPath.Parse(raw.Property("hdkeypath").Value.Value<string>());
+			result.HDSeedID = raw.Property("hdseedid") == null ? null : uint160.Parse(raw.Property("hdseedid").Value.Value<string>());
+			result.HDMasterKeyID = raw.Property("hdmasterkeyid") == null ? null : uint160.Parse(raw.Property("hdmasterkeyid").Value.Value<string>());
+			var jlabels = raw.Property("labels");
+			if (jlabels != null)
+			{
+				var labelObjects = jlabels.Value.Value<JArray>();
+				foreach (var jObj in labelObjects)
+				{
+					result.Labels.Add(((JObject)jObj).ToObject<Dictionary<string, string>>());
+				}
+			}
+
+			return result;
+		}
+
+		private static void SetSubInfo(GetAddressInfoScriptInfoResponse target, JObject raw, Network network)
+		{
+			target.IsWitness = raw.Property("iswitness").Value.Value<bool>();
+			target.IsScript = raw.Property("isscript").Value.Value<bool>();
+			target.Address = BitcoinAddress.Create(raw.Property("address").Value.Value<string>(), network);
+			target.ScriptPubKey = new Script(raw.Property("scriptPubKey").Value.Value<string>());
+			target.PubKey = raw.Property("pubkey") == null ? null : new PubKey(raw.Property("pubkey").Value.Value<string>());
+			var pubkeys = raw.Property("pubkeys");
+			if (pubkeys != null)
+			{
+				foreach (var pk in pubkeys.Value.Values<string>())
+					target.PubKeys.Add(new PubKey(pk));
+			}
+			target.SigsRequired = raw.Property("sigsrequired")?.Value.Value<uint>();
+			target.WitnessVersion = raw.Property("witness_version")?.Value.Value<int>();
+			target.WitnessProgram = raw.Property("witness_program")?.Value.Value<string>();
+		}
+	}
+
+	public class GetAddressInfoScriptInfoResponse
+	{
+		public BitcoinAddress Address { get; internal set; }
+		public Script ScriptPubKey { get; internal set; }
+		public bool IsScript { get; internal set; }
+		public bool IsWitness { get; internal set; }
+
+		// present only in a witness address.
+		public int? WitnessVersion { get; internal set; }
+		// present only in a witness address.
+		public string WitnessProgram { get; internal set; }
+		public string Script { get; internal set; }
+		public string Hex { get; internal set; }
+		public PubKey PubKey { get; internal set; }
+		public List<PubKey> PubKeys { get; internal set; }
+		public uint? SigsRequired { get; internal set; }
+	}
+}
+#endif

--- a/NBitcoin/RPC/RPCClient.Wallet.cs
+++ b/NBitcoin/RPC/RPCClient.Wallet.cs
@@ -86,6 +86,7 @@ namespace NBitcoin.RPC
 		wallet			 getaccountaddress			Yes
 		wallet			 getaccount
 		wallet			 getaddressesbyaccount		Yes
+		wallet			 getaddressesinfo
 		wallet			 getbalance
 		wallet			 getnewaddress
 		wallet			 getrawchangeaddress
@@ -158,6 +159,21 @@ namespace NBitcoin.RPC
 			return FundRawTransactionAsync(transaction, options).GetAwaiter().GetResult();
 		}
 
+		/// <summary>
+		/// throws an error if an address is not from the wallet.
+		/// </summary>
+		/// <param name="address"></param>
+		/// <returns></returns>
+		public GetAddressInfoResponse GetAddressInfo(IDestination address) => GetAddressInfoAsync(address).GetAwaiter().GetResult();
+
+		public async Task<GetAddressInfoResponse> GetAddressInfoAsync(IDestination address)
+		{
+			var addrString = address.ScriptPubKey.GetDestinationAddress(Network).ToString();
+			var response = await SendCommandAsync(RPCOperations.getaddressinfo, addrString);
+
+			return GetAddressInfoResponse.FromJsonResponse((JObject)response.Result, Network);
+		}
+
 		public Money GetBalance(int minConf, bool includeWatchOnly)
 		{
 			return GetBalanceAsync(minConf, includeWatchOnly).GetAwaiter().GetResult();
@@ -187,6 +203,24 @@ namespace NBitcoin.RPC
 			RPCResponse response = null;
 			if (options != null)
 			{
+				var jOptions = FundRawTransactionOptionsToJson(options);
+				response = await SendCommandAsync("fundrawtransaction", ToHex(transaction), jOptions).ConfigureAwait(false);
+			}
+			else
+			{
+				response = await SendCommandAsync("fundrawtransaction", ToHex(transaction)).ConfigureAwait(false);
+			}
+			var r = (JObject)response.Result;
+			return new FundRawTransactionResponse()
+			{
+				Transaction = ParseTxHex(r["hex"].Value<string>()),
+				Fee = Money.Coins(r["fee"].Value<decimal>()),
+				ChangePos = r["changepos"].Value<int>()
+			};
+		}
+
+		private JObject FundRawTransactionOptionsToJson(FundRawTransactionOptions options)
+		{
 				var jOptions = new JObject();
 				if (options.ChangeAddress != null)
 					jOptions.Add(new JProperty("changeAddress", options.ChangeAddress.ToString()));
@@ -207,19 +241,7 @@ namespace NBitcoin.RPC
 					}
 					jOptions.Add(new JProperty("subtractFeeFromOutputs", array));
 				}
-				response = await SendCommandAsync("fundrawtransaction", ToHex(transaction), jOptions).ConfigureAwait(false);
-			}
-			else
-			{
-				response = await SendCommandAsync("fundrawtransaction", ToHex(transaction)).ConfigureAwait(false);
-			}
-			var r = (JObject)response.Result;
-			return new FundRawTransactionResponse()
-			{
-				Transaction = ParseTxHex(r["hex"].Value<string>()),
-				Fee = Money.Coins(r["fee"].Value<decimal>()),
-				ChangePos = r["changepos"].Value<int>()
-			};
+			return jOptions;
 		}
 
 		//NBitcoin internally put a bit in the version number to make difference between transaction without input and transaction with witness.
@@ -779,9 +801,9 @@ namespace NBitcoin.RPC
 			response.Complete = result.Result["complete"].Value<bool>();
 			var errors = result.Result["errors"] as JArray;
 			var errorList = new List<SignRawTransactionResponse.ScriptError>();
-			if(errors != null)
+			if (errors != null)
 			{
-				foreach(var error in errors)
+				foreach (var error in errors)
 				{
 					var scriptError = new SignRawTransactionResponse.ScriptError();
 					scriptError.OutPoint = OutPoint.Parse($"{error["txid"].Value<string>()}-{(int)error["vout"].Value<long>()}");
@@ -868,13 +890,102 @@ namespace NBitcoin.RPC
 			if (psbt == null)
 				throw new ArgumentNullException(nameof(psbt));
 
-			var response = await SendCommandAsync(RPCOperations.walletprocesspsbt, psbt.ToBase64(), sign, SigHashToString(sighashType), bip32derivs ).ConfigureAwait(false);
+			var response = await SendCommandAsync(RPCOperations.walletprocesspsbt, psbt.ToBase64(), sign, SigHashToString(sighashType), bip32derivs).ConfigureAwait(false);
 			var result = (JObject)response.Result;
 			var psbt2 = PSBT.Parse(result.Property("psbt").Value.Value<string>());
 			var complete = result.Property("complete").Value.Value<bool>();
 
 			return new WalletProcessPSBTResponse(psbt2, complete);
 		}
+
+		public WalletCreateFundedPSBTResponse WalletCreateFundedPSBT(
+			TxIn[] inputs,
+			Tuple<Dictionary<BitcoinAddress, Money>, Dictionary<string, string>> outputs,
+			LockTime locktime,
+			FundRawTransactionOptions options = null,
+			bool bip32derivs = false
+			)
+			=> WalletCreateFundedPSBTAsync(inputs, outputs, locktime, options, bip32derivs).GetAwaiter().GetResult();
+
+		public async Task<WalletCreateFundedPSBTResponse> WalletCreateFundedPSBTAsync(
+		TxIn[] inputs,
+		Tuple<Dictionary<BitcoinAddress, Money>, Dictionary<string, string>> outputs,
+		LockTime locktime = default(LockTime),
+		FundRawTransactionOptions options = null,
+		bool bip32derivs = false
+		)
+		{
+			var values = new object[] { };
+			if (inputs == null)
+				inputs = new TxIn[] {};
+			if (outputs == null)
+				throw new ArgumentNullException(nameof(outputs));
+
+			var rpcInputs = inputs.Select(i => i.ToRPCInputs()).ToArray();
+
+			var outputToSend = new JObject {};
+			if (outputs.Item1 != null)
+			{
+				foreach (var kv in outputs.Item1)
+				{
+					outputToSend.Add(kv.Key.ToString(), kv.Value.ToUnit(MoneyUnit.BTC));
+				}
+			}
+			if (outputs.Item2 != null)
+			{
+				foreach (var kv in outputs.Item2)
+				{
+					outputToSend.Add(kv.Key, kv.Value);
+				}
+			}
+			JObject jOptions;
+			if (options != null)
+			{
+				jOptions = FundRawTransactionOptionsToJson(options);
+			}
+			else
+			{
+				jOptions = (JObject)"";
+			}
+			RPCResponse response = await SendCommandAsync(
+				"walletcreatefundedpsbt",
+				rpcInputs,
+				outputToSend,
+				locktime.Value,
+				jOptions,
+				bip32derivs).ConfigureAwait(false);
+			var result = (JObject)response.Result;
+			var psbt = PSBT.Parse(result.Property("psbt").Value.Value<string>());
+			var fee = Money.Coins(result.Property("fee").Value.Value<decimal>());
+			var changePos = result.Property("changepos").Value.Value<int>();
+			var tmp = changePos == -1 ? (int?)null : (int?)changePos;
+			return new WalletCreateFundedPSBTResponse { PSBT = psbt, Fee = fee, ChangePos = tmp };
+		}
+		public WalletCreateFundedPSBTResponse WalletCreateFundedPSBT(
+			TxIn[] inputs,
+			Dictionary<BitcoinAddress, Money> outputs,
+			LockTime locktime,
+			FundRawTransactionOptions options = null,
+			bool bip32derivs = false
+		) => WalletCreateFundedPSBT(
+			inputs,
+			Tuple.Create<Dictionary<BitcoinAddress, Money>, Dictionary<string, string>>(outputs, null),
+			locktime,
+			options,
+			bip32derivs);
+
+		public WalletCreateFundedPSBTResponse WalletCreateFundedPSBT(
+			TxIn[] inputs,
+			Dictionary<string, string> outputs,
+			LockTime locktime,
+			FundRawTransactionOptions options = null,
+			bool bip32derivs = false
+		) => WalletCreateFundedPSBT(
+			inputs,
+			Tuple.Create<Dictionary<BitcoinAddress, Money>, Dictionary<string, string>>(null, outputs),
+			locktime,
+			options,
+			bip32derivs);
 
 		public string SigHashToString(SigHash value)
 		{

--- a/NBitcoin/RPC/RPCOperations.cs
+++ b/NBitcoin/RPC/RPCOperations.cs
@@ -48,6 +48,7 @@ namespace NBitcoin.RPC
 		verifymessage,
 		getreceivedbyaddress,
 		getreceivedbyaccount,
+		getaddressinfo,
 		getbalance,
 		getunconfirmedbalance,
 		movecmd,

--- a/NBitcoin/RPC/RPCTransactionInput.cs
+++ b/NBitcoin/RPC/RPCTransactionInput.cs
@@ -1,0 +1,30 @@
+#if !NOJSONNET
+using Newtonsoft.Json;
+namespace NBitcoin.RPC
+{
+	public class RPCTransactionInput
+	{
+		[JsonProperty("txid", NullValueHandling = NullValueHandling.Ignore)]
+		public uint256 TxId { get; set; }
+		[JsonProperty("vout", NullValueHandling = NullValueHandling.Ignore)]
+		public uint vout { get; set; }
+		[JsonProperty("sequence", NullValueHandling = NullValueHandling.Ignore)]
+		public Sequence nSequence { get; set; }
+
+		public RPCTransactionInput(TxIn txin)
+		{
+			TxId = txin.PrevOut.Hash;
+			vout = txin.PrevOut.N;
+			nSequence = txin.Sequence;
+		}
+	}
+
+	public static class TxInExtension
+	{
+		public static RPCTransactionInput ToRPCInputs(this TxIn txin)
+		{
+			return new RPCTransactionInput(txin);
+		}
+	}
+}
+#endif

--- a/NBitcoin/RPC/WalletCreateFundedPSBTResponse.cs
+++ b/NBitcoin/RPC/WalletCreateFundedPSBTResponse.cs
@@ -1,0 +1,11 @@
+using NBitcoin.BIP174;
+
+namespace NBitcoin.RPC
+{
+	public class WalletCreateFundedPSBTResponse
+	{
+		public PSBT PSBT { get; internal set; }
+		public Money Fee { get; internal set; }
+		public int? ChangePos { get; internal set; }
+	}
+}


### PR DESCRIPTION
This is part of #627 , and it depends on #630 and #631 

Both tests depend on `importmulti` , but this does not support witness script in v0.17.
So ignore the case for p2wsh and p2sh-p2wsh.
maybe it is good to not merge until master bumps to v0.18 :(