### PR TITLE
Dash 0.13 Special Transactions support

### DIFF
--- a/NBitcoin.Altcoins/Dash.cs
+++ b/NBitcoin.Altcoins/Dash.cs
@@ -5,10 +5,12 @@ using NBitcoin.Protocol;
 using NBitcoin.RPC;
 using System;
 using System.Collections.Generic;
+using System.Data.SqlTypes;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace NBitcoin.Altcoins
 {
@@ -36,9 +38,15 @@ namespace NBitcoin.Altcoins
 			{
 				return new DashBlockHeader();
 			}
+
 			public override Block CreateBlock()
 			{
 				return new DashBlock(new DashBlockHeader());
+			}
+
+			public override Transaction CreateTransaction()
+			{
+				return new DashTransaction();
 			}
 		}
 
@@ -57,6 +65,348 @@ namespace NBitcoin.Altcoins
 			}
 		}
 
+		/// <summary>
+		/// Transactions with version >= 3 have a special transaction type in the version code
+		/// https://docs.dash.org/en/stable/merchants/technical.html#v0-13-0-integration-notes
+		/// 0.14 will add more types: https://github.com/dashpay/dips/blob/master/dip-0002-special-transactions.md
+		/// </summary>
+		public enum DashTransactionType
+		{
+			StandardTransaction = 0,
+			MasternodeRegistration = 1,
+			UpdateMasternodeService = 2,
+			UpdateMasternodeOperator = 3,
+			MasternodeRevocation = 4,
+			MasternodeListMerkleProof = 5,
+			QuorumCommitment = 6
+		}
+
+		public abstract class SpecialTransaction
+		{
+			protected SpecialTransaction(byte[] extraPayload)
+			{
+				data = new BinaryReader(new MemoryStream(extraPayload));
+				Version = data.ReadUInt16();
+			}
+
+			protected readonly BinaryReader data;
+			/// <summary>
+			/// Version number. Currently set to 1 for all DashTransactionTypes
+			/// </summary>
+			public ushort Version { get; set; }
+	  
+			/// <summary>
+			/// https://github.com/dashevo/dashcore-lib/blob/master/lib/constants/index.js
+			/// </summary>
+			public const int PUBKEY_ID_SIZE = 20;
+			public const int COMPACT_SIGNATURE_SIZE = 65;
+			public const int SHA256_HASH_SIZE = 32;
+			public const int BLS_PUBLIC_KEY_SIZE = 48;
+			public const int BLS_SIGNATURE_SIZE = 96;
+			public const int IpAddressLength = 16;
+			
+			protected void MakeSureWeAreAtEndOfPayload()
+			{
+				if (data.BaseStream.Position < data.BaseStream.Length)
+					throw new Exception(
+						"Failed to parse payload: raw payload is bigger than expected (pos=" +
+						data.BaseStream.Position + ", len=" + data.BaseStream.Length + ")");
+			}
+		}
+
+		/// <summary>
+		/// https://github.com/dashpay/dips/blob/master/dip-0003.md
+		/// </summary>
+		public class ProviderRegistrationTransaction : SpecialTransaction
+		{
+			public ProviderRegistrationTransaction(byte[] extraPayload) : base(extraPayload)
+			{
+				Type = data.ReadUInt16();
+				Mode = data.ReadUInt16();
+				CollateralHash = new uint256(data.ReadBytes(SHA256_HASH_SIZE), true);
+				CollateralIndex = data.ReadUInt32();
+				IpAddress = data.ReadBytes(IpAddressLength);
+				Port = BitConverter.ToUInt16(data.ReadBytes(2).Reverse().ToArray(), 0);
+				KeyIdOwner = new uint160(data.ReadBytes(PUBKEY_ID_SIZE), true);
+				KeyIdOperator = data.ReadBytes(BLS_PUBLIC_KEY_SIZE);
+				KeyIdVoting = new uint160(data.ReadBytes(PUBKEY_ID_SIZE), true);
+				OperatorReward = data.ReadUInt16();
+				var bs = new BitcoinStream(data.BaseStream, false);
+				bs.ReadWriteAsVarInt(ref ScriptPayoutSize);
+				ScriptPayout = new Script(data.ReadBytes((int)ScriptPayoutSize));
+				InputsHash = new uint256(data.ReadBytes(SHA256_HASH_SIZE), true);
+				bs.ReadWriteAsVarInt(ref PayloadSigSize);
+				PayloadSig = data.ReadBytes((int)PayloadSigSize);
+				MakeSureWeAreAtEndOfPayload();
+			}
+
+			public ushort Type { get; set; }
+			public ushort Mode { get; set; }
+			public uint256 CollateralHash { get; set; }
+			public uint CollateralIndex { get; set; }
+			public byte[] IpAddress { get; set; }
+			public ushort Port { get; set; }
+			public uint160 KeyIdOwner { get; set; }
+			public byte[] KeyIdOperator { get; set; }
+			public uint160 KeyIdVoting { get; set; }
+			public ushort OperatorReward { get; set; }
+			public uint ScriptPayoutSize;
+			public Script ScriptPayout { get; set; }
+			public uint256 InputsHash { get; set; }
+			public uint PayloadSigSize;
+			public byte[] PayloadSig { get; set; }
+		}
+	
+		public class ProviderUpdateServiceTransaction : SpecialTransaction
+		{
+			public ProviderUpdateServiceTransaction(byte[] extraPayload) : base(extraPayload)
+			{
+				ProTXHash = new uint256(data.ReadBytes(SHA256_HASH_SIZE), true);
+				IpAddress = data.ReadBytes(IpAddressLength);
+				Port = BitConverter.ToUInt16(data.ReadBytes(2).Reverse().ToArray(), 0);
+				var bs = new BitcoinStream(data.BaseStream, false);
+				bs.ReadWriteAsVarInt(ref ScriptOperatorPayoutSize);
+				ScriptOperatorPayout = new Script(data.ReadBytes((int)ScriptOperatorPayoutSize));
+				InputsHash = new uint256(data.ReadBytes(SHA256_HASH_SIZE), true);
+				PayloadSig = data.ReadBytes(BLS_SIGNATURE_SIZE);
+				MakeSureWeAreAtEndOfPayload();
+			}
+
+			public uint256 ProTXHash { get; set; }
+			public byte[] IpAddress { get; set; }
+			public ushort Port { get; set; }
+			public uint ScriptOperatorPayoutSize;
+			public Script ScriptOperatorPayout { get; set; }
+			public uint256 InputsHash { get; set; }
+			public byte[] PayloadSig { get; set; }
+		}
+	
+		public class ProviderUpdateRegistrarTransaction : SpecialTransaction
+		{
+			public ProviderUpdateRegistrarTransaction(byte[] extraPayload) : base(extraPayload)
+			{
+				ProTXHash = new uint256(data.ReadBytes(SHA256_HASH_SIZE), true);
+				Mode = data.ReadUInt16();
+				PubKeyOperator = data.ReadBytes(BLS_PUBLIC_KEY_SIZE);
+				KeyIdVoting = new uint160(data.ReadBytes(PUBKEY_ID_SIZE), true);
+				var bs = new BitcoinStream(data.BaseStream, false);
+				bs.ReadWriteAsVarInt(ref ScriptPayoutSize);
+				ScriptPayout = new Script(data.ReadBytes((int)ScriptPayoutSize));
+				InputsHash = new uint256(data.ReadBytes(SHA256_HASH_SIZE), true);
+				if (data.BaseStream.Position < data.BaseStream.Length)
+				{
+					bs.ReadWriteAsVarInt(ref PayloadSigSize);
+					PayloadSig = data.ReadBytes((int)PayloadSigSize);
+				}
+				else
+					PayloadSig = new byte[0];
+				MakeSureWeAreAtEndOfPayload();
+			}
+
+			public uint256 ProTXHash { get; set; }
+			public ushort Mode { get; set; }
+			public byte[] PubKeyOperator { get; set; }
+			public uint160 KeyIdVoting { get; set; }
+			public uint ScriptPayoutSize;
+			public Script ScriptPayout { get; set; }
+			public uint256 InputsHash { get; set; }
+			public uint PayloadSigSize;
+			public byte[] PayloadSig { get; set; }
+		}
+	
+		public class ProviderUpdateRevocationTransaction : SpecialTransaction
+		{
+			public ProviderUpdateRevocationTransaction(byte[] extraPayload) : base(extraPayload)
+			{
+				ProTXHash = new uint256(data.ReadBytes(SHA256_HASH_SIZE), true);
+				Reason = data.ReadUInt16();
+				InputsHash = new uint256(data.ReadBytes(SHA256_HASH_SIZE), true);
+				PayloadSig = data.ReadBytes(BLS_SIGNATURE_SIZE);
+				MakeSureWeAreAtEndOfPayload();
+			}
+
+			public uint256 ProTXHash { get; set; }
+			public ushort Reason { get; set; }
+			public uint256 InputsHash { get; set; }
+			public uint PayloadSigSize;
+			public byte[] PayloadSig { get; set; }
+		}
+
+		public abstract class SpecialTransactionWithHeight : SpecialTransaction
+		{
+			protected SpecialTransactionWithHeight(byte[] extraPayload) : base(extraPayload)
+			{
+				Height = data.ReadUInt32();
+			}
+
+			/// <summary>
+			/// Height of the block
+			/// </summary>
+			public uint Height { get; set; }
+		}
+
+		/// <summary>
+		/// For DashTransactionType.MasternodeListMerkleProof
+		/// https://github.com/dashpay/dips/blob/master/dip-0004.md
+		/// Only needs deserialization here, ExtraPayload can still be serialized
+		/// </summary>
+		public class CoinbaseSpecialTransaction : SpecialTransactionWithHeight
+		{
+			public CoinbaseSpecialTransaction(byte[] extraPayload) : base(extraPayload)
+			{
+				MerkleRootMNList = new uint256(data.ReadBytes(SHA256_HASH_SIZE));
+				MakeSureWeAreAtEndOfPayload();
+			}
+
+			/// <summary>
+			/// Merkle root of the masternode list
+			/// </summary>
+			public uint256 MerkleRootMNList { get; set; }
+		}
+
+		/// <summary>
+		/// https://github.com/dashevo/dashcore-lib/blob/master/lib/transaction/payload/commitmenttxpayload.js
+		/// </summary>
+		public class QuorumCommitmentTransaction : SpecialTransactionWithHeight
+		{
+			public QuorumCommitmentTransaction(byte[] extraPayload) : base(extraPayload)
+			{
+				Commitment = new QuorumCommitment(data);
+				MakeSureWeAreAtEndOfPayload();
+			}
+
+			public QuorumCommitment Commitment { get; set; }
+		}
+
+		public class QuorumCommitment
+		{
+			public QuorumCommitment(BinaryReader data)
+			{
+				QfcVersion = data.ReadUInt16();
+				LlmqType = data.ReadByte();
+				QuorumHash = new uint256(data.ReadBytes(SpecialTransaction.SHA256_HASH_SIZE));
+				var bs = new BitcoinStream(data.BaseStream, false);
+				bs.ReadWriteAsVarInt(ref SignersSize);
+				Signers = data.ReadBytes(((int)SignersSize + 7) / 8);
+				bs.ReadWriteAsVarInt(ref ValidMembersSize);
+				ValidMembers = data.ReadBytes(((int)ValidMembersSize + 7) / 8);
+				QuorumPublicKey = data.ReadBytes(SpecialTransaction.BLS_PUBLIC_KEY_SIZE);
+				QuorumVvecHash = new uint256(data.ReadBytes(SpecialTransaction.SHA256_HASH_SIZE));
+				QuorumSig = data.ReadBytes(SpecialTransaction.BLS_SIGNATURE_SIZE);
+				Sig = data.ReadBytes(SpecialTransaction.BLS_SIGNATURE_SIZE);
+			}
+
+			public ushort QfcVersion { get; set; }
+			public byte LlmqType { get; set; }
+			public uint256 QuorumHash { get; set; }
+			public uint SignersSize;
+			public byte[] Signers { get; set; }
+			public uint ValidMembersSize;
+			public byte[] ValidMembers { get; set; }
+			public byte[] QuorumPublicKey { get; set; }
+			public uint256 QuorumVvecHash { get; set; }
+			public byte[] QuorumSig { get; set; }
+			public byte[] Sig { get; set; }
+		}
+
+		/// <summary>
+		/// https://docs.dash.org/en/stable/merchants/technical.html#v0-13-0-integration-notes
+		/// </summary>
+		public class DashTransaction : Transaction
+		{
+			public uint DashVersion
+			{
+				get
+				{
+					return Version & 0xffff;
+				}
+			}
+			public DashTransactionType DashType
+			{
+				get
+				{
+					return (DashTransactionType)((Version >> 16) & 0xffff);
+				}
+			}
+			public byte[] ExtraPayload = new byte[0];
+			/*
+			MasternodeRegistration = 1,
+			 = 2,
+			 = 3,
+			 = 4,
+			*/
+			public ProviderRegistrationTransaction ProRegTx
+			{
+				get
+				{
+					return DashType == DashTransactionType.MasternodeRegistration
+						? new ProviderRegistrationTransaction(ExtraPayload)
+						: null;
+				}
+			}
+			public ProviderUpdateServiceTransaction ProUpServTx
+			{
+				get
+				{
+					return DashType == DashTransactionType.UpdateMasternodeService
+						? new ProviderUpdateServiceTransaction(ExtraPayload)
+						: null;
+				}
+			}
+			public ProviderUpdateRegistrarTransaction ProUpRegTx
+			{
+				get
+				{
+					return DashType == DashTransactionType.UpdateMasternodeOperator
+						? new ProviderUpdateRegistrarTransaction(ExtraPayload)
+						: null;
+				}
+			}
+			public ProviderUpdateRevocationTransaction ProUpRevTx
+			{
+				get
+				{
+					return DashType == DashTransactionType.MasternodeRevocation
+						? new ProviderUpdateRevocationTransaction(ExtraPayload)
+						: null;
+				}
+			}
+			public CoinbaseSpecialTransaction CbTx
+			{
+				get
+				{
+					return DashType == DashTransactionType.MasternodeListMerkleProof
+						? new CoinbaseSpecialTransaction(ExtraPayload)
+						: null;
+				}
+			}
+			public QuorumCommitmentTransaction QcTx
+			{
+				get
+				{
+					return DashType == DashTransactionType.QuorumCommitment
+						? new QuorumCommitmentTransaction(ExtraPayload)
+						: null;
+				}
+			}
+	  
+			public override void ReadWrite(BitcoinStream stream)
+			{
+				base.ReadWrite(stream);
+				// Support for Dash 0.13 extraPayload for Special Transactions
+				// https://github.com/dashpay/dips/blob/master/dip-0002-special-transactions.md
+				if (DashVersion >= 3 && DashType != DashTransactionType.StandardTransaction)
+				{
+					// Extra payload size is VarInt
+					uint extraPayloadSize = (uint)ExtraPayload.Length;
+					stream.ReadWriteAsVarInt(ref extraPayloadSize);
+					if (ExtraPayload.Length != extraPayloadSize)
+						ExtraPayload = new byte[extraPayloadSize];
+					stream.ReadWrite(ref ExtraPayload);
+				}
+			}
+		}
+
 		public class DashBlock : Block
 		{
 #pragma warning disable CS0612 // Type or member is obsolete
@@ -67,7 +417,13 @@ namespace NBitcoin.Altcoins
 			}
 			public override ConsensusFactory GetConsensusFactory()
 			{
-				return Dash.Instance.Mainnet.Consensus.ConsensusFactory;
+				return Instance.Mainnet.Consensus.ConsensusFactory;
+			}
+
+			public override string ToString()
+			{
+				return "DashBlock " + Header.ToString() + ", Height=" + GetCoinbaseHeight() +
+					", Version=" + Header.Version + ", Txs=" + Transactions.Count;
 			}
 		}
 #pragma warning restore CS0618 // Type or member is obsolete
