### PR TITLE
Try using threadsafe list for filters again

### DIFF
--- a/NBitcoin/Protocol/Filters/NodeFiltersCollection.cs
+++ b/NBitcoin/Protocol/Filters/NodeFiltersCollection.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace NBitcoin.Protocol.Filters
 {
-	public class NodeFiltersCollection : ThreadSafeCollection<INodeFilter>
+	public class NodeFiltersCollection : ThreadSafeList<INodeFilter>
 	{
 		public IDisposable Add(Action<IncomingMessage, Action> onReceiving, Action<Node, Payload, Action> onSending = null)
 		{


### PR DESCRIPTION
This change was made in #698 and seemed to introduce stability problems.

However, repeated local runs of the test `CanMaintainChainWithSlimChainBehavior` have not elicited a similar result: they all pass.