### PR TITLE
Change node filters to use a concurrent list instead of a dictionary

### DIFF
--- a/NBitcoin/Protocol/Filters/NodeFiltersCollection.cs
+++ b/NBitcoin/Protocol/Filters/NodeFiltersCollection.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace NBitcoin.Protocol.Filters
 {
-	public class NodeFiltersCollection : ThreadSafeCollection<INodeFilter>
+	public class NodeFiltersCollection : ThreadSafeList<INodeFilter>
 	{
 		public IDisposable Add(Action<IncomingMessage, Action> onReceiving, Action<Node, Payload, Action> onSending = null)
 		{

--- a/NBitcoin/Utils/ThreadSafeList.cs
+++ b/NBitcoin/Utils/ThreadSafeList.cs
@@ -96,16 +96,16 @@ namespace NBitcoin
 
 		public IEnumerator<T> GetEnumerator()
 		{
-			IEnumerator<T> enumerator = null;
-
-			lock (_lock)
+			IEnumerator<T> enumerator = _EnumeratorList?.GetEnumerator();
+			if (enumerator == null)
 			{
-				if (_EnumeratorList == null)
-					_EnumeratorList = _Behaviors.ToList();
-
-				enumerator = _EnumeratorList?.GetEnumerator();
+				lock (_lock)
+				{
+					var behaviorsList = _Behaviors.ToList();
+					_EnumeratorList = behaviorsList;
+					enumerator = behaviorsList.GetEnumerator();
+				}
 			}
-
 			return enumerator;
 		}
 

--- a/NBitcoin/Utils/ThreadSafeList.cs
+++ b/NBitcoin/Utils/ThreadSafeList.cs
@@ -96,14 +96,17 @@ namespace NBitcoin
 
 		public IEnumerator<T> GetEnumerator()
 		{
-			if (_EnumeratorList == null)
+			IEnumerator<T> enumerator = null;
+
+			lock (_lock)
 			{
-				lock (_lock)
-				{
+				if (_EnumeratorList == null)
 					_EnumeratorList = _Behaviors.ToList();
-				}
+
+				enumerator = _EnumeratorList?.GetEnumerator();
 			}
-			return _EnumeratorList?.GetEnumerator();
+
+			return enumerator;
 		}
 
 		#endregion

--- a/NBitcoin/Utils/ThreadSafeList.cs
+++ b/NBitcoin/Utils/ThreadSafeList.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NBitcoin
+{ 
+	public class ThreadSafeList<T> : IEnumerable<T>
+	{
+		private List<T> _Behaviors;
+		private object _lock = new object();
+
+		public ThreadSafeList()
+		{
+			lock (_lock)
+				_Behaviors = new List<T>();
+		}
+
+		/// <summary>
+		/// Add an item to the collection
+		/// </summary>
+		/// <param name="item"></param>
+		/// <returns>When disposed, the item is removed</returns>
+		public IDisposable Add(T item)
+		{
+			if (item == null)
+				throw new ArgumentNullException(nameof(item));
+			OnAdding(item);
+			lock (_lock)
+			{
+				_Behaviors.Add(item);
+			}
+			return new ActionDisposable(() =>
+			{
+			}, () => Remove(item));
+		}
+
+		protected virtual void OnAdding(T obj)
+		{
+		}
+		protected virtual void OnRemoved(T obj)
+		{
+		}
+
+		public bool Remove(T item)
+		{
+			bool removed = false;
+			lock (_lock)
+			{
+				removed = _Behaviors.Remove(item);
+			}
+
+			if (removed)
+				OnRemoved(item);
+			return removed;
+		}
+
+		public void Clear()
+		{
+			foreach (var behavior in this)
+				Remove(behavior);
+		}
+
+		public T FindOrCreate<U>() where U : T, new()
+		{
+			return FindOrCreate<U>(() => new U());
+		}
+		public U FindOrCreate<U>(Func<U> create) where U : T
+		{
+			var result = this.OfType<U>().FirstOrDefault();
+			if (result == null)
+			{
+				result = create();
+				Add(result);
+			}
+			return result;
+		}
+		public U Find<U>() where U : T
+		{
+			return this.OfType<U>().FirstOrDefault();
+		}
+
+		public void Remove<U>() where U : T
+		{
+			foreach (var b in this.OfType<U>())
+			{
+				Remove(b);
+			}
+		}
+
+		#region IEnumerable<T> Members
+
+		public IEnumerator<T> GetEnumerator()
+		{
+			return _Behaviors.ToList().GetEnumerator();
+		}
+
+		#endregion
+
+		#region IEnumerable Members
+
+		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+		{
+			return GetEnumerator();
+		}
+
+		#endregion
+	}
+}

--- a/NBitcoin/Utils/ThreadSafeList.cs
+++ b/NBitcoin/Utils/ThreadSafeList.cs
@@ -10,6 +10,8 @@ namespace NBitcoin
 		private List<T> _Behaviors;
 		private object _lock = new object();
 
+		private List<T> _EnumeratorList = null;
+
 		public ThreadSafeList()
 		{
 			lock (_lock)
@@ -29,6 +31,7 @@ namespace NBitcoin
 			lock (_lock)
 			{
 				_Behaviors.Add(item);
+				_EnumeratorList = null;
 			}
 			return new ActionDisposable(() =>
 			{
@@ -48,6 +51,7 @@ namespace NBitcoin
 			lock (_lock)
 			{
 				removed = _Behaviors.Remove(item);
+				_EnumeratorList = null;
 			}
 
 			if (removed)
@@ -92,12 +96,14 @@ namespace NBitcoin
 
 		public IEnumerator<T> GetEnumerator()
 		{
-			List<T> list = null;
-			lock (_lock)
+			if (_EnumeratorList == null)
 			{
-				list = _Behaviors.ToList();
+				lock (_lock)
+				{
+					_EnumeratorList = _Behaviors.ToList();
+				}
 			}
-			return list?.GetEnumerator();
+			return _EnumeratorList?.GetEnumerator();
 		}
 
 		#endregion

--- a/NBitcoin/Utils/ThreadSafeList.cs
+++ b/NBitcoin/Utils/ThreadSafeList.cs
@@ -92,7 +92,12 @@ namespace NBitcoin
 
 		public IEnumerator<T> GetEnumerator()
 		{
-			return _Behaviors.ToList().GetEnumerator();
+			List<T> list = null;
+			lock (_lock)
+			{
+				list = _Behaviors.ToList();
+			}
+			return list?.GetEnumerator();
 		}
 
 		#endregion


### PR DESCRIPTION
This is a prerequisite for the work I'm doing in #692

ConcurrentDictionary does not maintain insertion order so it's usage in NodeFiltersCollection does not allow for ordering of Filters. 

ThreadSafeList uses a list instead of ConcurrentDictionary and the locking of the collection is done manually. Currently I've only replaced the usage in NodeFiltersCollection but I have run all the tests using ThreadSafeList isntead of ThreadSafeCollection in all occurrences and all the same tests pass. So we may be able to replace other instances as well.

ThreadSafeList will allow insertion of duplicates whereas ThreadSafeCollection will not so that is a key difference to be aware of beyond the ordering difference. 