### PR TITLE
Use ulong inside uint256 to improve perf

### DIFF
--- a/NBitcoin/Crypto/Hashes.cs
+++ b/NBitcoin/Crypto/Hashes.cs
@@ -615,13 +615,13 @@ namespace NBitcoin.Crypto
 				switch (position)
 				{
 					case 0:
-						return (ulong)val.pn0 + (ulong)((ulong)val.pn1 << 32);
+						return (ulong)val.pn0;
 					case 1:
-						return (ulong)val.pn2 + (ulong)((ulong)val.pn3 << 32);
+						return (ulong)val.pn1;
 					case 2:
-						return (ulong)val.pn4 + (ulong)((ulong)val.pn5 << 32);
+						return (ulong)val.pn2;
 					case 3:
-						return (ulong)val.pn6 + (ulong)((ulong)val.pn7 << 32);
+						return (ulong)val.pn3;
 					default:
 						throw new ArgumentOutOfRangeException("position should be less than 4", "position");
 				}

--- a/NBitcoin/UInt2561.cs
+++ b/NBitcoin/UInt2561.cs
@@ -87,10 +87,6 @@ namespace NBitcoin
 			pn1 = b.pn1;
 			pn2 = b.pn2;
 			pn3 = b.pn3;
-			pn4 = b.pn4;
-			pn5 = b.pn5;
-			pn6 = b.pn6;
-			pn7 = b.pn7;
 		}
 
 		public static uint256 Parse(string hex)
@@ -114,38 +110,32 @@ namespace NBitcoin
 
 		private static readonly HexEncoder Encoder = new HexEncoder();
 		private const int WIDTH_BYTE = 256 / 8;
-		internal readonly UInt32 pn0;
-		internal readonly UInt32 pn1;
-		internal readonly UInt32 pn2;
-		internal readonly UInt32 pn3;
-		internal readonly UInt32 pn4;
-		internal readonly UInt32 pn5;
-		internal readonly UInt32 pn6;
-		internal readonly UInt32 pn7;
+		internal readonly ulong pn0;
+		internal readonly ulong pn1;
+		internal readonly ulong pn2;
+		internal readonly ulong pn3;
 
 		public byte GetByte(int index)
 		{
 #if HAS_SPAN
+			if (index < 0 || index > 31)
+				throw new ArgumentOutOfRangeException("index");
 			if (BitConverter.IsLittleEndian)
 			{
-				Span<uint> temp = stackalloc uint[8];
+				Span<ulong> temp = stackalloc ulong[4];
 				temp[0] = pn0;
 				temp[1] = pn1;
 				temp[2] = pn2;
 				temp[3] = pn3;
-				temp[4] = pn4;
-				temp[5] = pn5;
-				temp[6] = pn6;
-				temp[7] = pn7;
-				Span<byte> temp2 = MemoryMarshal.Cast<uint, byte>(temp);
+				Span<byte> temp2 = MemoryMarshal.Cast<ulong, byte>(temp);
 				return temp2[index];
 			}
 #endif
 
-			var uintIndex = index / sizeof(uint);
-			var byteIndex = index % sizeof(uint);
-			UInt32 value;
-			switch (uintIndex)
+			var ulongIndex = index / sizeof(ulong);
+			var byteIndex = index % sizeof(ulong);
+			ulong value;
+			switch (ulongIndex)
 			{
 				case 0:
 					value = pn0;
@@ -158,18 +148,6 @@ namespace NBitcoin
 					break;
 				case 3:
 					value = pn3;
-					break;
-				case 4:
-					value = pn4;
-					break;
-				case 5:
-					value = pn5;
-					break;
-				case 6:
-					value = pn6;
-					break;
-				case 7:
-					value = pn7;
 					break;
 				default:
 					throw new ArgumentOutOfRangeException("index");
@@ -203,15 +181,11 @@ namespace NBitcoin
 #if HAS_SPAN
 			if (BitConverter.IsLittleEndian && lendian)
 			{
-				var uints = MemoryMarshal.Cast<byte, uint>(vch.AsSpan().Slice(offset, length));
+				var uints = MemoryMarshal.Cast<byte, ulong>(vch.AsSpan().Slice(offset, length));
 				pn0 = uints[0];
 				pn1 = uints[1];
 				pn2 = uints[2];
 				pn3 = uints[3];
-				pn4 = uints[4];
-				pn5 = uints[5];
-				pn6 = uints[6];
-				pn7 = uints[7];
 				return;
 			}
 #endif
@@ -223,14 +197,10 @@ namespace NBitcoin
 				vch = vch.Reverse().ToArray();
 			}
 
-			pn0 = Utils.ToUInt32(vch, offset + 4 * 0, true);
-			pn1 = Utils.ToUInt32(vch, offset + 4 * 1, true);
-			pn2 = Utils.ToUInt32(vch, offset + 4 * 2, true);
-			pn3 = Utils.ToUInt32(vch, offset + 4 * 3, true);
-			pn4 = Utils.ToUInt32(vch, offset + 4 * 4, true);
-			pn5 = Utils.ToUInt32(vch, offset + 4 * 5, true);
-			pn6 = Utils.ToUInt32(vch, offset + 4 * 6, true);
-			pn7 = Utils.ToUInt32(vch, offset + 4 * 7, true);
+			pn0 = Utils.ToUInt64(vch, offset + 8 * 0, true);
+			pn1 = Utils.ToUInt64(vch, offset + 8 * 1, true);
+			pn2 = Utils.ToUInt64(vch, offset + 8 * 2, true);
+			pn3 = Utils.ToUInt64(vch, offset + 8 * 3, true);
 
 		}
 
