### PR TITLE
Make target use System.Numerics instead of BC BigInteger

### DIFF
--- a/NBitcoin.Tests/ChainTests.cs
+++ b/NBitcoin.Tests/ChainTests.cs
@@ -289,7 +289,11 @@ namespace NBitcoin.Tests
 			foreach (var history in histories)
 			{
 				var height = int.Parse(history.Split(',')[0]);
+#if NO_NATIVE_BIGNUM
 				var expectedTarget = new Target(new BouncyCastle.Math.BigInteger(history.Split(',')[1], 10));
+#else
+				var expectedTarget = new Target(System.Numerics.BigInteger.Parse(history.Split(',')[1]));
+#endif
 
 				var block = main.GetBlock(height).Header;
 

--- a/NBitcoin.Tests/NBitcoin.Tests.csproj
+++ b/NBitcoin.Tests/NBitcoin.Tests.csproj
@@ -24,10 +24,9 @@
 	</PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp3.1' ">
     <DefineConstants>$(DefineConstants);NETCORE;NOTRACESOURCE;NOCUSTOMSSLVALIDATION;NOHTTPSERVER</DefineConstants>
-    <DefineConstants Condition=" '$(TargetFrameworkOverride)' != 'netstandard2.0' " >$(DefineConstants);HAS_SPAN</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <DefineConstants>$(DefineConstants);NETCORE;HAS_SPAN;NO_BC</DefineConstants>
+  <PropertyGroup Condition=" ('$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'netcoreapp3.1') And ( '$(TargetFrameworkOverride)' != 'netstandard2.0' ) ">
+    <DefineConstants >$(DefineConstants);NETCORE;HAS_SPAN;NO_BC</DefineConstants>
     <RemoveBC>true</RemoveBC>
   </PropertyGroup>
 	<ItemGroup>

--- a/NBitcoin/Block.cs
+++ b/NBitcoin/Block.cs
@@ -1,4 +1,8 @@
-﻿using NBitcoin.BouncyCastle.Math;
+﻿#if NO_NATIVE_BIGNUM
+using NBitcoin.BouncyCastle.Math;
+#else
+using System.Numerics;
+#endif
 using NBitcoin.Crypto;
 using NBitcoin.DataEncoders;
 using NBitcoin.RPC;
@@ -214,7 +218,7 @@ namespace NBitcoin
 				return (nBits == 0);
 			}
 		}
-		#region IBitcoinSerializable Members
+#region IBitcoinSerializable Members
 
 		public virtual void ReadWrite(BitcoinStream stream)
 		{
@@ -228,7 +232,7 @@ namespace NBitcoin
 		}
 
 
-		#endregion
+#endregion
 
 
 		public virtual uint256 GetPoWHash()
@@ -301,12 +305,21 @@ namespace NBitcoin
 			}
 		}
 
+#if NO_NATIVE_BIGNUM
 		static BigInteger Pow256 = BigInteger.ValueOf(2).Pow(256);
+#else
+		static BigInteger Pow256 = BigInteger.Pow(new BigInteger(2), 256);
+#endif
 		public bool CheckProofOfWork()
 		{
 			var bits = Bits.ToBigInteger();
+#if NO_NATIVE_BIGNUM
 			if (bits.CompareTo(BigInteger.Zero) <= 0 || bits.CompareTo(Pow256) >= 0)
 				return false;
+#else
+			if (bits <= BigInteger.Zero || bits >= Pow256)
+				return false;
+#endif
 			// Check proof of work matches claimed amount
 			return GetPoWHash() <= Bits.ToUInt256();
 		}

--- a/NBitcoin/UInt2561.cs
+++ b/NBitcoin/UInt2561.cs
@@ -209,7 +209,7 @@ namespace NBitcoin
 #if HAS_SPAN
 		public uint256(ReadOnlySpan<byte> bytes)
 		{
-			if(bytes.Length != WIDTH_BYTE)
+			if (bytes.Length != WIDTH_BYTE)
 			{
 				throw new FormatException("the byte array should be 32 bytes long");
 			}
@@ -253,6 +253,83 @@ namespace NBitcoin
 			pn6 = Utils.ToUInt32(bytes, 4 * 6, true);
 			pn7 = Utils.ToUInt32(bytes, 4 * 7, true);
 
+		}
+
+		public int GetBisCount()
+		{
+			if (pn7 != 0)
+			{
+				for (int nbits = 31; nbits > 0; nbits--)
+				{
+					if ((pn7 & 1U << nbits) != 0)
+						return 32 * 7 + nbits + 1;
+				}
+				return 32 * 7 + 1;
+			}
+			if (pn6 != 0)
+			{
+				for (int nbits = 31; nbits > 0; nbits--)
+				{
+					if ((pn6 & 1U << nbits) != 0)
+						return 32 * 6 + nbits + 1;
+				}
+				return 32 * 6 + 1;
+			}
+			if (pn5 != 0)
+			{
+				for (int nbits = 31; nbits > 0; nbits--)
+				{
+					if ((pn5 & 1U << nbits) != 0)
+						return 32 * 5 + nbits + 1;
+				}
+				return 32 * 5 + 1;
+			}
+			if (pn4 != 0)
+			{
+				for (int nbits = 31; nbits > 0; nbits--)
+				{
+					if ((pn4 & 1U << nbits) != 0)
+						return 32 * 4 + nbits + 1;
+				}
+				return 32 * 4 + 1;
+			}
+			if (pn3 != 0)
+			{
+				for (int nbits = 31; nbits > 0; nbits--)
+				{
+					if ((pn3 & 1U << nbits) != 0)
+						return 32 * 3 + nbits + 1;
+				}
+				return 32 * 3 + 1;
+			}
+			if (pn2 != 0)
+			{
+				for (int nbits = 31; nbits > 0; nbits--)
+				{
+					if ((pn2 & 1U << nbits) != 0)
+						return 32 * 2 + nbits + 1;
+				}
+				return 32 * 2 + 1;
+			}
+			if (pn1 != 0)
+			{
+				for (int nbits = 31; nbits > 0; nbits--)
+				{
+					if ((pn1 & 1U << nbits) != 0)
+						return 32 * 1 + nbits + 1;
+				}
+				return 32 * 1 + 1;
+			}
+			if (pn0 != 0)
+			{
+				for (int nbits = 31; nbits > 0; nbits--)
+				{
+					if ((pn0 & 1U << nbits) != 0)
+						return 32 * 0 + nbits + 1;
+				}
+				return 32 * 0 + 1;
+			}
+			return 0;
 		}
 
 		public uint256(byte[] vch)
@@ -423,7 +500,7 @@ namespace NBitcoin
 #if HAS_SPAN
 		public void ToBytes(Span<byte> output, bool lendian = true)
 		{
-			if(output.Length < WIDTH_BYTE)
+			if (output.Length < WIDTH_BYTE)
 				throw new ArgumentException(message: $"The array should be at least of size {WIDTH_BYTE}", paramName: nameof(output));
 
 			var initial = output;
@@ -443,7 +520,7 @@ namespace NBitcoin
 			output = output.Slice(4);
 			Utils.ToBytes(pn7, true, output);
 
-			if(!lendian)
+			if (!lendian)
 				initial.Reverse();
 		}
 #endif


### PR DESCRIPTION
Slowly replace dependencies on BC's BigInteger.