@@ -80,7 +436,7 @@ namespace NBitcoin.Altcoins
 		static uint256 GetPoWHash(BlockHeader header)
 		{
 			var headerBytes = header.ToBytes();
-			var h = NBitcoin.Crypto.SCrypt.ComputeDerivedKey(headerBytes, headerBytes, 1024, 1, 1, null, 32);
+			var h = SCrypt.ComputeDerivedKey(headerBytes, headerBytes, 1024, 1, 1, null, 32);
 			return new uint256(h);
 		}
 

--- a/NBitcoin.Altcoins/Dash.cs
+++ b/NBitcoin.Altcoins/Dash.cs
@@ -1,16 +1,9 @@
-﻿using NBitcoin;
-using NBitcoin.Crypto;
+﻿using NBitcoin.Crypto;
 using NBitcoin.DataEncoders;
 using NBitcoin.Protocol;
-using NBitcoin.RPC;
 using System;
-using System.Collections.Generic;
-using System.Data.SqlTypes;
 using System.IO;
 using System.Linq;
-using System.Net;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
 
 namespace NBitcoin.Altcoins
 {
@@ -32,6 +25,7 @@ namespace NBitcoin.Altcoins
 			{
 			}
 
+			// ReSharper disable once MemberHidesStaticFromOuterClass
 			public static DashConsensusFactory Instance { get; } = new DashConsensusFactory();
 
 			public override BlockHeader CreateBlockHeader()
@@ -314,82 +308,34 @@ namespace NBitcoin.Altcoins
 		/// </summary>
 		public class DashTransaction : Transaction
 		{
-			public uint DashVersion
-			{
-				get
-				{
-					return Version & 0xffff;
-				}
-			}
-			public DashTransactionType DashType
-			{
-				get
-				{
-					return (DashTransactionType)((Version >> 16) & 0xffff);
-				}
-			}
+			public uint DashVersion => Version & 0xffff;
+			public DashTransactionType DashType => (DashTransactionType)((Version >> 16) & 0xffff);
 			public byte[] ExtraPayload = new byte[0];
-			/*
-			MasternodeRegistration = 1,
-			 = 2,
-			 = 3,
-			 = 4,
-			*/
-			public ProviderRegistrationTransaction ProRegTx
-			{
-				get
-				{
-					return DashType == DashTransactionType.MasternodeRegistration
-						? new ProviderRegistrationTransaction(ExtraPayload)
-						: null;
-				}
-			}
-			public ProviderUpdateServiceTransaction ProUpServTx
-			{
-				get
-				{
-					return DashType == DashTransactionType.UpdateMasternodeService
-						? new ProviderUpdateServiceTransaction(ExtraPayload)
-						: null;
-				}
-			}
-			public ProviderUpdateRegistrarTransaction ProUpRegTx
-			{
-				get
-				{
-					return DashType == DashTransactionType.UpdateMasternodeOperator
-						? new ProviderUpdateRegistrarTransaction(ExtraPayload)
-						: null;
-				}
-			}
-			public ProviderUpdateRevocationTransaction ProUpRevTx
-			{
-				get
-				{
-					return DashType == DashTransactionType.MasternodeRevocation
-						? new ProviderUpdateRevocationTransaction(ExtraPayload)
-						: null;
-				}
-			}
-			public CoinbaseSpecialTransaction CbTx
-			{
-				get
-				{
-					return DashType == DashTransactionType.MasternodeListMerkleProof
-						? new CoinbaseSpecialTransaction(ExtraPayload)
-						: null;
-				}
-			}
-			public QuorumCommitmentTransaction QcTx
-			{
-				get
-				{
-					return DashType == DashTransactionType.QuorumCommitment
-						? new QuorumCommitmentTransaction(ExtraPayload)
-						: null;
-				}
-			}
-	  
+			public ProviderRegistrationTransaction ProRegTx =>
+				DashType == DashTransactionType.MasternodeRegistration
+					? new ProviderRegistrationTransaction(ExtraPayload)
+					: null;
+			public ProviderUpdateServiceTransaction ProUpServTx =>
+				DashType == DashTransactionType.UpdateMasternodeService
+					? new ProviderUpdateServiceTransaction(ExtraPayload)
+					: null;
+			public ProviderUpdateRegistrarTransaction ProUpRegTx =>
+				DashType == DashTransactionType.UpdateMasternodeOperator
+					? new ProviderUpdateRegistrarTransaction(ExtraPayload)
+					: null;
+			public ProviderUpdateRevocationTransaction ProUpRevTx =>
+				DashType == DashTransactionType.MasternodeRevocation
+					? new ProviderUpdateRevocationTransaction(ExtraPayload)
+					: null;
+			public CoinbaseSpecialTransaction CbTx =>
+				DashType == DashTransactionType.MasternodeListMerkleProof
+					? new CoinbaseSpecialTransaction(ExtraPayload)
+					: null;
+			public QuorumCommitmentTransaction QcTx =>
+				DashType == DashTransactionType.QuorumCommitment
+					? new QuorumCommitmentTransaction(ExtraPayload)
+					: null;
+
 			public override void ReadWrite(BitcoinStream stream)
 			{
 				base.ReadWrite(stream);
@@ -422,7 +368,7 @@ namespace NBitcoin.Altcoins
 
 			public override string ToString()
 			{
-				return "DashBlock " + Header.ToString() + ", Height=" + GetCoinbaseHeight() +
+				return "DashBlock " + Header + ", Height=" + GetCoinbaseHeight() +
 					", Version=" + Header.Version + ", Txs=" + Transactions.Count;
 			}
 		}
@@ -472,7 +418,7 @@ namespace NBitcoin.Altcoins
 			.SetMagic(0xBD6B0CBF)
 			.SetPort(9999)
 			.SetRPCPort(9998)
-			.SetMaxP2PVersion(70208)
+			.SetMaxP2PVersion(70213)
 			.SetName("dash-main")
 			.AddAlias("dash-mainnet")
 			.AddDNSSeeds(new[]
@@ -490,7 +436,7 @@ namespace NBitcoin.Altcoins
 		protected override NetworkBuilder CreateTestnet()
 		{
 			var builder = new NetworkBuilder();
-			var res = builder.SetConsensus(new Consensus()
+			builder.SetConsensus(new Consensus()
 			{
 				SubsidyHalvingInterval = 210240,
 				MajorityEnforceBlockUpgrade = 51,
@@ -519,7 +465,7 @@ namespace NBitcoin.Altcoins
 			.SetMagic(0xFFCAE2CE)
 			.SetPort(19999)
 			.SetRPCPort(19998)
-			.SetMaxP2PVersion(70208)
+			.SetMaxP2PVersion(70213)
 		   .SetName("dash-test")
 		   .AddAlias("dash-testnet")
 		   .AddDNSSeeds(new[]
@@ -564,7 +510,7 @@ namespace NBitcoin.Altcoins
 			.SetMagic(0xDCB7C1FC)
 			.SetPort(19994)
 			.SetRPCPort(19993)
-			.SetMaxP2PVersion(70208)
+			.SetMaxP2PVersion(70213)
 			.SetName("dash-reg")
 			.AddAlias("dash-regtest")
 			.AddDNSSeeds(new DNSSeedData[0])

--- a/NBitcoin.TestFramework/WellknownNodeDownloadData.cs
+++ b/NBitcoin.TestFramework/WellknownNodeDownloadData.cs
@@ -285,29 +285,29 @@
 
 		public class DashNodeDownloadData
 		{
-			public NodeDownloadData v0_12_2 = new NodeDownloadData()
+			public NodeDownloadData v0_13_0 = new NodeDownloadData()
 			{
-				Version = "0.12.2.3",
+				Version = "0.13.0.0",
 				Windows = new NodeOSDownloadData()
 				{
 					DownloadLink = "https://github.com/dashpay/dash/releases/download/v{0}/dashcore-{0}-win64.zip",
 					Archive = "dashcore-{0}-win64.zip",
-					Executable = "dashcore-0.12.2/bin/dashd.exe",
-					Hash = "04e95d11443d785ad9d98b04fd2313ca96d937e424be80f639b73846304d154c"
+					Executable = "dashcore-0.13.0/bin/dashd.exe",
+					Hash = "89d2e06701f948cfecea612fb6b1a0175227108990a29849fc6fcc8a28fb62fd"
 				},
 				Linux = new NodeOSDownloadData()
 				{
-					DownloadLink = "https://github.com/dashpay/dash/releases/download/v{0}/dashcore-{0}-linux64.tar.gz",
-					Archive = "dashcore-{0}-linux64.tar.gz",
-					Executable = "dashcore-0.12.2/bin/dashd",
-					Hash = "8b7c72197f87be1f5d988c274cac06f6539ddb4591a578bfb852a412022378f2"
+					DownloadLink = "https://github.com/dashpay/dash/releases/download/v{0}/dashcore-{0}-x86_64-linux-gnu.tar.gz",
+					Archive = "dashcore-{0}-x86_64-linux-gnu.tar.gz",
+					Executable = "dashcore-0.13.0/bin/dashd",
+					Hash = "99b4309c7f53b2a93d4b60a45885000b88947af2f329e24ca757ff8cf882ab18"
 				},
 				Mac = new NodeOSDownloadData()
 				{
-					DownloadLink = "https://github.com/dashpay/dash/releases/download/v{0}/dashcore-{0}-osx.dmg",
-					Archive = "dashcore-{0}-osx.dmg",
-					Executable = "dashcore-0.12.2/bin/dashd",
-					Hash = "90ca27d6733df6fc69b0fc8220f2315623fe5b0cbd1fe31f247684d51808cb81"
+					DownloadLink = "https://github.com/dashpay/dash/releases/download/v{0}/dashcore-{0}-osx-unsigned.dmg",
+					Archive = "dashcore-{0}-osx-unsigned.dmg",
+					Executable = "dashcore-0.13.0/bin/dashd",
+					Hash = "6f97f502732e5b63a431d0edb5a9d14e95ff8afb8e7eb94463566a75e7589a70"
 				}
 			};
 		}

--- a/NBitcoin.Tests/DashTests.cs
+++ b/NBitcoin.Tests/DashTests.cs
@@ -1,11 +1,6 @@
-﻿using System.Net;
-using System.Threading.Tasks;
-using NBitcoin.Altcoins;
+﻿using NBitcoin.Altcoins;
 using NBitcoin.DataEncoders;
-using NBitcoin.RPC;
-using Newtonsoft.Json;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace NBitcoin.Tests
 {
@@ -209,6 +204,7 @@ namespace NBitcoin.Tests
 			Assert.Equal(Hex, tx.ToHex());
 		}
 
+		/*for manually testing via running Dash Testnet node
 		public DashTests(ITestOutputHelper output)
 		{
 			this.output = output;
@@ -216,7 +212,7 @@ namespace NBitcoin.Tests
 
 		private readonly ITestOutputHelper output;
 
-		//[Fact(DisplayName = "Enable manually to test when having local Dash testnet running")]
+		[Fact(DisplayName = "Enable manually to test when having local Dash testnet running")]
 		public async Task ConnectToDashTestnetAndCheckBlock7000()
 		{
 			var connectionString = new RPCCredentialString();
@@ -302,5 +298,6 @@ namespace NBitcoin.Tests
 			Assert.Equal("000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", Encoders.Hex.EncodeData(tx.QcTx.Commitment.QuorumPublicKey));
 			Assert.Equal("03000600000000000000fd49010100581b0000010001e3aeae4a2d013f6bdd3525318bcc579f95c3420e8897a23e8a479f1c39000000320000000000000032000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", tx.ToHex());
 		}
+		*/
 	}
 }

--- a/NBitcoin.Tests/DashTests.cs
+++ b/NBitcoin.Tests/DashTests.cs
@@ -1,0 +1,306 @@
+﻿using System.Net;
+using System.Threading.Tasks;
+using NBitcoin.Altcoins;
+using NBitcoin.DataEncoders;
+using NBitcoin.RPC;
+using Newtonsoft.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NBitcoin.Tests
+{
+	/// <summary>
+	/// Ensures all Dash Special Transaction types can be read
+	/// https://github.com/dashpay/dips/blob/master/dip-0002-special-transactions.md
+	/// Also fixes https://github.com/MetacoSA/NBitcoin/issues/607
+	/// </summary>
+	public class DashTests
+	{
+		/// <summary>
+		/// https://github.com/dashevo/dashcore-lib/blob/master/test/transaction/payload/proregtxpayload.js
+		/// </summary>
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void CanReadProviderRegistrationTransaction()
+		{
+			var proRegTx = new Dash.ProviderRegistrationTransaction(Encoders.Hex.DecodeData("010000000000effd6116c0bbe178d2e224c0f7fed5313a0b46dd222d63c5196319e2110db1031000000000000000000000000000ffff12ca34aa88c79f25f019d640ab50b569121967fabf3a2c74539b15ddc5d0053e2f3a2e70dbb1808ec60844ac4c8ba5fac73c9b6abbab23ef09df0d2347f2a3182eabead0027a2137e59c9f25f019d640ab50b569121967fabf3a2c74539bc9001976a914de77802bd7fcd19277b5229ac44085e3b3a3687088ac991c137dc07e13f02e188b2f97725f0f4487a0cd502ac8eb3fbc88e3c2f0d4ca411fe30ecf9cc167ff85f7d73efe9506de44762447063a62fbe82f19af39d6a353734ad0cd835d6b38cbe5a965b27a2be353ebe4a6a08e50510027c484ba74c4734c"));
+			Assert.Equal(1, proRegTx.Version);
+			Assert.Equal(0, proRegTx.Type);
+			Assert.Equal(0, proRegTx.Mode);
+			Assert.Equal("03b10d11e2196319c5632d22dd460b3a31d5fef7c024e2d278e1bbc01661fdef", proRegTx.CollateralHash.ToString());
+			Assert.Equal((uint)16, proRegTx.CollateralIndex);
+			Assert.Equal("00000000000000000000ffff12ca34aa", Encoders.Hex.EncodeData(proRegTx.IpAddress));
+			Assert.Equal(35015, proRegTx.Port);
+			Assert.Equal("9b53742c3abffa67191269b550ab40d619f0259f", proRegTx.KeyIdOwner.ToString());
+			Assert.Equal("15ddc5d0053e2f3a2e70dbb1808ec60844ac4c8ba5fac73c9b6abbab23ef09df0d2347f2a3182eabead0027a2137e59c", Encoders.Hex.EncodeData(proRegTx.KeyIdOperator));
+			Assert.Equal("9b53742c3abffa67191269b550ab40d619f0259f", proRegTx.KeyIdVoting.ToString());
+			Assert.Equal("76a914de77802bd7fcd19277b5229ac44085e3b3a3687088ac", Encoders.Hex.EncodeData(proRegTx.ScriptPayout.ToBytes()));
+			Assert.Equal(201, proRegTx.OperatorReward);
+			Assert.Equal("cad4f0c2e388bc3febc82a50cda087440f5f72972f8b182ef0137ec07d131c99",
+				proRegTx.InputsHash.ToString());
+			Assert.Equal("1fe30ecf9cc167ff85f7d73efe9506de44762447063a62fbe82f19af39d6a353734ad0cd835d6b38cbe5a965b27a2be353ebe4a6a08e50510027c484ba74c4734c", Encoders.Hex.EncodeData(proRegTx.PayloadSig));
+		}
+
+		/// <summary>
+		/// Checking example from
+		/// https://github.com/dashpay/docs/raw/master/binary/merchants/Integration-Resources-Dash-v0.13.0-Transaction-Types.pdf
+		/// </summary>
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void CanReadExampleProviderRegistrationTransaction()
+		{
+			var proRegTx = new Dash.ProviderRegistrationTransaction(Encoders.Hex.DecodeData("01000000000026d3cb36b5360a23f5f4a2ea4c98d385c0c7a80788439f52a237717d799356a60100000000000000000000000000ffffc38d008f4e1f8a94fb062049b841f716dcded8257a3632fb053c8273ec203d1ea62cbdb54e10618329e4ed93e99bc9c5ab2f4cb0055ad281f9ad0808a1dda6aedf12c41c53142828879b8a94fb062049b841f716dcded8257a3632fb053c00001976a914e4876df5735eaa10a761dca8d62a7a275349022188acbc1055e0331ea0ea63caf80e0a7f417e50df6469a97db1f4f1d81990316a5e0b412045323bca7defef188065a6b30fb3057e4978b4f914e4e8cc0324098ae60ff825693095b927cd9707fe10edbf8ef901fcbc63eb9a0e7cd6fed39d50a8cde1cdb4"));
+			Assert.Equal(1, proRegTx.Version);
+			Assert.Equal(0, proRegTx.Type);
+			Assert.Equal(0, proRegTx.Mode);
+			Assert.Equal("a65693797d7137a2529f438807a8c7c085d3984ceaa2f4f5230a36b536cbd326", proRegTx.CollateralHash.ToString());
+			Assert.Equal((uint)1, proRegTx.CollateralIndex);
+			Assert.Equal(19999, proRegTx.Port);
+			Assert.Equal("3c05fb32367a25d8dedc16f741b8492006fb948a", proRegTx.KeyIdOwner.ToString());
+			Assert.Equal("8273ec203d1ea62cbdb54e10618329e4ed93e99bc9c5ab2f4cb0055ad281f9ad0808a1dda6aedf12c41c53142828879b", Encoders.Hex.EncodeData(proRegTx.KeyIdOperator));
+			Assert.Equal("3c05fb32367a25d8dedc16f741b8492006fb948a", proRegTx.KeyIdVoting.ToString());
+			Assert.Equal("yh9o9kPRK1s3YsuyCBe3DEjBit2RnzhgwH", proRegTx.ScriptPayout.GetDestinationAddress(Dash.Instance.Testnet).ToString());
+			Assert.Equal(0, proRegTx.OperatorReward);
+			Assert.Equal("0b5e6a319019d8f1f4b17da96964df507e417f0a0ef8ca63eaa01e33e05510bc",
+				proRegTx.InputsHash.ToString());
+		}
+
+		/// <summary>
+		/// https://github.com/dashevo/dashcore-lib/blob/master/test/transaction/payload/proregtxpayload.js
+		/// </summary>
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void CanReadProviderUpdateServiceTransaction()
+		{
+			var proUpServTx = new Dash.ProviderUpdateServiceTransaction(Encoders.Hex.DecodeData(
+				"01007b1100a3e33b86b1e9948a1091648b44ac2e819850e321bbbbd9a7825cf173c800000000000000000000ffffc38d8f314e1f1976a9143e1f214c329557ae3711cb173bcf04d00762f3ff88ac3f7685789f3e6480ba6ed402285da0ed9cd0558265603fa8bad0eec0572cf1eb1746f9c46d654879d9afd67a439d4bc2ef7c1b26de2e59897fa83242d9bd819ff46c71d9e3d7aa1772f4003349b777140bedebded0a42efd64baf34f59c4a79c128df711c10a45505a0c2a94a5908f1642cbb56730f16b2cc2419a45890fb8ff"));
+			Assert.Equal(1, proUpServTx.Version);
+			Assert.Equal("c873f15c82a7d9bbbb21e35098812eac448b6491108a94e9b1863be3a300117b", proUpServTx.ProTXHash.ToString());
+			Assert.Equal("00000000000000000000ffffc38d8f31", Encoders.Hex.EncodeData(proUpServTx.IpAddress));
+			Assert.Equal(19999, proUpServTx.Port);
+			Assert.Equal("76a9143e1f214c329557ae3711cb173bcf04d00762f3ff88ac", Encoders.Hex.EncodeData(proUpServTx.ScriptOperatorPayout.ToBytes()));
+			Assert.Equal("ebf12c57c0eed0baa83f60658255d09ceda05d2802d46eba80643e9f7885763f", proUpServTx.InputsHash.ToString());
+		}
+
+		/// <summary>
+		/// https://github.com/dashevo/dashcore-lib/blob/master/test/transaction/payload/proupregtxpayload.js
+		/// </summary>
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void CanReadProviderUpdateRegistrarTransaction()
+		{
+			var proUpRegTx = new Dash.ProviderUpdateRegistrarTransaction(Encoders.Hex.DecodeData(
+				"01004f0fd120ac35429cdc616e470c53a52e032bba22304f8d1c54cc0af2040c3362000018ece819b998a36a185e323a8749e55fd3dc2e259b741f8580fbd68cbd9f51d30f4d4da34fd5afc71859dca3cf10fbda8a94fb062049b841f716dcded8257a3632fb053c1976a914f25c59be48ee1c4fd3733ecf56f440659f1d6c5088acb309a51267451a7f52e79ef2391aa952e9a0284e8fd8db56cdcae3b49b7e6dab4120c838c08b9492c5039444cac11e466df3609c585010fab636de75c687bab9f6154d9a7c26d7b5384a147fc67ddb2e66e5f773af73dbf818109aec692ed364eafd"));
+			Assert.Equal(1, proUpRegTx.Version);
+			Assert.Equal("62330c04f20acc541c8d4f3022ba2b032ea5530c476e61dc9c4235ac20d10f4f", proUpRegTx.ProTXHash.ToString());
+			Assert.Equal(0, proUpRegTx.Mode);
+			Assert.Equal("18ece819b998a36a185e323a8749e55fd3dc2e259b741f8580fbd68cbd9f51d30f4d4da34fd5afc71859dca3cf10fbda", Encoders.Hex.EncodeData(proUpRegTx.PubKeyOperator));
+			Assert.Equal("3c05fb32367a25d8dedc16f741b8492006fb948a", proUpRegTx.KeyIdVoting.ToString());
+			Assert.Equal("76a914f25c59be48ee1c4fd3733ecf56f440659f1d6c5088ac", Encoders.Hex.EncodeData(proUpRegTx.ScriptPayout.ToBytes()));
+			Assert.Equal("ab6d7e9bb4e3cacd56dbd88f4e28a0e952a91a39f29ee7527f1a456712a509b3", proUpRegTx.InputsHash.ToString());
+			Assert.Equal("20c838c08b9492c5039444cac11e466df3609c585010fab636de75c687bab9f6154d9a7c26d7b5384a147fc67ddb2e66e5f773af73dbf818109aec692ed364eafd", Encoders.Hex.EncodeData(proUpRegTx.PayloadSig));
+		}
+
+		/// <summary>
+		/// https://github.com/dashevo/dashcore-lib/blob/master/test/transaction/payload/proregtxpayload.js
+		/// </summary>
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void CanReadProviderUpdateRevocationTransaction()
+		{
+			var proUpRevTx = new Dash.ProviderUpdateRevocationTransaction(Encoders.Hex.DecodeData(
+				"01006f8a813df204873df003d6efc44e1906eaf6180a762513b1c91252826ce05916010082cf248cf6b8ac6a3cdc826edae582ead20421659ed891f9d4953a540616fb4f05279584b3339ed2ba95711ad28b18ee2878c4a904f76ea4d103e1d739f22ff7e3b9b3db7d0c4a7e120abb4952c3574a18de34fa29828f9fe3f52bd0b1fac17acd04f7751967d782045ab655053653438f1dd1e14ba6adeb8351b78c9eb59bf4"));
+			Assert.Equal(1, proUpRevTx.Version);
+			Assert.Equal("1659e06c825212c9b11325760a18f6ea06194ec4efd603f03d8704f23d818a6f", proUpRevTx.ProTXHash.ToString());
+			Assert.Equal(1, proUpRevTx.Reason);
+			Assert.Equal("4ffb1606543a95d4f991d89e652104d2ea82e5da6e82dc3c6aacb8f68c24cf82", proUpRevTx.InputsHash.ToString());
+			Assert.Equal("05279584b3339ed2ba95711ad28b18ee2878c4a904f76ea4d103e1d739f22ff7e3b9b3db7d0c4a7e120abb4952c3574a18de34fa29828f9fe3f52bd0b1fac17acd04f7751967d782045ab655053653438f1dd1e14ba6adeb8351b78c9eb59bf4", Encoders.Hex.EncodeData(proUpRevTx.PayloadSig));
+		}
+
+		/// <summary>
+		/// https://github.com/dashevo/dashcore-lib/blob/master/test/transaction/payload/coinbasepayload.js
+		/// </summary>
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void CanReadCoinbaseSpecialTransaction()
+		{
+			var cbTx = new Dash.CoinbaseSpecialTransaction(Encoders.Hex.DecodeData("0a0014000000b90100b3ccd30f16aa6aadf553fba6be9320d0002ed01c2f54d4975706763ce8"));
+			Assert.Equal(10, cbTx.Version);
+			Assert.Equal((uint)20, cbTx.Height);
+			Assert.Equal("e83c76065797d4542f1cd02e00d02093bea6fb53f5ad6aaa160fd3ccb30001b9", cbTx.MerkleRootMNList.ToString());
+		}
+	
+		/// <summary>
+		/// https://github.com/dashevo/dashcore-lib/blob/master/test/transaction/payload/commitmenttxpayload.js
+		/// </summary>
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void CanReadQuorumCommitmentTransaction()
+		{
+			var qcTx = new Dash.QuorumCommitmentTransaction(Encoders.Hex.DecodeData(
+				"01001e430400010001f2a1f356b9e086220d38754b1de1e4dcbd8b080c3fa0a62c2bd0961400000000320000000000000032000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"));
+			Assert.Equal(1, qcTx.Version);
+			Assert.Equal((uint)279326, qcTx.Height);
+			Assert.Equal(1, qcTx.Commitment.QfcVersion);
+			Assert.Equal(1, qcTx.Commitment.LlmqType);
+			Assert.Equal("000000001496d02b2ca6a03f0c088bbddce4e11d4b75380d2286e0b956f3a1f2",
+				qcTx.Commitment.QuorumHash.ToString());
+			Assert.Equal((uint)50, qcTx.Commitment.SignersSize);
+			Assert.Equal("00000000000000", Encoders.Hex.EncodeData(qcTx.Commitment.Signers));
+			Assert.Equal((uint)50, qcTx.Commitment.ValidMembersSize);
+			Assert.Equal("00000000000000",
+				Encoders.Hex.EncodeData(qcTx.Commitment.ValidMembers));
+			Assert.Equal(
+				"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+				Encoders.Hex.EncodeData(qcTx.Commitment.QuorumPublicKey));
+			Assert.Equal("0000000000000000000000000000000000000000000000000000000000000000",
+				qcTx.Commitment.QuorumVvecHash.ToString());
+			Assert.Equal(
+				"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+				Encoders.Hex.EncodeData(qcTx.Commitment.QuorumSig));
+			Assert.Equal(
+				"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+				Encoders.Hex.EncodeData(qcTx.Commitment.Sig));
+		}
+	
+		/// <summary>
+		/// Check with debug console in Dash Testnet (block 7000 is the first with special transactions,
+		/// all blocks prior to 7000 are standard transactions in testnet):
+		/// getblockhash 7000
+		/// getblock 0000001e8b87719178a7b2b86def5ff918285fa9993e561f2ef04da18c6044bf 1
+		/// getrawtransaction 61bc32c39a523a7705eaa52724b80d52741025547d6562d9fc588617790a06ce 1
+		/// </summary>
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void CheckDashBlock7000FirstTransaction()
+		{
+			const string Hex =
+				"03000500010000000000000000000000000000000000000000000000000000000000000000ffffffff1202581b0e2f5032506f6f6c2d74444153482fffffffff044d125b96010000001976a9144f79c383bc5d3e9d4d81b98f87337cedfa78953688ac40c3609a010000001976a914bafef41416718b231d5ca0143dccbc360d06b77688acf3b00504000000001976a914badadfdebaa6d015a0299f23fbc1fcbdd72ba96f88ac00000000000000002a6a28421df280ea438199057112738c5149e4307689d1201c96a66fbe83f4aa0c4016000000000300000000000000260100581b00000000000000000000000000000000000000000000000000000000000000000000";
+			Dash.DashTransaction tx = new Dash.DashTransaction();
+			tx.ReadWrite(new BitcoinStream(Encoders.Hex.DecodeData(Hex)));
+			//"version": 3,
+			//"type": 5,
+			Assert.Equal((uint)0x50003, tx.Version);
+			Assert.Equal((uint)3, tx.DashVersion);
+			Assert.Equal(Dash.DashTransactionType.MasternodeListMerkleProof, tx.DashType);
+			//"locktime": 0,
+			Assert.Equal(0, tx.LockTime.Height);
+			//"vin": [.]
+			Assert.Single(tx.Inputs);
+			Assert.Equal(4294967295, tx.Inputs[0].Sequence.Value);
+			//"vout": [.]
+			Assert.Equal(4, tx.Outputs.Count);
+			Assert.Equal(6817518157, tx.Outputs[0].Value.Satoshi);
+			Assert.True(tx.Outputs[0].ScriptPubKey.IsValid);
+			Assert.True(tx.IsCoinBase);
+			//"extraPayloadSize": 38,
+			Assert.Equal(38, tx.ExtraPayload.Length);
+			Assert.Equal("0100581b00000000000000000000000000000000000000000000000000000000000000000000", Encoders.Hex.EncodeData(tx.ExtraPayload));
+			//"cbTx": {
+			//	"version": 1,
+			//	"height": 7000,
+			//	"merkleRootMNList": "0000000000000000000000000000000000000000000000000000000000000000"
+			//},
+			Assert.NotNull(tx.CbTx);
+			Assert.Equal(1, tx.CbTx.Version);
+			Assert.Equal((uint)7000, tx.CbTx.Height);
+			Assert.Equal("0000000000000000000000000000000000000000000000000000000000000000", tx.CbTx.MerkleRootMNList.ToString());
+			// Make sure block can be written too and hex stays the same
+			Assert.Equal(Hex, tx.ToHex());
+		}
+
+		public DashTests(ITestOutputHelper output)
+		{
+			this.output = output;
+		}
+
+		private readonly ITestOutputHelper output;
+
+		//[Fact(DisplayName = "Enable manually to test when having local Dash testnet running")]
+		public async Task ConnectToDashTestnetAndCheckBlock7000()
+		{
+			var connectionString = new RPCCredentialString();
+			connectionString.UserPassword = new NetworkCredential("TestDash", "TestLocal");
+			connectionString.Server = "http://localhost:19998";
+			var client = new RPCClient(connectionString, Dash.Instance.Testnet);
+			Assert.True(await client.GetBlockCountAsync() > 7000);
+			await GrabAndOutputBlock(client, 6999);
+			await GrabAndOutputBlock(client, 7000);
+		}
+		
+		private async Task GrabAndOutputBlock(RPCClient client, int blockNumber)
+		{
+			var block = await client.GetBlockAsync(blockNumber);
+			output.WriteLine("Block " + blockNumber + " header: " +
+				JsonConvert.SerializeObject(block.Header));
+			if (blockNumber == 7000)
+				CheckDashBlock7000((Dash.DashBlock)block);
+			Assert.True(block.Check());
+			foreach (var tx in block.Transactions)
+				output.WriteLine("Tx: " + tx);
+		}
+
+		/// <summary>
+		/// Check with debug console:
+		/// getblockhash 7000
+		/// getblock 0000001e8b87719178a7b2b86def5ff918285fa9993e561f2ef04da18c6044bf 1
+		/// </summary>
+		private void CheckDashBlock7000(Dash.DashBlock block)
+		{
+			//"hash": "0000001e8b87719178a7b2b86def5ff918285fa9993e561f2ef04da18c6044bf",
+			Assert.Equal("0000001e8b87719178a7b2b86def5ff918285fa9993e561f2ef04da18c6044bf", block.Header.GetHash().ToString());
+			//"height": 7000,
+			Assert.Equal(7000, block.GetCoinbaseHeight());
+			//"version": 536870913,
+			Assert.Equal(536870913, block.Header.Version);
+			//"versionHex": "20000001",
+			Assert.Equal(0x20000001, block.Header.Version);
+			//"merkleroot": "5339c3b37049fc41c1e75194d36b8958dea0134cec42c5715bdae36cde87eff2",
+			Assert.Equal("5339c3b37049fc41c1e75194d36b8958dea0134cec42c5715bdae36cde87eff2",
+				block.Header.HashMerkleRoot.ToString());
+			//"time": 1545087335,
+			Assert.Equal(1545087335, block.Header.BlockTime.ToUnixTimeSeconds());
+			//"mediantime": 1545086480,
+			Assert.Equal((uint)767772160, block.Header.Nonce);
+			//"difficulty": 0.02184410439171994,
+			Assert.Equal(0.021844104391, block.Header.Bits.Difficulty);
+			Assert.True(block.Header.CheckProofOfWork());
+			//"tx": [..]
+			Assert.False(block.HeaderOnly);
+			Assert.Equal(2, block.Transactions.Count);
+			//see above: CheckDashBlock7000FirstTransaction((Dash.DashTransaction)block.Transactions[0]);
+			CheckDashBlock7000SecondTransaction((Dash.DashTransaction)block.Transactions[1]);
+			// Check if transaction hashes leave us with the correct merkel root
+			Assert.Equal(block.Header.HashMerkleRoot, block.GetMerkleRoot().Hash);
+		}
+	
+		private void CheckDashBlock7000SecondTransaction(Dash.DashTransaction tx)
+		{
+			//"version": 3,
+			//"type": 6,
+			Assert.Equal((uint)0x60003, tx.Version);
+			Assert.Equal((ushort)3, tx.DashVersion);
+			Assert.Equal(Dash.DashTransactionType.QuorumCommitment, tx.DashType);
+			//"locktime": 0,
+			Assert.Equal(0, tx.LockTime.Height);
+			//"vin": []
+			Assert.Empty(tx.Inputs);
+			//"vout": []
+			Assert.Empty(tx.Outputs);
+			//"extraPayloadSize": 38,
+			Assert.Equal(329, tx.ExtraPayload.Length);
+			Assert.Equal("0100581b0000010001e3aeae4a2d013f6bdd3525318bcc579f95c3420e8897a23e8a479f1c39000000320000000000000032000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", Encoders.Hex.EncodeData(tx.ExtraPayload));
+			//"qcTx": { ... }
+			Assert.NotNull(tx.QcTx);
+			Assert.Equal(1, tx.QcTx.Version);
+			Assert.Equal((uint)7000, tx.QcTx.Height);
+			Assert.Equal(1, tx.QcTx.Commitment.QfcVersion);
+			Assert.Equal(1, tx.QcTx.Commitment.LlmqType);
+			Assert.Equal("000000391c9f478a3ea297880e42c3959f57cc8b312535dd6b3f012d4aaeaee3", tx.QcTx.Commitment.QuorumHash.ToString());
+			Assert.Equal((uint)50, tx.QcTx.Commitment.SignersSize);
+			Assert.Equal((uint)50, tx.QcTx.Commitment.ValidMembersSize);
+			Assert.Equal("000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", Encoders.Hex.EncodeData(tx.QcTx.Commitment.QuorumPublicKey));
+			Assert.Equal("03000600000000000000fd49010100581b0000010001e3aeae4a2d013f6bdd3525318bcc579f95c3420e8897a23e8a479f1c39000000320000000000000032000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", tx.ToHex());
+		}
+	}
+}

--- a/NBitcoin.Tests/NodeBuilderEx.cs
+++ b/NBitcoin.Tests/NodeBuilderEx.cs
@@ -24,7 +24,7 @@ namespace NBitcoin.Tests
 
 			//var builder = NodeBuilder.Create(NodeDownloadData.Dogecoin.v1_10_0, Altcoins.Dogecoin.Instance.Regtest, caller);
 
-			//var builder = NodeBuilder.Create(NodeDownloadData.Dash.v0_12_2, Altcoins.Dash.Instance.Regtest, caller);
+			var builder = NodeBuilder.Create(NodeDownloadData.Dash.v0_13_0, Altcoins.Dash.Instance.Regtest, caller);
 
 			//var builder = NodeBuilder.Create(NodeDownloadData.BGold.v0_15_0, Altcoins.BGold.Instance.Regtest, caller);
 
@@ -48,7 +48,7 @@ namespace NBitcoin.Tests
 
 			//var builder = NodeBuilder.Create(NodeDownloadData.Dystem.v1_0_9_9, Altcoins.Dystem.Instance.Regtest, caller);
 
-			var builder = NodeBuilder.Create(NodeDownloadData.Bitcoin.v0_17_0, Altcoins.AltNetworkSets.Bitcoin.Regtest, caller);
+			//var builder = NodeBuilder.Create(NodeDownloadData.Bitcoin.v0_17_0, Altcoins.AltNetworkSets.Bitcoin.Regtest, caller);
 			//var builder = NodeBuilder.Create(NodeDownloadData.Liquid.v3_14_1_21, Altcoins.AltNetworkSets.Liquid.Regtest, caller);
 			//var builder = NodeBuilder.Create(NodeDownloadData.Bitcore.v0_15_2, Altcoins.Bitcore.Instance.Regtest, caller);
 			//var builder = NodeBuilder.Create(NodeDownloadData.Gincoin.v1_1_0_0, Altcoins.Gincoin.Instance.Regtest, caller);

--- a/NBitcoin.Tests/NodeBuilderEx.cs
+++ b/NBitcoin.Tests/NodeBuilderEx.cs
@@ -24,7 +24,7 @@ namespace NBitcoin.Tests
 
 			//var builder = NodeBuilder.Create(NodeDownloadData.Dogecoin.v1_10_0, Altcoins.Dogecoin.Instance.Regtest, caller);
 
-			var builder = NodeBuilder.Create(NodeDownloadData.Dash.v0_13_0, Altcoins.Dash.Instance.Regtest, caller);
+			//var builder = NodeBuilder.Create(NodeDownloadData.Dash.v0_13_0, Altcoins.Dash.Instance.Regtest, caller);
 
 			//var builder = NodeBuilder.Create(NodeDownloadData.BGold.v0_15_0, Altcoins.BGold.Instance.Regtest, caller);
 
@@ -48,7 +48,7 @@ namespace NBitcoin.Tests
 
 			//var builder = NodeBuilder.Create(NodeDownloadData.Dystem.v1_0_9_9, Altcoins.Dystem.Instance.Regtest, caller);
 
-			//var builder = NodeBuilder.Create(NodeDownloadData.Bitcoin.v0_17_0, Altcoins.AltNetworkSets.Bitcoin.Regtest, caller);
+			var builder = NodeBuilder.Create(NodeDownloadData.Bitcoin.v0_17_0, Altcoins.AltNetworkSets.Bitcoin.Regtest, caller);
 			//var builder = NodeBuilder.Create(NodeDownloadData.Liquid.v3_14_1_21, Altcoins.AltNetworkSets.Liquid.Regtest, caller);
 			//var builder = NodeBuilder.Create(NodeDownloadData.Bitcore.v0_15_2, Altcoins.Bitcore.Instance.Regtest, caller);
 			//var builder = NodeBuilder.Create(NodeDownloadData.Gincoin.v1_1_0_0, Altcoins.Gincoin.Instance.Regtest, caller);

--- a/NBitcoin/DataEncoders/HexEncoder.cs
+++ b/NBitcoin/DataEncoders/HexEncoder.cs
@@ -19,10 +19,10 @@ namespace NBitcoin.DataEncoders
 			if(data == null)
 				throw new ArgumentNullException(nameof(data));
 
-			int pos = 0;
 			var spaces = (Space ? Math.Max((count - 1), 0) : 0);
 
 #if !HAS_SPAN
+			int pos = 0;
 			var s = new char[2 * count + spaces];
 			for(var i = offset; i < offset + count; i++)
 			{


### PR DESCRIPTION
All the fixes for https://github.com/MetacoSA/NBitcoin/issues/607 and support to load all new Special Transaction types in Dash 0.13:
1	Provider Registration Transaction (ProRegTx),
2	Provider Update Service Transaction (ProUpServTx),
3	Provider Update Registrar Transaction (ProUpRegTx),
4	Provider Update Revocation Transaction (ProUpRevTx),
5	Coinbase Transaction (CbTx),
6	Quorum Commitment (QcTx)
Details in the source code, especially the new DashTests.cs