### PR TITLE
CoverTheRest fails to get the correct fee amount

### DIFF
--- a/NBitcoin.Tests/transaction_tests.cs
+++ b/NBitcoin.Tests/transaction_tests.cs
@@ -307,7 +307,7 @@ namespace NBitcoin.Tests
 				Assert.Null(wallet.SelectCoinsMinConf(Money.Cents(1), filter_standard, out setCoinsRet, out nValueRet));
 
 				wallet.AddCoin(Money.Cents(1), 4);        // add a new 1 cent coin
-				
+
 				// with a new 1 cent coin, we still can't find a mature 1 cent
 				Assert.Null(wallet.SelectCoinsMinConf(Money.Cents(1), filter_standard, out setCoinsRet, out nValueRet));
 
@@ -1319,6 +1319,82 @@ namespace NBitcoin.Tests
 			Assert.True(entry.Asset.Quantity == quantity);
 			if (destination != null)
 				Assert.True(txout.ScriptPubKey == destination.ScriptPubKey);
+		}
+
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void CorrectFeeAfterAnyoneCanPay()
+		{
+			var network = Network.Main;
+			var feeRate = new FeeRate(1_000L);
+			var tokenValue = 5_500L;
+			var tokenPrice = 10_000L;
+
+			OutPoint tokenOutpoint = null;
+			Script tokenOwnerScriptPubKey = null;
+			Script tokenAnyoneCanPayScript = null;
+
+			// create token with anyone can pay signature
+			{
+				var privateKey = new Key();
+				tokenOwnerScriptPubKey = privateKey.PubKey.Hash.ScriptPubKey;
+
+				Coin token = CreateCoin(tokenValue, tokenOwnerScriptPubKey);
+				tokenOutpoint = token.Outpoint;
+
+				var txbuilder = new TransactionBuilder(network);
+
+				txbuilder
+					.AddCoins(token)
+					.CoverOnly(token.Amount)
+					.Send(tokenOwnerScriptPubKey, new Money(tokenPrice));
+				Transaction tx = txbuilder.BuildTransaction(false);
+
+				// sign with anyone can pay
+				tx = txbuilder.AddKeys(privateKey).SignTransaction(tx, SigHash.AnyoneCanPay | SigHash.Single);
+
+				// extract signature
+				tokenAnyoneCanPayScript = tx.Inputs[0].ScriptSig;
+			}
+
+			// another key tries to consume this token
+			{
+				var tx = network.Consensus.ConsensusFactory.CreateTransaction();
+				TxIn in0 = new TxIn(tokenOutpoint, tokenAnyoneCanPayScript);
+				TxOut out0 = new TxOut(Money.FromUnit(tokenPrice, MoneyUnit.Satoshi), tokenOwnerScriptPubKey);
+				tx.Inputs.Add(in0);
+				tx.Outputs.Add(out0);
+
+				var privateKey = new Key();
+				var tokenBuyerScriptPubKey = privateKey.PubKey.Hash.ScriptPubKey;
+
+				var tokenCoin = new Coin(tokenOutpoint, new TxOut(tokenValue, tokenOwnerScriptPubKey));
+				var coins = new ICoin[] { CreateCoin(5_500L, tokenBuyerScriptPubKey) };
+				var txbuilder = new TransactionBuilder(network);
+
+				tx = txbuilder
+					.ContinueToBuild(tx)
+					.AddCoins(tokenCoin)
+					.AddCoins(coins)
+					.CoverTheRest()
+					.SetChange(tokenBuyerScriptPubKey)
+					.SendEstimatedFees(feeRate)
+					.BuildTransaction(false);
+
+				// sign and verify
+				tx = txbuilder.AddKeys(new Key[] { privateKey }).SignTransaction(tx);
+
+				var estimatedFees = txbuilder.EstimateFees(feeRate);
+				var fee = tx.GetFee(txbuilder.FindSpentCoins(tx));
+				System.Console.WriteLine("fee: " + fee.Satoshi + "; estimatedFees" + estimatedFees.Satoshi);
+				System.Console.WriteLine(tx.ToString());
+				Assert.Equal(tokenAnyoneCanPayScript, tx.Inputs[0].ScriptSig);
+				Assert.Equal(estimatedFees, fee);
+
+				bool result = txbuilder.Verify(tx,out TransactionPolicyError[] errors);
+				Assert.True(result);
+
+			}
 		}
 
 		[Fact]


### PR DESCRIPTION
this test shows a small example for a case where CoverTheRest fails, 
which can be resolved by an CoverAll method like here:

https://github.com/soraphis/NBitcoin/compare/test/cover-all...soraphis:feature/cover-all

(I wasn't sure in which order I should present the test and its fix)