### PR TITLE
NBitcoin.Bench project

### DIFF
--- a/NBitcoin.Bench/GolombRiceFilters.cs
+++ b/NBitcoin.Bench/GolombRiceFilters.cs
@@ -1,0 +1,93 @@
+using System;
+using NBitcoin;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NBitcoin.Benck
+{
+	[ClrJob(baseline: true), CoreJob]
+	[RPlotExporter, RankColumn]
+	public class GolombRiceFilterBuilding
+	{
+		private GolombRiceFilterBuilder _builder;
+		private List<byte[]> _itemsInFilter;
+
+		// We estimate a block will never have more than 100,000 txouts
+		// OTOH 20,000 outputs could be a rasonable number of txouts 
+		// for a block considering the current block sizes.
+		// Also, currently P2WPKH tx are 5% of total scripts and that
+		// gives us 1,000 txouts.
+		[Params(1_000, 20_000, 100_000)]
+		public int N;
+
+		[GlobalSetup]
+		public void Setup()
+		{
+			var random = new Random(Seed:145);
+			var keyBuffer = new byte[32];
+			random.NextBytes(keyBuffer);
+			var key = new uint256(keyBuffer);
+
+			_builder = new GolombRiceFilterBuilder()
+				.SetKey(key)
+				.SetP(20);
+
+			_itemsInFilter = new List<byte[]>();
+			for (var j = 0; j < N; j++)
+			{
+				var data = new byte[random.Next(20, 30)];
+				random.NextBytes(data);
+				_itemsInFilter.Add(data);
+			}
+			_builder.AddEntries(_itemsInFilter);
+		}
+
+		[Benchmark]
+		public GolombRiceFilter Build() => _builder.Build();
+	}
+
+	[ClrJob(baseline: true), CoreJob]
+	[RPlotExporter, RankColumn]
+	public class GolombRiceFilterQuering
+	{
+		private GolombRiceFilter _filter;
+		private byte[][] _sample;
+		private Random _random = new Random(Seed:145);
+		private byte[] _testKey;
+
+		[Params(1_000, 10_000, 100_000)]
+		public int N;
+
+		[GlobalSetup]
+		public void Setup()
+		{
+			var keyBuffer = new byte[32];
+			_random.NextBytes(keyBuffer);
+			var key = new uint256(keyBuffer);
+			_testKey = key.ToBytes().Take(16).ToArray();
+
+			var builder = new GolombRiceFilterBuilder()
+				.SetKey(key)
+				.SetP(20);
+
+			var itemsInFilter = new List<byte[]>();
+			for (var j = 0; j < N; j++)
+			{
+				var data = new byte[_random.Next(20, 30)];
+				_random.NextBytes(data);
+				itemsInFilter.Add(data);
+			}
+			builder.AddEntries(itemsInFilter);
+			_sample = itemsInFilter.OrderBy(x=>_random.Next()).Take(N / 200).ToArray();
+			_filter = builder.Build();
+		}
+
+		[Benchmark]
+		public bool Match() => _filter.Match(_sample[_sample.Count() %2 ], _testKey);
+
+		[Benchmark]
+		public bool MatchAny() => _filter.MatchAny(_sample, _testKey);
+	}
+}

--- a/NBitcoin.Bench/NBitcoin.Bench.csproj
+++ b/NBitcoin.Bench/NBitcoin.Bench.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+  		<ProjectReference Include="..\NBitcoin\NBitcoin.csproj" />
+  </ItemGroup>
+</Project>

--- a/NBitcoin.Bench/Program.cs
+++ b/NBitcoin.Bench/Program.cs
@@ -1,0 +1,12 @@
+﻿using BenchmarkDotNet.Running;
+
+namespace NBitcoin.Benck
+{
+	public class Program
+	{
+		public static void Main(string[] args)
+		{
+			BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+		}
+	}
+}

--- a/NBitcoin.sln
+++ b/NBitcoin.sln
@@ -18,6 +18,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NBitcoin.Altcoins", "NBitco
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NBitcoin.TestFramework", "NBitcoin.TestFramework\NBitcoin.TestFramework.csproj", "{653C0F21-25FE-4B72-95AC-20D070A45415}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NBitcoin.Bench", "NBitcoin.Bench\NBitcoin.Bench.csproj", "{153FEA8A-FA98-4ADD-8570-5FD88631C489}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -40,6 +42,10 @@ Global
 		{653C0F21-25FE-4B72-95AC-20D070A45415}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{653C0F21-25FE-4B72-95AC-20D070A45415}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{653C0F21-25FE-4B72-95AC-20D070A45415}.Release|Any CPU.Build.0 = Release|Any CPU
