### PR TITLE
Improve FeeRate class

### DIFF
--- a/NBitcoin/FeeRate.cs
+++ b/NBitcoin/FeeRate.cs
@@ -45,7 +45,7 @@ namespace NBitcoin
 			if(feePerK is null)
 				throw new ArgumentNullException(nameof(feePerK));
 			if(feePerK.Satoshi < 0)
-				throw new ArgumentOutOfRangeException(nameof(feePerK));
+				throw new ArgumentOutOfRangeException(nameof(feePerK), "Cannot be less than 0.");
 			_FeePerK = feePerK;
 		}
 
@@ -54,7 +54,7 @@ namespace NBitcoin
 			if(feePaid is null)
 				throw new ArgumentNullException(nameof(feePaid));
 			if(feePaid.Satoshi < 0)
-				throw new ArgumentOutOfRangeException(nameof(feePaid));
+				throw new ArgumentOutOfRangeException(nameof(feePaid), "Cannot be less than 0.");
 			if (size > 0)
 				_FeePerK = (long)((decimal)feePaid.Satoshi / (decimal)size * 1000m);
 			else
@@ -64,7 +64,7 @@ namespace NBitcoin
 		public FeeRate(decimal satoshiPerByte)
 		{
 			if(satoshiPerByte < 0)
-				throw new ArgumentOutOfRangeException(nameof(satoshiPerByte));
+				throw new ArgumentOutOfRangeException(nameof(satoshiPerByte), "Cannot be less than 0.");
 			_FeePerK = Money.Satoshis(satoshiPerByte * 1000);
 		}
 

--- a/NBitcoin/FeeRate.cs
+++ b/NBitcoin/FeeRate.cs
@@ -56,7 +56,7 @@ namespace NBitcoin
 			if(feePaid.Satoshi < 0)
 				throw new ArgumentOutOfRangeException(nameof(feePaid));
 			if (size > 0)
-				this._FeePerK = (long)((decimal)feePaid.Satoshi / (decimal)size * 1000m);
+				_FeePerK = (long)((decimal)feePaid.Satoshi / (decimal)size * 1000m);
 			else
 				_FeePerK = Money.Zero;
 		}

--- a/NBitcoin/FeeRate.cs
+++ b/NBitcoin/FeeRate.cs
@@ -45,7 +45,7 @@ namespace NBitcoin
 			if(feePerK == null)
 				throw new ArgumentNullException(nameof(feePerK));
 			if(feePerK.Satoshi < 0)
-				throw new ArgumentOutOfRangeException("feePerK");
+				throw new ArgumentOutOfRangeException(nameof(feePerK));
 			_FeePerK = feePerK;
 		}
 
@@ -54,7 +54,7 @@ namespace NBitcoin
 			if(feePaid == null)
 				throw new ArgumentNullException(nameof(feePaid));
 			if(feePaid.Satoshi < 0)
-				throw new ArgumentOutOfRangeException("feePaid");
+				throw new ArgumentOutOfRangeException(nameof(feePaid));
 			if (size > 0)
 				this._FeePerK = (long)((decimal)feePaid.Satoshi / (decimal)size * 1000m);
 			else
@@ -64,7 +64,7 @@ namespace NBitcoin
 		public FeeRate(decimal satoshiPerByte)
 		{
 			if(satoshiPerByte < 0)
-				throw new ArgumentOutOfRangeException("satoshiPerByte");
+				throw new ArgumentOutOfRangeException(nameof(satoshiPerByte));
 			_FeePerK = Money.Satoshis(satoshiPerByte * 1000);
 		}
 

