### PR TITLE
Make Script.GetDestination() support P2PK script

### DIFF
--- a/NBitcoin/Script.cs
+++ b/NBitcoin/Script.cs
@@ -1,5 +1,4 @@
 ﻿using System.Runtime.InteropServices;
-using NBitcoin.Crypto;
 using NBitcoin.DataEncoders;
 using System;
 using System.Collections.Generic;
@@ -128,7 +127,7 @@ namespace NBitcoin
 		/// them to be valid. (but old blocks may not comply with) Currently just P2SH,
 		/// but in the future other flags may be added, such as a soft-fork to enforce
 		/// strict DER encoding.
-		/// 
+		///
 		/// Failing one of these tests may trigger a DoS ban - see CheckInputs() for
 		/// details.
 		/// </summary>
@@ -754,7 +753,7 @@ namespace NBitcoin
 		}
 
 		/// <summary>
-		/// Extract P2SH/P2PH/P2WSH/P2WPKH id from scriptPubKey
+		/// Extract P2PK/P2SH/P2PH/P2WSH/P2WPKH id from scriptPubKey
 		/// </summary>
 		/// <param name="network"></param>
 		/// <returns></returns>
@@ -767,7 +766,12 @@ namespace NBitcoin
 			if(scriptHashParams != null)
 				return scriptHashParams;
 			var wit = PayToWitTemplate.Instance.ExtractScriptPubKeyParameters(this);
-			return wit;
+			if(wit != null)
+				return wit;
+			var pubKeyParams = PayToPubkeyTemplate.Instance.ExtractScriptPubKeyParameters(this);
+			if(pubKeyParams != null)
+				return pubKeyParams.Hash;
+			return null;
 		}
 
 		/// <summary>

--- a/NBitcoin/Script.cs
+++ b/NBitcoin/Script.cs
@@ -408,6 +408,11 @@ namespace NBitcoin
 			return new Script(data, true, true);
 		}
 
+		public static Script FromHex(string hex)
+		{
+			return FromBytesUnsafe(Encoders.Hex.DecodeData(hex));
+		}
+
 		public Script(byte[] data)
 			: this((IEnumerable<byte>)data)
 		{


### PR DESCRIPTION
This will make `Script.GetDestinationAddress()` success with P2PK script. The reason I need this because I need to get address from the early mining reward, which is P2PK instead of P2PKH (e.g. https://bchain.info/BTC/tx/0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098).