### PR TITLE
Fix GetBlockFilterAsync

### DIFF
--- a/NBitcoin.Tests/RPCClientTests.cs
+++ b/NBitcoin.Tests/RPCClientTests.cs
@@ -1100,7 +1100,7 @@ namespace NBitcoin.Tests
 		}
 
 		[Fact]
-		public void GetFilter()
+		public async Task GetBlockFilterAsync()
 		{
 			using (var builder = NodeBuilderEx.Create())
 			{
@@ -1110,19 +1110,22 @@ namespace NBitcoin.Tests
 				node.Generate(101);
 
 				var prevFilterHeader = uint256.Zero;
-				for(var height = 0; height < 101; height++)
+				for (var height = 0; height < 101; height++)
 				{
 					var block = rpc.GetBlock(height);
 					var blockHash = block.GetHash();
 					var blockFilter = rpc.GetBlockFilter(blockHash);
+					var sameFilter = await rpc.GetBlockFilterAsync(blockHash);
+					Assert.Equal(blockFilter.Header, sameFilter.Header);
+					Assert.Equal(blockFilter.Filter.ToString(), sameFilter.Filter.ToString());
 
 					Assert.Equal(blockFilter.Header, blockFilter.Filter.GetHeader(prevFilterHeader));
 
 					byte[] FilterKey(uint256 hash) => hash.ToBytes().SafeSubarray(0, 16);
 					var coinbaseTx = block.Transactions[0];
 					var minerScriptPubKey = coinbaseTx.Outputs[0].ScriptPubKey;
-					Assert.True(blockFilter.Filter.MatchAny(new[] { minerScriptPubKey.ToBytes() }, FilterKey(blockHash) ));
-					Assert.False(blockFilter.Filter.MatchAny(new[] { RandomUtils.GetBytes(20) }, FilterKey(blockHash) ));
+					Assert.True(blockFilter.Filter.MatchAny(new[] { minerScriptPubKey.ToBytes() }, FilterKey(blockHash)));
+					Assert.False(blockFilter.Filter.MatchAny(new[] { RandomUtils.GetBytes(20) }, FilterKey(blockHash)));
 
 					prevFilterHeader = blockFilter.Header;
 				}

--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -1355,15 +1355,22 @@ namespace NBitcoin.RPC
 			return uint256.Parse(resp.Result.ToString());
 		}
 
+		/// <summary>
+		/// Retrieve a BIP 157 content filter for a particular block.
+		/// </summary>
+		/// <param name="blockHash">The hash of the block.</param>
 		public BlockFilter GetBlockFilter(uint256 blockHash)
 		{
-			var resp = SendCommand("getblockfilter", blockHash, "basic");
-			return ParseCompactFilter(resp);
+			return GetBlockFilterAsync(blockHash).GetAwaiter().GetResult();
 		}
 
+		/// <summary>
+		/// Retrieve a BIP 157 content filter for a particular block.
+		/// </summary>
+		/// <param name="blockHash">The hash of the block.</param>
 		public async Task<BlockFilter> GetBlockFilterAsync(uint256 blockHash)
 		{
-			var resp = await SendCommandAsync("getfilter", blockHash, "basic").ConfigureAwait(false);
+			var resp = await SendCommandAsync(RPCOperations.getblockfilter, blockHash, "basic").ConfigureAwait(false);
 			return ParseCompactFilter(resp);
 		}
 

--- a/NBitcoin/RPC/RPCOperations.cs
+++ b/NBitcoin/RPC/RPCOperations.cs
@@ -97,6 +97,7 @@ namespace NBitcoin.RPC
 		walletcreatefundedpsbt,
 
 		getblockcount,
+		getblockfilter,
 		getbestblockhash,
 		getdifficulty,
 		settxfee,


### PR DESCRIPTION
`GetBlockFilterAsync` was sending `getfilter` command, which is incorrect, since the command is `getblockfilter`.

Also added test for it and made sure that the NBitcoin practices are consistent with this RPC command (eg., I added the command to the `RPCOperations` enum instead of using string.)