### PR TITLE
[Refactoring] Remove unnecessary if statement

### DIFF
--- a/NBitcoin.Tests/transaction_tests.cs
+++ b/NBitcoin.Tests/transaction_tests.cs
@@ -2128,7 +2128,7 @@ namespace NBitcoin.Tests
 			txBuilder.AddCoins(RandomCoin(Money.Satoshis(1000), k.PubKey.WitHash));
 			txBuilder.Send(new Key().ScriptPubKey, Money.Satoshis(600));
 			txBuilder.SetChange(new Key().PubKey.WitHash);
-			// The dust should be 294, so should have 1 outputs
+			// The dust should be 293, so should have 1 outputs
 			txBuilder.SendFees(Money.Satoshis(400 - 293));
 			signed = txBuilder.BuildPSBT(false);
 			Assert.Single(signed.Outputs);

--- a/NBitcoin/TransactionBuilder.cs
+++ b/NBitcoin/TransactionBuilder.cs
@@ -1526,12 +1526,10 @@ namespace NBitcoin
 			{
 				if (changeScript == null)
 					throw new InvalidOperationException("A change address should be specified (" + ctx.ChangeType + ")");
-				if (!(dust is Money) || change.CompareTo(dust) >= 0)
-				{
-					ctx.RestoreMemento(originalCtx);
-					ctx.ChangeAmount = change;
-					goto retry;
-				}
+
+				ctx.RestoreMemento(originalCtx);
+				ctx.ChangeAmount = change;
+				goto retry;
 			}
 			ctx.ChangeAmount = zero;
 			if (ShuffleRandom != null)


### PR DESCRIPTION
```
if (change.CompareTo(dust) >= 0 && change.CompareTo(zero) != 0)
{
	if (!(dust is Money) || change.CompareTo(dust) >= 0)
}
```
If the first if statement is true the second one should always be true, and thus it should be removed.