### PR TITLE
Add Script.IsScriptType() to determine type of script

### DIFF
--- a/NBitcoin.Tests/AltcoinTests.cs
+++ b/NBitcoin.Tests/AltcoinTests.cs
@@ -1,12 +1,9 @@
 ﻿using NBitcoin.Altcoins.Elements;
-using NBitcoin.DataEncoders;
 using NBitcoin.RPC;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace NBitcoin.Tests
@@ -212,7 +209,7 @@ namespace NBitcoin.Tests
 						AddressType = AddressType.Bech32
 					});
 					// If this fail, rpc support segwit bug you said it does not
-					Assert.Equal(rpc.Capabilities.SupportSegwit, address.ScriptPubKey.IsWitness);
+					Assert.Equal(rpc.Capabilities.SupportSegwit, address.ScriptPubKey.IsScriptType(ScriptType.Witness));
 					if (rpc.Capabilities.SupportSegwit)
 					{
 						Assert.True(builder.Network.Consensus.SupportSegwit, "The node RPC support segwit, but Network.Consensus.SupportSegwit is set to false");

--- a/NBitcoin.Tests/Bip158_tests.cs
+++ b/NBitcoin.Tests/Bip158_tests.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.IO;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using Xunit;
-using NBitcoin.DataEncoders;
 using NBitcoin.Crypto;
 
 namespace NBitcoin.Tests
@@ -21,7 +19,7 @@ namespace NBitcoin.Tests
 			foreach(var test in tests.Skip(1))
 			{
 				var i= 0;
-				var testBlockHeight = test[i++]; 
+				var testBlockHeight = test[i++];
 				var testBlockHash = uint256.Parse((string)test[i++]);
 				var testBlock = Block.Parse((string)test[i++], Network.Main);
 				var testPreviousBasicHeader = uint256.Parse((string)test[i++]);
@@ -65,7 +63,7 @@ namespace NBitcoin.Tests
 
 			var key = Hashes.Hash256(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 });
 			var filter = new GolombRiceFilterBuilder()
-				.SetKey( key ) 
+				.SetKey( key )
 				.AddEntries(names)
 				.SetP(0x10)
 				.Build();
@@ -108,11 +106,11 @@ namespace NBitcoin.Tests
 		[Trait("UnitTest", "UnitTest")]
 		public void FalsePositivesTest()
 		{
-			// Given this library can be used for building and query filters for each block of 
+			// Given this library can be used for building and query filters for each block of
 			// the bitcoin's blockchain, we must be sure it performs well, specially in the queries.
 
 			// Considering a 4MB block (overestimated) with an average transaction size of 250 bytes (underestimated)
-			// gives us 16000 transactions (this is about 27 tx/sec). Assuming 2.5 txouts per tx we have 83885 txouts 
+			// gives us 16000 transactions (this is about 27 tx/sec). Assuming 2.5 txouts per tx we have 83885 txouts
 			// per block.
 			const byte P = 20;
 			const int blockCount = 100;
@@ -127,7 +125,7 @@ namespace NBitcoin.Tests
 
 			// Generation of data to be added into the filter
 			var random = new Random();
-				
+
 			var blocks = new List<BlockFilter>(blockCount);
 			for (var i = 0; i < blockCount; i++)
 			{
@@ -264,7 +262,7 @@ namespace NBitcoin.Tests
 				for (int i = 0; i < tx.Outputs.Count; i++)
 				{
 					var output = tx.Outputs[i];
-					if (!output.ScriptPubKey.IsPayToScriptHash && output.ScriptPubKey.IsWitness)
+					if (!output.ScriptPubKey.IsScriptType(ScriptType.P2SH) && output.ScriptPubKey.IsScriptType(ScriptType.Witness))
 					{
 						var outpoint = new OutPoint(tx.GetHash(), i);
 						scripts.Add(output.ScriptPubKey);
@@ -287,7 +285,7 @@ namespace NBitcoin.Tests
 				for (int i = 0; i < tx.Outputs.Count; i++)
 				{
 					var output = tx.Outputs[i];
-					if (!output.ScriptPubKey.IsPayToScriptHash && output.ScriptPubKey.IsWitness)
+					if (!output.ScriptPubKey.IsScriptType(ScriptType.P2SH) && output.ScriptPubKey.IsScriptType(ScriptType.Witness))
 					{
 						Assert.True(filter.Match(output.ScriptPubKey.ToCompressedBytes(), testkey));
 					}
@@ -394,7 +392,7 @@ namespace NBitcoin.Tests
 
 			var key = Hashes.Hash256(Encoding.ASCII.GetBytes("A key for testing"));
 			var builder = new GolombRiceFilterBuilder()
-				.SetKey( key ) 
+				.SetKey( key )
 				.SetP(0x20);
 
 			foreach(var script in scripts)

--- a/NBitcoin.Tests/script_tests.cs
+++ b/NBitcoin.Tests/script_tests.cs
@@ -369,12 +369,12 @@ namespace NBitcoin.Tests
 				flags |= ScriptVerify.Witness;
 				flags |= ScriptVerify.P2SH;
 			}
-			
+
 			var creditingTransaction = CreateCreditingTransaction(scriptPubKey, amount);
 			var spendingTransaction = CreateSpendingTransaction(wit, scriptSig, creditingTransaction);
 			ScriptError actual;
 			Script.VerifyScript(scriptSig, spendingTransaction, 0, new TxOut(amount, scriptPubKey), flags, SigHash.Undefined, out actual);
-			Assert.True(expectedError == actual, "Test : " + testIndex + " " + comment);			
+			Assert.True(expectedError == actual, "Test : " + testIndex + " " + comment);
 #if !NOCONSENSUSLIB
 			var ok = Script.VerifyScriptConsensus(scriptPubKey, spendingTransaction, 0, amount, flags);
 
@@ -1240,6 +1240,66 @@ namespace NBitcoin.Tests
 			script = PayToMultiSigTemplate.Instance.GenerateScriptPubKey(2, true, new PubKey[] { pk4_1, pk4_2, pk4_3 });
 			expected = Script.FromBytesUnsafe(Encoders.Hex.DecodeData("5221021f2f6e1e50cb6a953935c3601284925decd3fd21bc445712576873fb8c6ebc1821022df8750480ad5b26950b25c7ba79d3e37d75f640f8e5d9bcd5b150a0f85014da2103e3818b65bcc73a7d64064106a859cc1a5a728c4345ff0b641209fba0d90de6e953ae"));
 			Assert.Equal(expected, script);
+		}
+
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void CanIdentifyP2PKHScript()
+		{
+			var script = Script.FromHex("76a914c398efa9c392ba6013c5e04ee729755ef7f58b3288ac");
+
+			Assert.False(script.IsScriptType(ScriptType.Witness));
+			Assert.True(script.IsScriptType(ScriptType.P2PKH));
+			Assert.False(script.IsScriptType(ScriptType.P2SH));
+			Assert.False(script.IsScriptType(ScriptType.P2PK));
+			Assert.False(script.IsScriptType(ScriptType.P2WPKH));
+			Assert.False(script.IsScriptType(ScriptType.P2WSH));
+			Assert.False(script.IsScriptType(ScriptType.MultiSig));
+		}
+
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void CanIdentifyP2SHScript()
+		{
+			var script = Script.FromHex("a914e9c3dd0c07aac76179ebc76a6c78d4d67c6c160a87");
+
+			Assert.False(script.IsScriptType(ScriptType.Witness));
+			Assert.False(script.IsScriptType(ScriptType.P2PKH));
+			Assert.True(script.IsScriptType(ScriptType.P2SH));
+			Assert.False(script.IsScriptType(ScriptType.P2PK));
+			Assert.False(script.IsScriptType(ScriptType.P2WPKH));
+			Assert.False(script.IsScriptType(ScriptType.P2WSH));
+			Assert.False(script.IsScriptType(ScriptType.MultiSig));
+		}
+
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void CanIdentifyP2PKScript()
+		{
+			var script = Script.FromHex("410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac");
+
+			Assert.False(script.IsScriptType(ScriptType.Witness));
+			Assert.False(script.IsScriptType(ScriptType.P2PKH));
+			Assert.False(script.IsScriptType(ScriptType.P2SH));
+			Assert.True(script.IsScriptType(ScriptType.P2PK));
+			Assert.False(script.IsScriptType(ScriptType.P2WPKH));
+			Assert.False(script.IsScriptType(ScriptType.P2WSH));
+			Assert.False(script.IsScriptType(ScriptType.MultiSig));
+		}
+
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void CanIdentifyMultiSigScript()
+		{
+			var script = Script.FromHex("514104cc71eb30d653c0c3163990c47b976f3fb3f37cccdcbedb169a1dfef58bbfbfaff7d8a473e7e2e6d317b87bafe8bde97e3cf8f065dec022b51d11fcdd0d348ac4410461cbdcc5409fb4b4d42b51d33381354d80e550078cb532a34bfa2fcfdeb7d76519aecc62770f5b0e4ef8551946d8a540911abe3e7854a26f39f58b25c15342af52ae");
+
+			Assert.False(script.IsScriptType(ScriptType.Witness));
+			Assert.False(script.IsScriptType(ScriptType.P2PKH));
+			Assert.False(script.IsScriptType(ScriptType.P2SH));
+			Assert.False(script.IsScriptType(ScriptType.P2PK));
+			Assert.False(script.IsScriptType(ScriptType.P2WPKH));
+			Assert.False(script.IsScriptType(ScriptType.P2WSH));
+			Assert.True(script.IsScriptType(ScriptType.MultiSig));
 		}
 	}
 }

--- a/NBitcoin.Tests/script_tests.cs
+++ b/NBitcoin.Tests/script_tests.cs
@@ -1301,5 +1301,35 @@ namespace NBitcoin.Tests
 			Assert.False(script.IsScriptType(ScriptType.P2WSH));
 			Assert.True(script.IsScriptType(ScriptType.MultiSig));
 		}
+
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void CanIdentifyP2WPKHScript()
+		{
+			var script = Script.FromHex("0014c4e2db37553d3e55c23da2ef5f2f41eb79935849");
+
+			Assert.True(script.IsScriptType(ScriptType.Witness));
+			Assert.False(script.IsScriptType(ScriptType.P2PKH));
+			Assert.False(script.IsScriptType(ScriptType.P2SH));
+			Assert.False(script.IsScriptType(ScriptType.P2PK));
+			Assert.True(script.IsScriptType(ScriptType.P2WPKH));
+			Assert.False(script.IsScriptType(ScriptType.P2WSH));
+			Assert.False(script.IsScriptType(ScriptType.MultiSig));
+		}
+
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void CanIdentifyP2WSHScript()
+		{
+			var script = Script.FromHex("00201965d4c2e7e7b1973b00931ed042d0bacd03c12b7dc5e06b550c31d15fec7cc1");
+
+			Assert.True(script.IsScriptType(ScriptType.Witness));
+			Assert.False(script.IsScriptType(ScriptType.P2PKH));
+			Assert.False(script.IsScriptType(ScriptType.P2SH));
+			Assert.False(script.IsScriptType(ScriptType.P2PK));
+			Assert.False(script.IsScriptType(ScriptType.P2WPKH));
+			Assert.True(script.IsScriptType(ScriptType.P2WSH));
+			Assert.False(script.IsScriptType(ScriptType.MultiSig));
+		}
 	}
 }