@@ -243,25 +213,17 @@ namespace NBitcoin
 			}
 			if (BitConverter.IsLittleEndian)
 			{
-				var uints = MemoryMarshal.Cast<byte, uint>(bytes);
+				var uints = MemoryMarshal.Cast<byte, ulong>(bytes);
 				pn0 = uints[0];
 				pn1 = uints[1];
 				pn2 = uints[2];
 				pn3 = uints[3];
-				pn4 = uints[4];
-				pn5 = uints[5];
-				pn6 = uints[6];
-				pn7 = uints[7];
 				return;
 			}
-			pn0 = Utils.ToUInt32(bytes.Slice(0), true);
-			pn1 = Utils.ToUInt32(bytes.Slice(4 * 1), true);
-			pn2 = Utils.ToUInt32(bytes.Slice(4 * 2), true);
-			pn3 = Utils.ToUInt32(bytes.Slice(4 * 3), true);
-			pn4 = Utils.ToUInt32(bytes.Slice(4 * 4), true);
-			pn5 = Utils.ToUInt32(bytes.Slice(4 * 5), true);
-			pn6 = Utils.ToUInt32(bytes.Slice(4 * 6), true);
-			pn7 = Utils.ToUInt32(bytes.Slice(4 * 7), true);
+			pn0 = Utils.ToUInt64(bytes.Slice(0), true);
+			pn1 = Utils.ToUInt64(bytes.Slice(8 * 1), true);
+			pn2 = Utils.ToUInt64(bytes.Slice(8 * 2), true);
+			pn3 = Utils.ToUInt64(bytes.Slice(8 * 3), true);
 		}
 #endif
 		/// <summary>
@@ -282,101 +244,57 @@ namespace NBitcoin
 #if HAS_SPAN
 			if (BitConverter.IsLittleEndian)
 			{
-				Span<uint> uints = MemoryMarshal.Cast<byte, uint>(bytes.AsSpan());
+				Span<ulong> uints = MemoryMarshal.Cast<byte, ulong>(bytes.AsSpan());
 				pn0 = uints[0];
 				pn1 = uints[1];
 				pn2 = uints[2];
 				pn3 = uints[3];
-				pn4 = uints[4];
-				pn5 = uints[5];
-				pn6 = uints[6];
-				pn7 = uints[7];
 				return;
 			}
 #endif