--- a/NBitcoin/FeeRate.cs
+++ b/NBitcoin/FeeRate.cs
@@ -89,7 +89,7 @@ namespace NBitcoin
 		{
 			if(Object.ReferenceEquals(this, obj))
 				return true;
-			if(((object)this is null) || (obj is null))
+			if(this is null || obj is null)
 				return false;
 			var left = this;
 			var right = obj as FeeRate;
@@ -186,7 +186,7 @@ namespace NBitcoin
 		{
 			if (Object.ReferenceEquals(left, right))
 				return true;
-			if (((object)left is null) || ((object)right is null))
+			if (left is null || right is null)
 				return false;
 			return left._FeePerK == right._FeePerK;
 		}

--- a/NBitcoin/FeeRate.cs
+++ b/NBitcoin/FeeRate.cs
@@ -42,7 +42,7 @@ namespace NBitcoin
 
 		public FeeRate(Money feePerK)
 		{
-			if(feePerK == null)
+			if(feePerK is null)
 				throw new ArgumentNullException(nameof(feePerK));
 			if(feePerK.Satoshi < 0)
 				throw new ArgumentOutOfRangeException(nameof(feePerK));
@@ -51,7 +51,7 @@ namespace NBitcoin
 
 		public FeeRate(Money feePaid, int size)
 		{
-			if(feePaid == null)
+			if(feePaid is null)
 				throw new ArgumentNullException(nameof(feePaid));
 			if(feePaid.Satoshi < 0)
 				throw new ArgumentOutOfRangeException(nameof(feePaid));
@@ -89,11 +89,11 @@ namespace NBitcoin
 		{
 			if(Object.ReferenceEquals(this, obj))
 				return true;
-			if(((object)this == null) || (obj == null))
+			if(((object)this is null) || (obj is null))
 				return false;
 			var left = this;
 			var right = obj as FeeRate;
-			if(right == null)
+			if(right is null)
 				return false;
 			return left._FeePerK == right._FeePerK;
 		}
@@ -124,7 +124,7 @@ namespace NBitcoin
 
 		public int CompareTo(FeeRate other)
 		{
-			return other == null 
+			return other is null 
 				? 1 
 				: _FeePerK.CompareTo(other._FeePerK);
 		}
@@ -135,7 +135,7 @@ namespace NBitcoin
 
 		public int CompareTo(object obj)
 		{
-			if (obj == null)
+			if (obj is null)
 				return 1;
 			var m = obj as FeeRate;
 			if (m != null)
@@ -151,33 +151,33 @@ namespace NBitcoin
 
 		public static bool operator <(FeeRate left, FeeRate right)
 		{
-			if (left == null)
+			if (left is null)
 				throw new ArgumentNullException(nameof(left));
-			if (right == null)
+			if (right is null)
 				throw new ArgumentNullException(nameof(right));
 			return left._FeePerK < right._FeePerK;
 		}
 		public static bool operator >(FeeRate left, FeeRate right)
 		{
-			if (left == null)
+			if (left is null)
 				throw new ArgumentNullException(nameof(left));
-			if (right == null)
+			if (right is null)
 				throw new ArgumentNullException(nameof(right));
 			return left._FeePerK > right._FeePerK;
 		}
 		public static bool operator <=(FeeRate left, FeeRate right)
 		{
-			if (left == null)
+			if (left is null)
 				throw new ArgumentNullException(nameof(left));
-			if (right == null)
+			if (right is null)
 				throw new ArgumentNullException(nameof(right));
 			return left._FeePerK <= right._FeePerK;
 		}
 		public static bool operator >=(FeeRate left, FeeRate right)
 		{
-			if (left == null)
+			if (left is null)
 				throw new ArgumentNullException(nameof(left));
-			if (right == null)
+			if (right is null)
 				throw new ArgumentNullException(nameof(right));
 			return left._FeePerK >= right._FeePerK;
 		}
@@ -186,7 +186,7 @@ namespace NBitcoin
 		{
 			if (Object.ReferenceEquals(left, right))
 				return true;
-			if (((object)left == null) || ((object)right == null))
+			if (((object)left is null) || ((object)right is null))
 				return false;
 			return left._FeePerK == right._FeePerK;
 		}
@@ -203,9 +203,9 @@ namespace NBitcoin
 
 		public static FeeRate Min(FeeRate left, FeeRate right)
 		{
-			if (left == null)
+			if (left is null)
 				throw new ArgumentNullException(nameof(left));
-			if (right == null)
+			if (right is null)
 				throw new ArgumentNullException(nameof(right));
 			return left <= right 
 				? left 
@@ -214,9 +214,9 @@ namespace NBitcoin
 
 		public static FeeRate Max(FeeRate left, FeeRate right)
 		{
-			if (left == null)
+			if (left is null)
 				throw new ArgumentNullException(nameof(left));
-			if (right == null)
+			if (right is null)
 				throw new ArgumentNullException(nameof(right));
 			return left >= right
 				? left


### PR DESCRIPTION
- https://github.com/MetacoSA/NBitcoin/commit/d3f4e93cc1101265d0dc9100df23afbbfcf20c4a Use `nameof(` consistently (it was missing at 2-3 places.)
- https://github.com/MetacoSA/NBitcoin/commit/270d7f9ded2f38a9c7c11e6d2f563660a5e439ef Use `is null` instead of `== null`
- https://github.com/MetacoSA/NBitcoin/commit/7c663fe9da2fa9d4b8400aef109a7a229036c320 Remove unnecessary `(object)` cast. They became unnecessary after `== null` has been replaced by `is null`.
- https://github.com/MetacoSA/NBitcoin/commit/d9e90829233cb61ff963592d2282131931d0c8c3 Remove one `this.` to be consistent with the rest of the code.
- https://github.com/MetacoSA/NBitcoin/commit/ef0651da569a6915302c6a8ca4ee2b636a7e5cda When throwing `ArgumentOutOfRangeException` specify error message: `Cannot be less than 0.` If we would've got this more specific error message here, it would've been more obvious what's going wrong in our logs: https://github.com/zkSNACKs/WalletWasabi/pull/1284#issuecomment-478255896