--- a/NBitcoin/BIP174/PSBTInput.cs
+++ b/NBitcoin/BIP174/PSBTInput.cs
@@ -1,16 +1,10 @@
 ﻿using System;
 using System.Linq;
 using System.Collections.Generic;
-using System.Text;
 using Newtonsoft.Json;
 using System.IO;
 using NBitcoin.DataEncoders;
-using NBitcoin.Crypto;
-using NBitcoin;
-using UnKnownKVMap = System.Collections.Generic.SortedDictionary<byte[], byte[]>;
-using HDKeyPathKVMap = System.Collections.Generic.SortedDictionary<NBitcoin.PubKey, System.Tuple<NBitcoin.HDFingerprint, NBitcoin.KeyPath>>;
 using PartialSigKVMap = System.Collections.Generic.SortedDictionary<NBitcoin.PubKey, NBitcoin.TransactionSignature>;
-using System.Collections;
 
 namespace NBitcoin
 {
@@ -220,7 +214,7 @@ namespace NBitcoin
 			}
 		}
 
-		
+
 
 		public PartialSigKVMap PartialSigs
 		{
@@ -260,7 +254,7 @@ namespace NBitcoin
 			}
 			else
 			{
-				if (coin.TxOut.ScriptPubKey.IsPayToScriptHash && redeem_script == null)
+				if (coin.TxOut.ScriptPubKey.IsScriptType(ScriptType.P2SH) && redeem_script == null)
 				{
 					// Let's try to be smart by finding the redeemScript in the global tx
 					if (Parent.Settings.IsSmart && redeem_script == null)
@@ -415,10 +409,10 @@ namespace NBitcoin
 				if (witness_script != null)
 					errors.Add(new PSBTError(Index, "Input finalized, but witness script is not null"));
 			}
-			
+
 			if (witness_utxo != null && non_witness_utxo != null)
 				errors.Add(new PSBTError(Index, "witness utxo and non witness utxo simultaneously present"));
-			
+
 			if (witness_script != null && witness_utxo == null)
 				errors.Add(new PSBTError(Index, "witness script present but no witness utxo"));
 
@@ -452,7 +446,7 @@ namespace NBitcoin
 				{
 					if (redeem_script.Hash.ScriptPubKey != witness_utxo.ScriptPubKey)
 						errors.Add(new PSBTError(Index, "The redeem_script is not coherent with the scriptPubKey of the witness_utxo"));
-					if (witness_script != null && 
+					if (witness_script != null &&
 						redeem_script != null &&
 						PayToWitScriptHashTemplate.Instance.ExtractScriptPubKeyParameters(redeem_script) != witness_script.WitHash)
 						errors.Add(new PSBTError(Index, "witnessScript with witness UTXO does not match the redeemScript"));
@@ -461,9 +455,9 @@ namespace NBitcoin
 
 			if (witness_utxo?.ScriptPubKey is Script s)
 			{
-				if (!s.IsPayToScriptHash && !s.IsWitness)
+				if (!s.IsScriptType(ScriptType.P2SH) && !s.IsScriptType(ScriptType.Witness))
 					errors.Add(new PSBTError(Index, "A Witness UTXO is provided for a non-witness input"));
-				if (s.IsPayToScriptHash && redeem_script is Script r && !r.IsWitness)
+				if (s.IsScriptType(ScriptType.P2SH) && redeem_script is Script r && !r.IsScriptType(ScriptType.Witness))
 					errors.Add(new PSBTError(Index, "A Witness UTXO is provided for a non-witness input"));
 			}
 			return errors;

--- a/NBitcoin/BIP174/PartiallySignedTransaction.cs
+++ b/NBitcoin/BIP174/PartiallySignedTransaction.cs
@@ -2,14 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using NBitcoin.Crypto;
 using NBitcoin.DataEncoders;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using UnKnownKVMap = System.Collections.Generic.SortedDictionary<byte[], byte[]>;
-using HDKeyPathKVMap = System.Collections.Generic.SortedDictionary<NBitcoin.PubKey, System.Tuple<NBitcoin.HDFingerprint, NBitcoin.KeyPath>>;
-using PartialSigKVMap = System.Collections.Generic.SortedDictionary<NBitcoin.KeyId, System.Tuple<NBitcoin.PubKey, NBitcoin.Crypto.ECDSASignature>>;
 using NBitcoin.BuilderExtensions;
 
 namespace NBitcoin
@@ -281,7 +276,7 @@ namespace NBitcoin
 					if (input.TxIn.PrevOut.N >= tx.Outputs.Count)
 						continue;
 					var output = tx.Outputs[input.TxIn.PrevOut.N];
-					if (output.ScriptPubKey.IsWitness || input.RedeemScript?.IsWitness is true)
+					if (output.ScriptPubKey.IsScriptType(ScriptType.Witness) || input.RedeemScript?.IsScriptType(ScriptType.Witness) is true)
 					{
 						input.WitnessUtxo = output;
 						input.NonWitnessUtxo = null;
@@ -859,7 +854,7 @@ namespace NBitcoin
 		}
 
 		/// <summary>
-		/// Filter the keys which contains the <paramref name="accountKey"/> and <paramref name="accountKeyPath"/> in the HDKeys and whose input/output 
+		/// Filter the keys which contains the <paramref name="accountKey"/> and <paramref name="accountKeyPath"/> in the HDKeys and whose input/output
 		/// the same scriptPubKeys as <paramref name="accountHDScriptPubKey"/>.
 		/// </summary>
 		/// <param name="accountHDScriptPubKey">The hdScriptPubKey used to generate addresses</param>

--- a/NBitcoin/Coin.cs
+++ b/NBitcoin/Coin.cs
@@ -3,8 +3,6 @@ using NBitcoin.Stealth;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NBitcoin
 {
@@ -451,7 +449,7 @@ namespace NBitcoin
 		{
 			get
 			{
-				return _OverrideScriptCode != null || !ScriptPubKey.IsPayToScriptHash && !PayToWitScriptHashTemplate.Instance.CheckScriptPubKey(ScriptPubKey);
+				return _OverrideScriptCode != null || !ScriptPubKey.IsScriptType(ScriptType.P2SH) && !PayToWitScriptHashTemplate.Instance.CheckScriptPubKey(ScriptPubKey);
 			}
 		}
 

--- a/NBitcoin/ScriptEvaluationContext.cs
+++ b/NBitcoin/ScriptEvaluationContext.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using NBitcoin.Crypto;
+﻿using NBitcoin.Crypto;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -484,7 +483,7 @@ namespace NBitcoin
 			}
 
 			// Additional validation for spend-to-script-hash transactions:
-			if(((ScriptVerify & ScriptVerify.P2SH) != 0) && scriptPubKey.IsPayToScriptHash)
+			if(((ScriptVerify & ScriptVerify.P2SH) != 0) && scriptPubKey.IsScriptType(ScriptType.P2SH))
 			{
 				Load(evaluationCopy);
 				evaluationCopy = this;
@@ -2067,8 +2066,8 @@ namespace NBitcoin
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="ContextStack{T}"/> 
-		/// base on another stack. This is for copy/clone. 
+		/// Initializes a new instance of the <see cref="ContextStack{T}"/>
+		/// base on another stack. This is for copy/clone.
 		/// </summary>
 		/// <param name="stack">The stack.</param>
 		public ContextStack(ContextStack<T> stack)


### PR DESCRIPTION
As discussion in #701, we decided to obsolete both `IsWitness` and `IsPayToScriptHash` in favor of `IsScriptType`. I don't know how multi-sig and segwit works so if the code for them is not right just let me know.