### PR TITLE
Enable using different Tor identities per node.

### DIFF
--- a/NBitcoin.Tests/ProtocolTests.cs
+++ b/NBitcoin.Tests/ProtocolTests.cs
@@ -817,7 +817,7 @@ namespace NBitcoin.Tests
 		// You need to run Tor Browser (the test use socks port 9150, not 9050)
 
 #pragma warning disable xUnit1013 // Public method should be marked as test
-		// [Fact]
+		//[Fact]
 		public async Task TestDifferentConnectionMethods()
 #pragma warning restore xUnit1013 // Public method should be marked as test
 		{
@@ -851,10 +851,9 @@ namespace NBitcoin.Tests
 					{
 						var node = await Node.ConnectAsync(Network.Main, endpoint, new NodeConnectionParameters()
 						{
-							EndpointConnector = new DefaultEndpointConnector{ ChangeTorIdentities = changeIpIdentities },
 							TemplateBehaviors =
 							{
-								new SocksSettingsBehavior(Utils.ParseEndpoint("localhost", 9150), onlyForOnionHosts)
+								new SocksSettingsBehavior(Utils.ParseEndpoint("localhost", 9150), onlyForOnionHosts, null, changeIpIdentities)
 							},
 							ConnectCancellation = cancellationToken.Token
 						});

--- a/NBitcoin/Protocol/Behaviors/SocksSettingsBehavior.cs
+++ b/NBitcoin/Protocol/Behaviors/SocksSettingsBehavior.cs
@@ -1,6 +1,7 @@
 ﻿#if !NOSOCKET
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Text;
 
@@ -21,6 +22,13 @@ namespace NBitcoin.Protocol.Behaviors
 			SocksEndpoint = socksEndpoint;
 			OnlyForOnionHosts = onlyForOnionHosts;
 		}
+		public SocksSettingsBehavior(EndPoint socksEndpoint, bool onlyForOnionHosts, NetworkCredential networkCredential, bool streamIsolation)
+		{
+			SocksEndpoint = socksEndpoint;
+			OnlyForOnionHosts = onlyForOnionHosts;
+			StreamIsolation = streamIsolation;
+			NetworkCredential = networkCredential;
+		}
 		/// <summary>
 		/// If the socks endpoint to connect to
 		/// </summary>
@@ -29,9 +37,35 @@ namespace NBitcoin.Protocol.Behaviors
 		/// If the socks proxy is only used for Tor traffic (default: true)
 		/// </summary>
 		public bool OnlyForOnionHosts { get; set; } = true;
+
+
+		/// <summary>
+		/// Credentials to connect to the SOCKS proxy (Use StreamIsolation instead of you want Tor isolation)
+		/// </summary>
+		public NetworkCredential NetworkCredential { get; set; }
+
+		/// <summary>
+		/// Randomize the NetworkCredentials to the Socks proxy
+		/// </summary>
+		public bool StreamIsolation { get; set; }
+
+		internal NetworkCredential GetCredentials()
+		{
+			return NetworkCredential ??
+				(StreamIsolation ? GenerateCredentials() : null);
+		}
+
+		private NetworkCredential GenerateCredentials()
+		{
+			const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+			var identity = new string(Enumerable.Repeat(chars, 21)
+			.Select(s => s[(int)(RandomUtils.GetUInt32() % s.Length)]).ToArray());
+			return new NetworkCredential(identity, identity);
+		}
+
 		public override object Clone()
 		{
-			return new SocksSettingsBehavior(SocksEndpoint, OnlyForOnionHosts);
+			return new SocksSettingsBehavior(SocksEndpoint, OnlyForOnionHosts, NetworkCredential, StreamIsolation);
 		}
 
 		protected override void AttachCore()

--- a/NBitcoin/Protocol/Connectors/DefaultEndpointConnector.cs
+++ b/NBitcoin/Protocol/Connectors/DefaultEndpointConnector.cs
@@ -19,18 +19,25 @@ namespace NBitcoin.Protocol.Connectors
 		/// </summary>
 		public bool AllowOnlyTorEndpoints { get; set; } = false;
 
+
+		/// <summary>
+		/// Use a new Tor stream for every connection.
+		/// </summary>
+		public bool ChangeTorIdentities { get; set; } = false;
+
 		public DefaultEndpointConnector()
 		{
 		}
 
-		public DefaultEndpointConnector(bool allowOnlyTorEndpoints)
+		public DefaultEndpointConnector(bool allowOnlyTorEndpoints, bool changeTorIdentities)
 		{
 			AllowOnlyTorEndpoints = allowOnlyTorEndpoints;
+			ChangeTorIdentities = changeTorIdentities;
 		}
 
 		public IEnpointConnector Clone()
 		{
-			return new DefaultEndpointConnector(AllowOnlyTorEndpoints);
+			return new DefaultEndpointConnector(AllowOnlyTorEndpoints, ChangeTorIdentities);
 		}
 
 		public async Task ConnectSocket(Socket socket, EndPoint endpoint, NodeConnectionParameters nodeConnectionParameters, CancellationToken cancellationToken)
@@ -51,7 +58,7 @@ namespace NBitcoin.Protocol.Connectors
 			if (!socks)
 				return;
 
-			await SocksHelper.Handshake(socket, endpoint, cancellationToken).ConfigureAwait(false);
+			await SocksHelper.Handshake(socket, endpoint, ChangeTorIdentities, cancellationToken).ConfigureAwait(false);
 		}
 	}
 }

