### PR TITLE
Remove Andreas Schildbach's Testnet DNS Seed

### DIFF
--- a/NBitcoin/Network.cs
+++ b/NBitcoin/Network.cs
@@ -2201,7 +2201,9 @@ namespace NBitcoin
 #if !NOSOCKET
 			vFixedSeeds.Clear();
 			vSeeds.Clear();
-			vSeeds.Add(new DNSSeedData("bitcoin.petertodd.org", "testnet-seed.bitcoin.petertodd.org"));
+			vSeeds.Add(new DNSSeedData("bitcoin.jonasschnelli.ch", "testnet-seed.bitcoin.jonasschnelli.ch"));
+			vSeeds.Add(new DNSSeedData("tbtc.petertodd.org", "seed.tbtc.petertodd.org"));
+			vSeeds.Add(new DNSSeedData("bitcoin.sprovoost.nl", "seed.testnet.bitcoin.sprovoost.nl"));
 			vSeeds.Add(new DNSSeedData("bluematt.me", "testnet-seed.bluematt.me"));
 #endif
 

--- a/NBitcoin/Network.cs
+++ b/NBitcoin/Network.cs
@@ -2203,7 +2203,6 @@ namespace NBitcoin
 			vSeeds.Clear();
 			vSeeds.Add(new DNSSeedData("bitcoin.petertodd.org", "testnet-seed.bitcoin.petertodd.org"));
 			vSeeds.Add(new DNSSeedData("bluematt.me", "testnet-seed.bluematt.me"));
-			vSeeds.Add(new DNSSeedData("bitcoin.schildbach.de", "testnet-seed.bitcoin.schildbach.de"));
 #endif
 
 			base58Prefixes = Network.Main.base58Prefixes.ToArray();


### PR DESCRIPTION
Remove DNS seed that's empty and owner claims he does not run it anymore.

Source: "Indeed, I'm not running it any more." [0]

[0] https://twitter.com/schildbach/status/1138793353749946369