### PR TITLE
Add testcase for ecdsa serilization

### DIFF
--- a/NBitcoin.Tests/ECDSATests.cs
+++ b/NBitcoin.Tests/ECDSATests.cs
@@ -1,0 +1,26 @@
+using Xunit;
+using NBitcoin;
+using NBitcoin.Tests.Helpers;
+
+namespace NBitcoin.Tests
+{
+	public class ECDSATests
+	{
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void ECDSASerializationTests()
+		{
+			var rBytes = new byte[] { 255, 243, 22, 18, 30, 119, 145, 145, 181, 246, 229, 69,
+			127, 129, 220, 20, 146, 135, 213, 55, 116, 193, 77,
+			112, 75, 86, 154, 129, 192, 171, 159, 3};
+			var sBytes = new byte[] { 89, 73, 211,
+			209, 8, 245, 164, 77, 242, 61, 237, 65, 36, 219, 246,
+			197, 201, 239, 46, 70, 143, 17, 255, 34, 215, 16, 183,
+			164, 144, 161, 29, 194};
+			var r = new BouncyCastle.Math.BigInteger(rBytes);
+			var s = new BouncyCastle.Math.BigInteger(sBytes);
+			var rBytes2 = Utils.BigIntegerToBytes(r, 32);
+			Assert.Equal(rBytes.ToHexString(), rBytes2.ToHexString());
+		}
+	}
+}

--- a/NBitcoin.Tests/Helpers/Extensions.cs
+++ b/NBitcoin.Tests/Helpers/Extensions.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace NBitcoin.Tests.Helpers
+{
+	public static class Extensions
+	{
+		public static string ToHexString(this Span<byte> span)
+		{
+			return "0x" + BitConverter.ToString(span.ToArray()).Replace("-", "").ToLowerInvariant();
+
+		}
+
+		public static string ToHexString(this byte[] b)
+			=> ToHexString(b.AsSpan());
+
+		public static byte[] HexToBytes(this string hexString)
+		{
+			int chars = hexString.Length;
+			byte[] bytes = new byte[chars / 2];
+			for (int i = 0; i < chars; i += 2)
+			{
+				bytes[i / 2] = Convert.ToByte(hexString.Substring(i, 2), 16);
+			}
+			return bytes;
+		}
+	}
+}


### PR DESCRIPTION
In Lightning Network, signature serialization is done by non-DER format, that is
 R value(32 bytes) + S Value(32 bytes)

I've been doing this serialization by creating wrapper class for ECDSASignature, and it seems to work fine. But only when the first byte of an R is 0xff, it fails to deserialize properly. (found by Property based testing.)
So I have reproduced the problem in this PR for begging someone's help.

(I've been trying to fix it by myself but BigInteger's `ToByteArray` method is too cryptic :()

I will really appreciate if someone tells me why this test is failing and if this is an intended behavior or not.