-			pn0 = Utils.ToUInt32(bytes, 4 * 0, true);
-			pn1 = Utils.ToUInt32(bytes, 4 * 1, true);
-			pn2 = Utils.ToUInt32(bytes, 4 * 2, true);
-			pn3 = Utils.ToUInt32(bytes, 4 * 3, true);
-			pn4 = Utils.ToUInt32(bytes, 4 * 4, true);
-			pn5 = Utils.ToUInt32(bytes, 4 * 5, true);
-			pn6 = Utils.ToUInt32(bytes, 4 * 6, true);
-			pn7 = Utils.ToUInt32(bytes, 4 * 7, true);
+			pn0 = Utils.ToUInt64(bytes, 8 * 0, true);
+			pn1 = Utils.ToUInt64(bytes, 8 * 1, true);
+			pn2 = Utils.ToUInt64(bytes, 8 * 2, true);
+			pn3 = Utils.ToUInt64(bytes, 8 * 3, true);
 		}
 
 		public int GetBisCount()
 		{
-			if (pn7 != 0)
-			{
-				for (int nbits = 31; nbits > 0; nbits--)
-				{
-					if ((pn7 & 1U << nbits) != 0)
-						return 32 * 7 + nbits + 1;
-				}
-				return 32 * 7 + 1;
-			}
-			if (pn6 != 0)
-			{
-				for (int nbits = 31; nbits > 0; nbits--)
-				{
-					if ((pn6 & 1U << nbits) != 0)
-						return 32 * 6 + nbits + 1;
-				}
-				return 32 * 6 + 1;
-			}
-			if (pn5 != 0)
-			{
-				for (int nbits = 31; nbits > 0; nbits--)
-				{
-					if ((pn5 & 1U << nbits) != 0)
-						return 32 * 5 + nbits + 1;
-				}
-				return 32 * 5 + 1;
-			}
-			if (pn4 != 0)
-			{
-				for (int nbits = 31; nbits > 0; nbits--)
-				{
-					if ((pn4 & 1U << nbits) != 0)
-						return 32 * 4 + nbits + 1;
-				}
-				return 32 * 4 + 1;
-			}
 			if (pn3 != 0)
 			{
-				for (int nbits = 31; nbits > 0; nbits--)
+				for (int nbits = 63; nbits > 0; nbits--)
 				{
-					if ((pn3 & 1U << nbits) != 0)
-						return 32 * 3 + nbits + 1;
+					if ((pn3 & 1UL << nbits) != 0)
+						return 64 * 3 + nbits + 1;
 				}
-				return 32 * 3 + 1;
+				return 64 * 3 + 1;
 			}
 			if (pn2 != 0)
 			{
-				for (int nbits = 31; nbits > 0; nbits--)
+				for (int nbits = 63; nbits > 0; nbits--)
 				{
-					if ((pn2 & 1U << nbits) != 0)
-						return 32 * 2 + nbits + 1;
+					if ((pn2 & 1UL << nbits) != 0)
+						return 64 * 2 + nbits + 1;
 				}
-				return 32 * 2 + 1;
+				return 64 * 2 + 1;
 			}
 			if (pn1 != 0)
 			{
-				for (int nbits = 31; nbits > 0; nbits--)
+				for (int nbits = 63; nbits > 0; nbits--)
 				{
-					if ((pn1 & 1U << nbits) != 0)
-						return 32 * 1 + nbits + 1;
+					if ((pn1 & 1UL << nbits) != 0)
+						return 64 * 1 + nbits + 1;
 				}
-				return 32 * 1 + 1;
+				return 64 * 1 + 1;
 			}
 			if (pn0 != 0)
 			{
-				for (int nbits = 31; nbits > 0; nbits--)
+				for (int nbits = 63; nbits > 0; nbits--)
 				{
-					if ((pn0 & 1U << nbits) != 0)
-						return 32 * 0 + nbits + 1;
+					if ((pn0 & 1UL << nbits) != 0)
+						return 64 * 0 + nbits + 1;
 				}
-				return 32 * 0 + 1;
+				return 64 * 0 + 1;
 			}
 			return 0;
 		}
@@ -404,10 +322,6 @@ namespace NBitcoin
 			equals &= pn1 == other.pn1;
 			equals &= pn2 == other.pn2;
 			equals &= pn3 == other.pn3;
