### PR TITLE
Updated the regtest Liquid asset ID

### DIFF
--- a/NBitcoin.Altcoins/Liquid.cs
+++ b/NBitcoin.Altcoins/Liquid.cs
@@ -12,7 +12,7 @@ namespace NBitcoin.Altcoins
 		static Liquid()
 		{
 			ElementsParams<Liquid>.PeggedAssetId = new uint256("6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d");
-			ElementsParams<LiquidRegtest>.PeggedAssetId = new uint256("5ac9f65c0efcc4775e0baec4ec03abdde22473cd3cf33c0419ca290e0751b225");
+			ElementsParams<LiquidRegtest>.PeggedAssetId = new uint256("b2e15d0d7a0c94e4e2ce0fe6e8691b9e451377f6e46e8045a86f7c4b5d4f0f23");
 		}
 		public override string CryptoCode => "LBTC";
 		public static Liquid Instance { get; } = new Liquid();

--- a/NBitcoin.TestFramework/NodeBuilder.cs
+++ b/NBitcoin.TestFramework/NodeBuilder.cs
@@ -100,6 +100,12 @@ namespace NBitcoin.Tests
 		}
 		public string RegtestFolderName { get; set; }
 
+		/// <summary>
+		/// For blockchains that use an arbitrary chain (e.g. instead of main, testnet and regtest
+		/// Elements can use chain=elementsregtest).
+		/// </summary>
+		public string Chain { get; set; }
+
 		public NodeOSDownloadData GetCurrentOSDownloadData()
 		{
 			return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? Windows :
@@ -457,10 +463,24 @@ namespace NBitcoin.Tests
 		{
 			NodeConfigParameters config = new NodeConfigParameters();
 			StringBuilder configStr = new StringBuilder();
-			configStr.AppendLine("regtest=1");
+			if (String.IsNullOrEmpty(NodeImplementation.Chain))
+			{
+				configStr.AppendLine("regtest=1");
+			}
+			else
+			{
+				configStr.AppendLine($"chain={NodeImplementation.Chain}");
+			}
 			if (NodeImplementation.UseSectionInConfigFile)
 			{
-				configStr.AppendLine("[regtest]");
+				if (String.IsNullOrEmpty(NodeImplementation.Chain))
+				{
+					configStr.AppendLine("[regtest]");
+				}
+				else
+				{
+					configStr.AppendLine($"[{NodeImplementation.Chain}]");
+				}
 			}
 			config.Add("rest", "1");
 			config.Add("server", "1");

--- a/NBitcoin.TestFramework/WellknownNodeDownloadData.cs
+++ b/NBitcoin.TestFramework/WellknownNodeDownloadData.cs
@@ -731,6 +731,23 @@ namespace NBitcoin.Tests
 				RegtestFolderName = "elementsregtest",
 				AdditionalRegtestConfig = "initialfreecoins=210000000000000"
 			};
+
+			public NodeDownloadData v0_17_0_1 = new NodeDownloadData()
+			{
+				Version = "0.17.0.1",
+				Windows = new NodeOSDownloadData()
+				{
+					DownloadLink = "https://github.com/ElementsProject/elements/releases/download/elements-{0}/elements-{0}-win64.zip",
+					Archive = "elements-{0}-win64.zip",
+					Executable = "elements-0.17.0/bin/elementsd.exe",
+					Hash = "e1dd04716d23e214b697ee33f2a77c803ae7e93ed93f2db68462a8c278361a24"
+				},
+				RegtestFolderName = "elementsregtest",
+				Chain = "elementsregtest",
+				AdditionalRegtestConfig = "initialfreecoins=210000000000000\nvalidatepegin=0",
+				UseSectionInConfigFile = true
+			};
+
 		}
 		public class LiquidNodeDownloadData
 		{


### PR DESCRIPTION
Since Liquid has switched back to Elements as the code repository the chain and asset ID's have changed for regtest.

See readme on https://github.com/Blockstream/liquid.