### PR TITLE
Improve performance of uint256

### DIFF
--- a/NBitcoin.Bench/UInt256Bench.cs
+++ b/NBitcoin.Bench/UInt256Bench.cs
@@ -1,0 +1,36 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NBitcoin.Bench
+{
+	public class UInt256Bench
+	{
+		uint256 Value;
+		byte[] Bytes;
+		byte[] EmptyArray;
+		[GlobalSetup]
+		public void Setup()
+		{
+			Value = RandomUtils.GetUInt256();
+			Bytes = Value.ToBytes();
+			EmptyArray = new byte[32];
+		}
+		[Benchmark]
+		public void Read()
+		{
+			new uint256(Bytes);
+		}
+		[Benchmark]
+		public void WriteToArray()
+		{
+			Value.ToBytes(EmptyArray);
+		}
+		[Benchmark]
+		public void WriteToSpan()
+		{
+			Value.ToBytes(EmptyArray.AsSpan());
+		}
+	}
+}

--- a/NBitcoin.Tests/uint256_tests.cs
+++ b/NBitcoin.Tests/uint256_tests.cs
@@ -104,6 +104,34 @@ namespace NBitcoin.Tests
 
 		[Fact]
 		[Trait("UnitTest", "UnitTest")]
+		public void uitnSerializationTests2()
+		{
+			var v = new uint256("0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20");
+			var vr = new uint256("201f1e1d1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201");
+			var bytes = v.ToBytes();
+			Assert.Equal(0x20, bytes[0]);
+			Assert.Equal(0x01, bytes[31]);
+
+			var v2 = new uint256(bytes);
+			Assert.Equal(v, v2);
+
+			Assert.Equal("0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20", v2.ToString());
+
+			var bytes2 = new byte[32];
+			v2.ToBytes(bytes2);
+			var v3 = new uint256(bytes2, 0, 32);
+			Assert.Equal(v2, v3);
+
+			Assert.Equal(vr, new uint256(v.ToBytes(false)));
+			v.ToBytes(bytes, false);
+			Assert.Equal(vr, new uint256(bytes));
+
+			v.ToBytes(bytes);
+			Assert.Equal(vr, new uint256(bytes, false));
+		}
+
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
 		public void uitnSerializationTests()
 		{
 			MemoryStream ms = new MemoryStream();


### PR DESCRIPTION
Before
|       Method |     Mean |    Error |   StdDev |
|------------- |---------:|---------:|---------:|
|         Read | 27.78 ns | 0.422 ns | 0.352 ns |
| WriteToArray | 89.02 ns | 1.452 ns | 1.358 ns |
|  WriteToSpan | 20.86 ns | 0.404 ns | 0.338 ns |


After
|       Method |      Mean |     Error |    StdDev |
|------------- |----------:|----------:|----------:|
|         Read |  9.020 ns | 0.1607 ns | 0.1424 ns |
| WriteToArray | 14.387 ns | 0.1589 ns | 0.1487 ns |
|  WriteToSpan | 14.172 ns | 0.1521 ns | 0.1348 ns |

Note that I only do on endian machine, as the logic is too tricky and untestable for bigendian machine. @lontivero @nopara73 you wanted that for a while I think.

@dangershony  I think somebody was also bumping his head on this at one point in stratis?