-			equals &= pn4 == other.pn4;
-			equals &= pn5 == other.pn5;
-			equals &= pn6 == other.pn6;
-			equals &= pn7 == other.pn7;
 			return equals;
 		}
 
@@ -434,10 +348,6 @@ namespace NBitcoin
 			equals &= a.pn1 == b.pn1;
 			equals &= a.pn2 == b.pn2;
 			equals &= a.pn3 == b.pn3;
-			equals &= a.pn4 == b.pn4;
-			equals &= a.pn5 == b.pn5;
-			equals &= a.pn6 == b.pn6;
-			equals &= a.pn7 == b.pn7;
 			return equals;
 		}
 
@@ -468,22 +378,6 @@ namespace NBitcoin
 			if (a is null && !(b is null))
 				return -1;
 			if (!(a is null) && b is null)
-				return 1;
-			if (a.pn7 < b.pn7)
-				return -1;
-			if (a.pn7 > b.pn7)
-				return 1;
-			if (a.pn6 < b.pn6)
-				return -1;
-			if (a.pn6 > b.pn6)
-				return 1;
-			if (a.pn5 < b.pn5)
-				return -1;
-			if (a.pn5 > b.pn5)
-				return 1;
-			if (a.pn4 < b.pn4)
-				return -1;
-			if (a.pn4 > b.pn4)
 				return 1;
 			if (a.pn3 < b.pn3)
 				return -1;
@@ -554,25 +448,17 @@ namespace NBitcoin
 #else
 			if (lendian)
 			{
-				Buffer.BlockCopy(Utils.ToBytes(pn0, true), 0, output, 4 * 0, 4);
-				Buffer.BlockCopy(Utils.ToBytes(pn1, true), 0, output, 4 * 1, 4);
-				Buffer.BlockCopy(Utils.ToBytes(pn2, true), 0, output, 4 * 2, 4);
-				Buffer.BlockCopy(Utils.ToBytes(pn3, true), 0, output, 4 * 3, 4);
-				Buffer.BlockCopy(Utils.ToBytes(pn4, true), 0, output, 4 * 4, 4);
-				Buffer.BlockCopy(Utils.ToBytes(pn5, true), 0, output, 4 * 5, 4);
-				Buffer.BlockCopy(Utils.ToBytes(pn6, true), 0, output, 4 * 6, 4);
-				Buffer.BlockCopy(Utils.ToBytes(pn7, true), 0, output, 4 * 7, 4);
+				Buffer.BlockCopy(Utils.ToBytes(pn0, true), 0, output, 8 * 0, 8);
+				Buffer.BlockCopy(Utils.ToBytes(pn1, true), 0, output, 8 * 1, 8);
+				Buffer.BlockCopy(Utils.ToBytes(pn2, true), 0, output, 8 * 2, 8);
+				Buffer.BlockCopy(Utils.ToBytes(pn3, true), 0, output, 8 * 3, 8);
 			}
 			else
 			{
-				Buffer.BlockCopy(Utils.ToBytes(pn7, false), 0, output, 4 * 0, 4);
-				Buffer.BlockCopy(Utils.ToBytes(pn6, false), 0, output, 4 * 1, 4);
-				Buffer.BlockCopy(Utils.ToBytes(pn5, false), 0, output, 4 * 2, 4);
-				Buffer.BlockCopy(Utils.ToBytes(pn4, false), 0, output, 4 * 3, 4);
-				Buffer.BlockCopy(Utils.ToBytes(pn3, false), 0, output, 4 * 4, 4);
-				Buffer.BlockCopy(Utils.ToBytes(pn2, false), 0, output, 4 * 5, 4);
-				Buffer.BlockCopy(Utils.ToBytes(pn1, false), 0, output, 4 * 6, 4);
-				Buffer.BlockCopy(Utils.ToBytes(pn0, false), 0, output, 4 * 7, 4);
+				Buffer.BlockCopy(Utils.ToBytes(pn3, false), 0, output, 8 * 0, 8);
+				Buffer.BlockCopy(Utils.ToBytes(pn2, false), 0, output, 8 * 1, 8);
+				Buffer.BlockCopy(Utils.ToBytes(pn1, false), 0, output, 8 * 2, 8);
+				Buffer.BlockCopy(Utils.ToBytes(pn0, false), 0, output, 8 * 3, 8);
 			}
 #endif
 		}
