### PR TITLE
Clone EndpointConnector

### DIFF
--- a/NBitcoin/Protocol/NodeConnectionParameters.cs
+++ b/NBitcoin/Protocol/NodeConnectionParameters.cs
@@ -45,6 +45,7 @@ namespace NBitcoin.Protocol
 			Nonce = other.Nonce;
 			Advertize = other.Advertize;
 			PreferredTransactionOptions = other.PreferredTransactionOptions;
+			EndpointConnector = other.EndpointConnector;
 			foreach(var behavior in other.TemplateBehaviors)
 			{
 				TemplateBehaviors.Add(behavior.Clone());


### PR DESCRIPTION
Fixes a missing property (EndpointConnector) in the copy constructor called for the Clone method. 