### PR TITLE
Avoid moving memory

### DIFF
--- a/NBitcoin/UInt256.cs
+++ b/NBitcoin/UInt256.cs
@@ -471,15 +471,14 @@ namespace NBitcoin
 
 			if (BitConverter.IsLittleEndian)
 			{
-				Span<ulong> temp = stackalloc ulong[4];
+				Span<ulong> temp = new ulong[4];
 				temp[0] = pn0;
 				temp[1] = pn1;
 				temp[2] = pn2;
 				temp[3] = pn3;
-				var tempBytes = MemoryMarshal.Cast<ulong, byte>(temp);
+				output = MemoryMarshal.Cast<ulong, byte>(temp);
 				if (!lendian)
-					tempBytes.Reverse();
-				tempBytes.CopyTo(output);
+					output.Reverse();
 				return;
 			}
 			var initial = output;


### PR DESCRIPTION
Just by preventing the movement of chunks of memory from stack to heap. 

## Before

|       Method |      Mean |     Error |    StdDev |
|------------- |----------:|----------:|----------:|
|         Read |  9.664 ns | 0.0928 ns | 0.0775 ns |
| WriteToArray | 25.471 ns | 0.3244 ns | 0.2709 ns |
|  WriteToSpan | 25.833 ns | 0.5122 ns | 0.4791 ns |


## After

|       Method |      Mean |     Error |    StdDev |
|------------- |----------:|----------:|----------:|
|         Read |  9.947 ns | 0.2332 ns | 0.5070 ns |
| WriteToArray | 14.802 ns | 0.3077 ns | 0.2569 ns |
|  WriteToSpan | 15.079 ns | 0.1960 ns | 0.1738 ns |
```