@@ -585,16 +471,12 @@ namespace NBitcoin
 
 			if (BitConverter.IsLittleEndian)
 			{
-				Span<uint> temp = stackalloc uint[8];
+				Span<ulong> temp = stackalloc ulong[4];
 				temp[0] = pn0;
 				temp[1] = pn1;
 				temp[2] = pn2;
 				temp[3] = pn3;
-				temp[4] = pn4;
-				temp[5] = pn5;
-				temp[6] = pn6;
-				temp[7] = pn7;
-				var tempBytes = MemoryMarshal.Cast<uint, byte>(temp);
+				var tempBytes = MemoryMarshal.Cast<ulong, byte>(temp);
 				if (!lendian)
 					tempBytes.Reverse();
 				tempBytes.CopyTo(output);
@@ -602,20 +484,12 @@ namespace NBitcoin
 			}
 			var initial = output;
 			Utils.ToBytes(pn0, true, output);
-			output = output.Slice(4);
+			output = output.Slice(8);
 			Utils.ToBytes(pn1, true, output);
-			output = output.Slice(4);
+			output = output.Slice(8);
 			Utils.ToBytes(pn2, true, output);
-			output = output.Slice(4);
+			output = output.Slice(8);
 			Utils.ToBytes(pn3, true, output);
-			output = output.Slice(4);
-			Utils.ToBytes(pn4, true, output);
-			output = output.Slice(4);
-			Utils.ToBytes(pn5, true, output);
-			output = output.Slice(4);
-			Utils.ToBytes(pn6, true, output);
-			output = output.Slice(4);
-			Utils.ToBytes(pn7, true, output);
 
 			if (!lendian)
 				initial.Reverse();
@@ -641,29 +515,25 @@ namespace NBitcoin
 
 		public ulong GetLow64()
 		{
-			return pn0 | (ulong)pn1 << 32;
+			return pn0;
 		}
 
 		public uint GetLow32()
 		{
-			return pn0;
+			return unchecked((uint)(pn0 & 0xFFFFFFFF));
 		}
 
 		public override int GetHashCode()
 		{
-			int hash = 17;
+			long hash = 17;
 			unchecked
 			{
-				hash = hash * 31 + (int)pn0;
-				hash = hash * 31 + (int)pn1;
-				hash = hash * 31 + (int)pn2;
-				hash = hash * 31 + (int)pn3;
-				hash = hash * 31 + (int)pn4;
-				hash = hash * 31 + (int)pn5;
-				hash = hash * 31 + (int)pn6;
-				hash = hash * 31 + (int)pn7;
+				hash = hash * 61 + (long)pn0;
+				hash = hash * 61 + (long)pn1;
+				hash = hash * 61 + (long)pn2;
+				hash = hash * 61 + (long)pn3;
+				return (int)hash;
 			}
-			return hash;
 		}
 	}
 	public sealed class uint160 : IComparable<uint160>, IEquatable<uint160>, IComparable


### PR DESCRIPTION
Continuation from https://github.com/MetacoSA/NBitcoin/pull/852

Use ulong instead of uint.

Before

|       Method |      Mean |     Error |    StdDev |
|------------- |----------:|----------:|----------:|
|         Read |  9.020 ns | 0.1607 ns | 0.1424 ns |
| WriteToArray | 14.387 ns | 0.1589 ns | 0.1487 ns |
|  WriteToSpan | 14.172 ns | 0.1521 ns | 0.1348 ns |

After 
|       Method |      Mean |     Error |    StdDev |
|------------- |----------:|----------:|----------:|
|         Read |  7.195 ns | 0.1243 ns | 0.1102 ns |
| WriteToArray | 13.537 ns | 0.2288 ns | 0.2140 ns |
|  WriteToSpan | 13.271 ns | 0.1050 ns | 0.0820 ns |