### PR TITLE
Money: add long/ulong constructors that accept the MoneyUnit param

### DIFF
--- a/NBitcoin/Money.cs
+++ b/NBitcoin/Money.cs
@@ -380,6 +380,27 @@ namespace NBitcoin
 		}
 
 
+		public Money(long amount, MoneyUnit unit)
+		{
+			// sanity check. Only valid units are allowed
+			CheckMoneyUnit(unit, "unit");
+			checked
+			{
+				Satoshi = amount * (int)unit;
+			}
+		}
+
+		public Money(ulong amount, MoneyUnit unit)
+		{
+			// sanity check. Only valid units are allowed
+			CheckMoneyUnit(unit, "unit");
+			checked
+			{
+				var satoshi = (long)amount * (int)unit;
+				Satoshi = satoshi;
+			}
+		}
+
 		/// <summary>
 		/// Split the Money in parts without loss
 		/// </summary>


### PR DESCRIPTION
If MoneyUnit.Satoshi exists, it's only logical to have overloads
with long/ulong versions of `amount` parameter when MoneyUnit.Satoshi
is used in the constructor.