### PR TITLE
Fix for RPC getrawtransaction to avoid null exception

### DIFF
--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -1566,7 +1566,7 @@ namespace NBitcoin.RPC
 				Transaction = ParseTxHex(json.Value<string>("hex")),
 				TransactionId = uint256.Parse(json.Value<string>("txid")),
 				TransactionTime = json["time"] != null ? NBitcoin.Utils.UnixTimeToDateTime(json.Value<long>("time")) : (DateTimeOffset?)null,
-				Hash = uint256.Parse(json.Value<string>("hash")),
+				Hash = json["hash"] != null ? uint256.Parse(json.Value<string>("hash")) : null,
 				Size = json.Value<uint>("size"),
 				VirtualSize = json.Value<uint>("vsize"),
 				Version = json.Value<uint>("version"),

--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -1566,7 +1566,7 @@ namespace NBitcoin.RPC
 				Transaction = ParseTxHex(json.Value<string>("hex")),
 				TransactionId = uint256.Parse(json.Value<string>("txid")),
 				TransactionTime = json["time"] != null ? NBitcoin.Utils.UnixTimeToDateTime(json.Value<long>("time")) : (DateTimeOffset?)null,
-				Hash = json["hash"] != null ? uint256.Parse(json.Value<string>("hash")) : null,
+				Hash = json["hash"] is JToken token ? uint256.Parse(token.Value<string>()) : null,
 				Size = json.Value<uint>("size"),
 				VirtualSize = json.Value<uint>("vsize"),
 				Version = json.Value<uint>("version"),


### PR DESCRIPTION
For derivatives that don't support segwit there is no `hash` field returned in the `getrawtransaction` JSON response.