### PR TITLE
Allow opt-in RBF using TransactionBuilder

### DIFF
--- a/NBitcoin/Sequence.cs
+++ b/NBitcoin/Sequence.cs
@@ -18,6 +18,14 @@ namespace NBitcoin
 			}
 		}
 
+		public static Sequence OptInRBF
+		{
+			get
+			{
+				return new Sequence(MAX_BIP125_RBF_SEQUENCE);
+			}
+		}
+
 		/// <summary>
 		/// If this flag set, CTxIn::nSequence is NOT interpreted as a
 		/// relative lock-time. 
@@ -47,6 +55,12 @@ namespace NBitcoin
 		/// sequence number disabled relative lock-time.
 		/// </remarks>
 		public const uint SEQUENCE_FINAL = 0xffffffff;
+
+		/// <summary>
+		/// Setting nSequence to this value on any input in a transaction
+		/// to signal the transaction is replaceable. */
+		/// </summary>
+		public const uint MAX_BIP125_RBF_SEQUENCE = SEQUENCE_FINAL -2;
 
 		/// <summary>
 		/// In order to use the same number of bits to encode roughly the
@@ -100,7 +114,7 @@ namespace NBitcoin
 		{
 			get
 			{
-				return Value < 0xffffffff - 1;
+				return Value <= MAX_BIP125_RBF_SEQUENCE;
 			}
 		}
 

--- a/NBitcoin/TransactionBuilder.cs
+++ b/NBitcoin/TransactionBuilder.cs
@@ -553,6 +553,7 @@ namespace NBitcoin
 			CoinSelector = new DefaultCoinSelector(ShuffleRandom);
 			StandardTransactionPolicy = new StandardTransactionPolicy();
 			DustPrevention = true;
+			OptInRBF = false;
 			InitExtensions();
 		}
 
@@ -589,6 +590,15 @@ namespace NBitcoin
 		/// If true, it will remove any TxOut below Dust, so the transaction get correctly relayed by the network. (Default: true)
 		/// </summary>
 		public bool DustPrevention
+		{
+			get;
+			set;
+		}
+
+		/// <summary>
+		/// If true, it will signal the transaction replaceability in every input. (Default: false)
+		/// </summary>
+		public bool OptInRBF
 		{
 			get;
 			set;
@@ -1377,7 +1387,12 @@ namespace NBitcoin
 				var input = ctx.Transaction.Inputs.FirstOrDefault(i => i.PrevOut == coin.Outpoint);
 				if(input == null)
 					input = ctx.Transaction.Inputs.Add(coin.Outpoint);
-				if(_LockTime != null && !ctx.NonFinalSequenceSet)
+
+				if(OptInRBF)
+				{
+					input.Sequence = Sequence.OptInRBF;
+				}
+				else if(_LockTime != null && !ctx.NonFinalSequenceSet)
 				{
 					input.Sequence = 0;
 					ctx.NonFinalSequenceSet = true;

--- a/NBitcoin/TransactionBuilder.cs
+++ b/NBitcoin/TransactionBuilder.cs
@@ -1392,7 +1392,7 @@ namespace NBitcoin
 				{
 					input.Sequence = Sequence.OptInRBF;
 				}
-				else if(_LockTime != null && !ctx.NonFinalSequenceSet)
+				if(_LockTime != null && !ctx.NonFinalSequenceSet)
 				{
 					input.Sequence = 0;
 					ctx.NonFinalSequenceSet = true;


### PR DESCRIPTION
This PR is for discussing a possible implementation to opt-in signaling `RBF` in transactions built using the `TransactionBuilder`. It adds a `TransactionBuilder.OptInRBF` property (default: `False`) that when set to true sets *all* the inputs' sequence to `0xfffffffd`.


