### PR TITLE
Make uint256 and uint160 implement IEquitable

### DIFF
--- a/NBitcoin/UInt2561.cs
+++ b/NBitcoin/UInt2561.cs
@@ -7,7 +7,7 @@ using NBitcoin.Protocol;
 
 namespace NBitcoin
 {
-	public class uint256
+	public class uint256 : IEquatable<uint256>
 	{
 		public class MutableUint256 : IBitcoinSerializable
 		{
@@ -283,6 +283,8 @@ namespace NBitcoin
 			return equals;
 		}
 
+		public bool Equals(uint256 other) => this == other;
+
 		public static bool operator ==(uint256 a, uint256 b)
 		{
 			if(System.Object.ReferenceEquals(a, b))
@@ -473,7 +475,7 @@ namespace NBitcoin
 			return hash;
 		}
 	}
-	public class uint160
+	public class uint160 : IEquatable<uint160>
 	{
 		public class MutableUint160 : IBitcoinSerializable
 		{
@@ -672,6 +674,8 @@ namespace NBitcoin
 			equals &= pn4 == item.pn4;
 			return equals;
 		}
+
+		public bool Equals(uint160 other) => this == other;
 
 		public static bool operator ==(uint160 a, uint160 b)
 		{

--- a/NBitcoin/UInt2561.cs
+++ b/NBitcoin/UInt2561.cs
@@ -271,7 +271,7 @@ namespace NBitcoin
 
 		public bool Equals(uint256 other)
 		{
-			if (other == null)
+			if (other is null)
 			{
 				return false;
 			}
@@ -672,7 +672,7 @@ namespace NBitcoin
 
 		public bool Equals(uint160 other)
 		{
-			if (other == null)
+			if (other is null)
 				return false;
 			bool equals = true;
 			equals &= pn0 == other.pn0;

--- a/NBitcoin/UInt2561.cs
+++ b/NBitcoin/UInt2561.cs
@@ -266,24 +266,27 @@ namespace NBitcoin
 		public override bool Equals(object obj)
 		{
 			var item = obj as uint256;
-			if(item == null)
+			return Equals(item);
+		}
+
+		public bool Equals(uint256 other)
+		{
+			if (other == null)
 			{
 				return false;
 			}
 
 			bool equals = true;
-			equals &= pn0 == item.pn0;
-			equals &= pn1 == item.pn1;
-			equals &= pn2 == item.pn2;
-			equals &= pn3 == item.pn3;
-			equals &= pn4 == item.pn4;
-			equals &= pn5 == item.pn5;
-			equals &= pn6 == item.pn6;
-			equals &= pn7 == item.pn7;
+			equals &= pn0 == other.pn0;
+			equals &= pn1 == other.pn1;
+			equals &= pn2 == other.pn2;
+			equals &= pn3 == other.pn3;
+			equals &= pn4 == other.pn4;
+			equals &= pn5 == other.pn5;
+			equals &= pn6 == other.pn6;
+			equals &= pn7 == other.pn7;
 			return equals;
 		}
-
-		public bool Equals(uint256 other) => this == other;
 
 		public static bool operator ==(uint256 a, uint256 b)
 		{
@@ -664,18 +667,21 @@ namespace NBitcoin
 		public override bool Equals(object obj)
 		{
 			var item = obj as uint160;
-			if(item == null)
-				return false;
-			bool equals = true;
-			equals &= pn0 == item.pn0;
-			equals &= pn1 == item.pn1;
-			equals &= pn2 == item.pn2;
-			equals &= pn3 == item.pn3;
-			equals &= pn4 == item.pn4;
-			return equals;
+			return Equals(item);
 		}
 
-		public bool Equals(uint160 other) => this == other;
+		public bool Equals(uint160 other)
+		{
+			if (other == null)
+				return false;
+			bool equals = true;
+			equals &= pn0 == other.pn0;
+			equals &= pn1 == other.pn1;
+			equals &= pn2 == other.pn2;
+			equals &= pn3 == other.pn3;
+			equals &= pn4 == other.pn4;
+			return equals;
+		}
 
 		public static bool operator ==(uint160 a, uint160 b)
 		{


### PR DESCRIPTION
This refactoring does not modify the behavior, but makes equality comparision of uint256 and uint160 faster and those classes generally more extensible and usable.

> The IEquatable(T) interface is used by generic collection objects such as Dictionary(TKey, TValue), List(T), and LinkedList(T) when testing for equality in such methods as Contains, IndexOf, LastIndexOf, and Remove.

> The IEquatable<T> implementation will require one less cast for these classes and as a result will be slightly faster than the standard object.Equals method that would be used otherwise.

https://stackoverflow.com/questions/2476793/when-to-use-iequatable-and-why