+		{153FEA8A-FA98-4ADD-8570-5FD88631C489}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{153FEA8A-FA98-4ADD-8570-5FD88631C489}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{153FEA8A-FA98-4ADD-8570-5FD88631C489}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{153FEA8A-FA98-4ADD-8570-5FD88631C489}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This PR adds a new project for bechmarking with `BenchmarkDotNet` into NBitcoin solution. It is used for measuring `GolombRiceFilterBuilder` and `GolomRiceFilter`s in the context of the discussion in Wasabi Wallet filter creation https://github.com/zkSNACKs/WalletWasabi/issues/1134

Below you can see the running results for `GolombRiceFilter.Match` and `GolombRiceFilter.MatchAny` methods: 

```
BenchmarkDotNet=v0.11.3, OS=ubuntu 18.04
Intel Core i7-7500U CPU 2.70GHz (Kaby Lake), 1 CPU, 4 logical and 2 physical cores
.NET Core SDK=2.2.100
  [Host] : .NET Core 2.1.6 (CoreCLR 4.6.27019.06, CoreFX 4.6.27019.05), 64bit RyuJIT
  Core   : .NET Core 2.1.6 (CoreCLR 4.6.27019.06, CoreFX 4.6.27019.05), 64bit RyuJIT

Job=Core  Runtime=Core

   Method |      N |         Mean |      Error |     StdDev | Rank |
--------- |------- |-------------:|-----------:|-----------:|-----:|
    Match |   1000 |     4.954 us |  0.0226 us |  0.0200 us |    1 |
 MatchAny |   1000 |     5.187 us |  0.0477 us |  0.0422 us |    2 |
    Match |  10000 |   249.643 us |  4.8950 us |  5.4407 us |    5 |
 MatchAny |  10000 |    10.870 us |  0.0954 us |  0.0796 us |    3 |
    Match | 100000 | 3,668.975 us | 36.2116 us | 32.1006 us |    6 |
 MatchAny | 100000 |   116.348 us |  2.8049 us |  2.6237 us |    4 |

// * Legends *
  N      : Value of the 'N' parameter
  Mean   : Arithmetic mean of all measurements
  Error  : Half of 99.9% confidence interval
  StdDev : Standard deviation of all measurements
  Rank   : Relative position of current benchmark mean among all benchmarks (Arabic style)
  1 us   : 1 Microsecond (0.000001 sec)
```

This is the result of running the test against `GolombRiceFilterBuilder.Build` method:

```
BenchmarkDotNet=v0.11.3, OS=ubuntu 18.04
Intel Core i7-7500U CPU 2.70GHz (Kaby Lake), 1 CPU, 4 logical and 2 physical cores
.NET Core SDK=2.2.100
  [Host] : .NET Core 2.1.6 (CoreCLR 4.6.27019.06, CoreFX 4.6.27019.05), 64bit RyuJIT
  Core   : .NET Core 2.1.6 (CoreCLR 4.6.27019.06, CoreFX 4.6.27019.05), 64bit RyuJIT

Job=Core  Runtime=Core

 Method |      N |        Mean |       Error |      StdDev | Rank |
------- |------- |------------:|------------:|------------:|-----:|
  Build |   1000 |    175.5 us |   0.9845 us |   0.8221 us |    1 |
  Build |  20000 |  4,022.0 us |  23.9804 us |  20.0247 us |    2 |
  Build | 100000 | 24,525.1 us | 479.2576 us | 400.2018 us |    3 |

// * Legends *
  N      : Value of the 'N' parameter
  Mean   : Arithmetic mean of all measurements
  Error  : Half of 99.9% confidence interval
  StdDev : Standard deviation of all measurements
  Rank   : Relative position of current benchmark mean among all benchmarks (Arabic style)
  1 us   : 1 Microsecond (0.000001 sec)
```

It seems the `Build` times doesn't increase linearly (sucks).