### PR TITLE
[QUESTION] Uinit test for bip84

### DIFF
--- a/NBitcoin.Tests/bip32_tests.cs
+++ b/NBitcoin.Tests/bip32_tests.cs
@@ -276,6 +276,32 @@ namespace NBitcoin.Tests
 			var keyB = new ExtPubKey(keyA.ToBytes());
 			AssertEx.CollectionEquals(keyA.ToBytes(), keyB.ToBytes());
 		}
+
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void CanWorkWithSLIP32()
+		{
+			var mnemonic = new Mnemonic("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about");
+			var extKey = mnemonic.DeriveExtKey();
+			var derivedKey = extKey.Derive(KeyPath.Parse("m/44'/0'/0'")).GetWif(Network.Main);
+			Assert.Equal("xprv9xpXFhFpqdQK3TmytPBqXtGSwS3DLjojFhTGht8gwAAii8py5X6pxeBnQ6ehJiyJ6nDjWGJfZ95WxByFXVkDxHXrqu53WCRGypk2ttuqncb", derivedKey.ToString() );
+			Assert.Equal("xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj", derivedKey.Neuter().ToString() );
+			derivedKey = extKey.Derive(KeyPath.Parse("m/44'/0'/0'/0/0")).GetWif(Network.Main);
+			Assert.Equal("1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA", derivedKey.ScriptPubKey.GetDestinationAddress(Network.Main).ToString());
+
+			derivedKey = extKey.Derive(KeyPath.Parse("m/49'/0'/0'")).GetWif(Network.Main);
+			Assert.Equal("yprvAHwhK6RbpuS3dgCYHM5jc2ZvEKd7Bi61u9FVhYMpgMSuZS613T1xxQeKTffhrHY79hZ5PsskBjcc6C2V7DrnsMsNaGDaWev3GLRQRgV7hxF", derivedKey.ToString() );
+			Assert.Equal("ypub6Ww3ibxVfGzLrAH1PNcjyAWenMTbbAosGNB6VvmSEgytSER9azLDWCxoJwW7Ke7icmizBMXrzBx9979FfaHxHcrArf3zbeJJJUZPf663zsP", derivedKey.Neuter().ToString() );
+			derivedKey = extKey.Derive(KeyPath.Parse("m/49'/0'/0'/0/0")).GetWif(Network.Main);
+			Assert.Equal("37VucYSaXLCAsxYyAPfbSi9eh4iEcbShgf", derivedKey.ScriptPubKey.GetDestinationAddress(Network.Main).ToString());
+
+			derivedKey = extKey.Derive(KeyPath.Parse("m/84'/0'/0'")).GetWif(Network.Main);
+			Assert.Equal("zprvAdG4iTXWBoARxkkzNpNh8r6Qag3irQB8PzEMkAFeTRXxHpbF9z4QgEvBRmfvqWvGp42t42nvgGpNgYSJA9iefm1yYNZKEm7z6qUWCroSQnE", derivedKey.ToString() );
+			Assert.Equal("zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs", derivedKey.Neuter().ToString() );
+			derivedKey = extKey.Derive(KeyPath.Parse("m/84'/0'/0'/0/0")).GetWif(Network.Main);
+			Assert.Equal("bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu", derivedKey.ScriptPubKey.GetDestinationAddress(Network.Main).ToString());
+		}
+
 		private void RunTest(TestVector test)
 		{
 			var seed = TestUtils.ParseHex(test.strHexMaster);

--- a/NBitcoin/Network.cs
+++ b/NBitcoin/Network.cs
@@ -65,6 +65,10 @@ namespace NBitcoin
 		SECRET_KEY,
 		EXT_PUBLIC_KEY,
 		EXT_SECRET_KEY,
+		EXT_P2WPKH_PUBLIC_KEY,
+		EXT_P2WPKH_SECRET_KEY,
+		EXT_P2WPKH_IN_P2SH_PUBLIC_KEY,
+		EXT_P2WPKH_IN_P2SH_SECRET_KEY,
 		ENCRYPTED_SECRET_KEY_EC,
 		ENCRYPTED_SECRET_KEY_NO_EC,
 		PASSPHRASE_CODE,
@@ -84,7 +88,7 @@ namespace NBitcoin
 
 	public partial class Network
 	{
-		internal byte[][] base58Prefixes = new byte[13][];
+		internal byte[][] base58Prefixes = new byte[(int)Base58Type.MAX_BASE58_TYPES][];
 		internal Bech32Encoder[] bech32Encoders = new Bech32Encoder[2];
 
 		public uint MaxP2PVersion
@@ -851,6 +855,10 @@ namespace NBitcoin
 			base58Prefixes[(int)Base58Type.ENCRYPTED_SECRET_KEY_EC] = new byte[] { 0x01, 0x43 };
 			base58Prefixes[(int)Base58Type.EXT_PUBLIC_KEY] = new byte[] { (0x04), (0x88), (0xB2), (0x1E) };
 			base58Prefixes[(int)Base58Type.EXT_SECRET_KEY] = new byte[] { (0x04), (0x88), (0xAD), (0xE4) };
+			base58Prefixes[(int)Base58Type.EXT_P2WPKH_PUBLIC_KEY] = new byte[] { (0x04), (0xB2), (0x47), (0x46) }; 
+			base58Prefixes[(int)Base58Type.EXT_P2WPKH_SECRET_KEY] = new byte[] { (0x04), (0xB2), (0x43), (0x0C) };
+			base58Prefixes[(int)Base58Type.EXT_P2WPKH_IN_P2SH_PUBLIC_KEY] = new byte[] { (0x04), (0x9D), (0x7C), (0xB2) }; 
+			base58Prefixes[(int)Base58Type.EXT_P2WPKH_IN_P2SH_SECRET_KEY] = new byte[] { (0x04), (0x9D), (0x78), (0x78) };
 			base58Prefixes[(int)Base58Type.PASSPHRASE_CODE] = new byte[] { 0x2C, 0xE9, 0xB3, 0xE1, 0xFF, 0x39, 0xE2 };
 			base58Prefixes[(int)Base58Type.CONFIRMATION_CODE] = new byte[] { 0x64, 0x3B, 0xF6, 0xA8, 0x9A };
 			base58Prefixes[(int)Base58Type.STEALTH_ADDRESS] = new byte[] { 0x2a };
@@ -933,6 +941,11 @@ namespace NBitcoin
 			base58Prefixes[(int)Base58Type.SECRET_KEY] = new byte[] { (239) };
 			base58Prefixes[(int)Base58Type.EXT_PUBLIC_KEY] = new byte[] { (0x04), (0x35), (0x87), (0xCF) };
 			base58Prefixes[(int)Base58Type.EXT_SECRET_KEY] = new byte[] { (0x04), (0x35), (0x83), (0x94) };
+			base58Prefixes[(int)Base58Type.EXT_P2WPKH_PUBLIC_KEY] = new byte[] { (0x04), (0x5F), (0x1C), (0xF6) }; 
+			base58Prefixes[(int)Base58Type.EXT_P2WPKH_SECRET_KEY] = new byte[] { (0x04), (0x5F), (0x18), (0xBC) };
+			base58Prefixes[(int)Base58Type.EXT_P2WPKH_IN_P2SH_PUBLIC_KEY] = new byte[] { (0x04), (0x4A), (0x52), (0x62) }; 
+			base58Prefixes[(int)Base58Type.EXT_P2WPKH_IN_P2SH_SECRET_KEY] = new byte[] { (0x04), (0x4A), (0x4E), (0x28) };
+
 			base58Prefixes[(int)Base58Type.STEALTH_ADDRESS] = new byte[] { 0x2b };
 			base58Prefixes[(int)Base58Type.ASSET_ID] = new byte[] { 115 };
 			base58Prefixes[(int)Base58Type.COLORED_ADDRESS] = new byte[] { 0x13 };


### PR DESCRIPTION
I would like to add support for encoding `ExtKey` with different prefix depending the derivation scheme used. This is something that some people asked for Wasabi wallet but. The problem that I found is that `ExtKey` knows nothing about the concept of derivation scheme, what makes sense, and then it cannot know how to encode itself based on something that it doesn't know about.

I tried a couple of things but they are all ugly. I think the best could be simply overload the `ExtKey.GetWif` method to receive an extra parameter indicating what derivation scheme/prefix to use.

What do you think about this? Which is for you the best way, if any, to implement it?

Note: take a look at the new Base58Type enum elements' name and tell me if they are acceptable.  