### PR TITLE
Fix typo on obsolete call

### DIFF
--- a/NBitcoin/BitcoinAddress.cs
+++ b/NBitcoin/BitcoinAddress.cs
@@ -106,7 +106,7 @@ namespace NBitcoin
 		/// <param name="str">The string to parse</param>
 		/// <returns>A BitcoinAddress or BitcoinScriptAddress</returns>
 		/// <exception cref="System.FormatException">Invalid format</exception>
-		[Obsolete("Use BitcoinCreate(string, Network) instead")]
+		[Obsolete("Use BitcoinAddress.Create(string, Network) instead")]
 		public static BitcoinAddress Create(string str)
 		{
 			if (str == null)


### PR DESCRIPTION
Also, would like to ask why is this obsolete, I know you can always do:

```csharp
Network.Parse<BitcoinAddress>(addr.ToString(), null)
```

But to me also `BitcoinAddress.Create(str)` makes sense as well.