--- a/NBitcoin/Protocol/Connectors/DefaultEndpointConnector.cs
+++ b/NBitcoin/Protocol/Connectors/DefaultEndpointConnector.cs
@@ -20,24 +20,18 @@ namespace NBitcoin.Protocol.Connectors
 		public bool AllowOnlyTorEndpoints { get; set; } = false;
 
 
-		/// <summary>
-		/// Use a new Tor stream for every connection.
-		/// </summary>
-		public bool ChangeTorIdentities { get; set; } = false;
-
 		public DefaultEndpointConnector()
 		{
 		}
 
-		public DefaultEndpointConnector(bool allowOnlyTorEndpoints, bool changeTorIdentities)
+		public DefaultEndpointConnector(bool allowOnlyTorEndpoints)
 		{
 			AllowOnlyTorEndpoints = allowOnlyTorEndpoints;
-			ChangeTorIdentities = changeTorIdentities;
 		}
 
 		public IEnpointConnector Clone()
 		{
-			return new DefaultEndpointConnector(AllowOnlyTorEndpoints, ChangeTorIdentities);
+			return new DefaultEndpointConnector(AllowOnlyTorEndpoints);
 		}
 
 		public async Task ConnectSocket(Socket socket, EndPoint endpoint, NodeConnectionParameters nodeConnectionParameters, CancellationToken cancellationToken)
@@ -58,7 +52,7 @@ namespace NBitcoin.Protocol.Connectors
 			if (!socks)
 				return;
 
-			await SocksHelper.Handshake(socket, endpoint, ChangeTorIdentities, cancellationToken).ConfigureAwait(false);
+			await SocksHelper.Handshake(socket, endpoint, socksSettings.GetCredentials(), cancellationToken).ConfigureAwait(false);
 		}
 	}
 }


### PR DESCRIPTION
Closes https://github.com/zkSNACKs/WalletWasabi/issues/1293

**UPDATE:** This PR is tested and ready.

The code is probably good, but I couldn't test it. Is there a quick way to test it or should I tie together my local NBitcoin branch with Wasabi somehow?  

If it doesn't fail, then it works as intended since the code has been brought from Wasabi where we have tests for it.  

The trick is that Tor SOCKS5 authentication is actually not authentication, but you can give it any string and if the string is different, then Tor will use a different Tor stream. (With best effort.)