### PR TITLE
Fix edge case when query value siphash is zero

### DIFF
--- a/NBitcoin.Tests/Bip158_tests.cs
+++ b/NBitcoin.Tests/Bip158_tests.cs
@@ -465,7 +465,7 @@ namespace NBitcoin.Tests
 				.Build();
 
 			var scriptPubKey = Encoders.Hex.DecodeData("D432CB07482718ECE932DA6914D1FDC1A8EACE3F127D");
-			var key = blockHash[0..16];
+			var key = blockHash.SafeSubarray(0, 16);
 			Assert.False(filter.Match(scriptPubKey, key));
 		}
 	}

--- a/NBitcoin.Tests/Bip158_tests.cs
+++ b/NBitcoin.Tests/Bip158_tests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using Xunit;
 using NBitcoin.Crypto;
+using NBitcoin.DataEncoders;
 
 namespace NBitcoin.Tests
 {
@@ -173,7 +174,7 @@ namespace NBitcoin.Tests
 					falsePositiveCount++;
 			}
 
-			Assert.True(falsePositiveCount < 5);
+			Assert.True(falsePositiveCount <= 2);
 
 			// Filter has to mat existing values
 			var falseNegativeCount = 0;
@@ -184,6 +185,7 @@ namespace NBitcoin.Tests
 					falseNegativeCount++;
 			}
 
+			// False negatives have to be always zero.
 			Assert.Equal(0, falseNegativeCount);
 		}
 
@@ -448,6 +450,23 @@ namespace NBitcoin.Tests
 				var match = filter.MatchAny(new[] { script.ToBytes() }, keyMatch);
 				Assert.True(match);
 			}
+		}
+
+		[Fact]
+		public void EdgeCaseSipHashEqualZero()
+		{
+			var dummyScriptPubKey = Encoders.Hex.DecodeData("0009BBE4C2D17185643765C265819BF5261755247D");
+			var blockHash = Encoders.Hex.DecodeData("CB4D1D1ED725B888173BEF553BBE2BF4237B42364BC90638F0CB040F87B57CD4");
+			var filter = new GolombRiceFilterBuilder()
+				.SetKey(new uint256(blockHash))
+				.SetP(20)
+				.SetM(1 << 20)
+				.AddEntries(new[]{ dummyScriptPubKey })
+				.Build();
+
+			var scriptPubKey = Encoders.Hex.DecodeData("D432CB07482718ECE932DA6914D1FDC1A8EACE3F127D");
+			var key = blockHash[0..16];
+			Assert.False(filter.Match(scriptPubKey, key));
 		}
 	}
 }

--- a/NBitcoin.Tests/NBitcoin.Tests.csproj
+++ b/NBitcoin.Tests/NBitcoin.Tests.csproj
@@ -4,9 +4,10 @@
 		<Company>Metaco SA</Company>
 		<Copyright>Copyright © Metaco SA 2017</Copyright>
 		<Description>The C# Bitcoin Library</Description>
+		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
   <PropertyGroup>
-	  <TargetFrameworks>net461;netcoreapp3.0</TargetFrameworks>
+	  <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
 	  <TargetFrameworks Condition="'$(BuildingInsideVisualStudio)' == 'true'">netcoreapp3.0</TargetFrameworks>
 	  <!--<TargetFrameworks Condition="'$(BuildingInsideVisualStudio)' == 'true' And '$(MSBuildRuntimeType)' == 'Core' ">netcoreapp2.1</TargetFrameworks>-->
 	  <!--<NoWarn>CS0618</NoWarn>-->

--- a/NBitcoin.Tests/NBitcoin.Tests.csproj
+++ b/NBitcoin.Tests/NBitcoin.Tests.csproj
@@ -7,7 +7,7 @@
 		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
   <PropertyGroup>
-	  <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+	  <TargetFrameworks>net461;netcoreapp3.0</TargetFrameworks>
 	  <TargetFrameworks Condition="'$(BuildingInsideVisualStudio)' == 'true'">netcoreapp3.0</TargetFrameworks>
 	  <!--<TargetFrameworks Condition="'$(BuildingInsideVisualStudio)' == 'true' And '$(MSBuildRuntimeType)' == 'Core' ">netcoreapp2.1</TargetFrameworks>-->
 	  <!--<NoWarn>CS0618</NoWarn>-->

--- a/NBitcoin/BIP158/GolombRiceFilter.cs
+++ b/NBitcoin/BIP158/GolombRiceFilter.cs
@@ -210,43 +210,30 @@ namespace NBitcoin
 			if (key == null)
 				throw new ArgumentNullException(nameof(key));
 
-			if (N == 0)
-				return false;
-
 			var hs = ConstructHashedSet(P, N, M, key, data, dataCount);
-
-			var lastValue1 = 0UL;
-			var lastValue2 = hs[0];
-			var i = 1;
 
 			var bitStream = new BitStream(Data);
 			var sr = new GRCodedStreamReader(bitStream, P, 0);
 
-			while (lastValue1 != lastValue2)
+			while(sr.TryRead(out var val))
 			{
-				if (lastValue1 > lastValue2)
+				var dataIndex = 0;
+				while(true)
 				{
-					if (i < hs.Length)
-					{
-						lastValue2 = hs[i];
-						i++;
-					}
-					else
-					{
+					if (dataIndex == dataCount)
 						return false;
-					}
-				}
-				else if (lastValue2 > lastValue1)
-				{
 
-					if (sr.TryRead(out var val))
-						lastValue1 = val;
-					else
-						return false;
+					if (hs[dataIndex] == val)
+						return true;
+
+					if (hs[dataIndex] > val)
+						break;
+
+					dataIndex++;
 				}
 			}
 
-			return true;
+			return false;
 		}
 
 		/// <summary>


### PR DESCRIPTION
This PR reduces the number of **false positives** we get when querying the filters. It is an edge case but after querying thousands of filters with hundreds of keys the number of blocks downloaded is now much less.

It was heavily tested for correctness but it is not optimized (not measured yet). 