### PR TITLE
+50% Improve performance of address parsing 

### DIFF
--- a/NBitcoin/Base58Data.cs
+++ b/NBitcoin/Base58Data.cs
@@ -22,8 +22,13 @@ namespace NBitcoin
 	/// </summary>
 	public abstract class Base58Data : IBase58Data
 	{
+#if HAS_SPAN
+		protected byte[] vchData = Array.Empty<byte>();
+		protected ReadOnlyMemory<byte> vchVersion;
+#else
 		protected byte[] vchData = new byte[0];
 		protected byte[] vchVersion = new byte[0];
+#endif
 		protected string wifData = "";
 		private Network _Network;
 		public Network Network
@@ -61,11 +66,26 @@ namespace NBitcoin
 			}
 
 			byte[] vchTemp = _Network.NetworkStringParser.GetBase58CheckEncoder().DecodeData(psz);
-			var expectedVersion = _Network.GetVersionBytes(Type, true);
+#if HAS_SPAN
+			if (!(_Network.GetVersionMemory(Type, false) is ReadOnlyMemory<byte> expectedVersion))
+				throw new FormatException("Invalid " + this.GetType().Name);
+#else
+			var expectedVersion = _Network.GetVersionBytes(Type, false);
+			if (expectedVersion is null)
+				throw new FormatException("Invalid " + this.GetType().Name);
+#endif
 
-
+#if HAS_SPAN
+			var vchTempMemory = vchTemp.AsMemory();
+			vchVersion = vchTempMemory.Slice(0, expectedVersion.Length);
+#else
 			vchVersion = vchTemp.SafeSubarray(0, expectedVersion.Length);
+#endif
+#if HAS_SPAN
+			if (!vchVersion.Span.SequenceEqual(expectedVersion.Span))
+#else
 			if (!Utils.ArrayEqual(vchVersion, expectedVersion))
+#endif
 			{
 				if (_Network.NetworkStringParser.TryParse(psz, Network, out T other))
 				{
@@ -80,7 +100,11 @@ namespace NBitcoin
 			}
 			else
 			{
+#if HAS_SPAN
+				vchData = vchTempMemory.Slice(expectedVersion.Length).ToArray();
+#else
 				vchData = vchTemp.SafeSubarray(expectedVersion.Length);
+#endif
 				wifData = psz;
 			}
 
@@ -93,8 +117,19 @@ namespace NBitcoin
 		private void SetData(byte[] vchData)
 		{
 			this.vchData = vchData;
-			this.vchVersion = _Network.GetVersionBytes(Type, true);
+#if HAS_SPAN
+			if (!(_Network.GetVersionMemory(Type, false) is ReadOnlyMemory<byte> v))
+				throw new FormatException("Invalid " + this.GetType().Name);
+			this.vchVersion = v;
+			Span<byte> buffer = vchVersion.Length + vchData.Length is int length &&
+								length > 256 ? new byte[length] : stackalloc byte[length];
+			this.vchVersion.Span.CopyTo(buffer);
+			this.vchData.CopyTo(buffer.Slice(this.vchVersion.Length));
+			wifData = _Network.NetworkStringParser.GetBase58CheckEncoder().EncodeData(buffer);
+#else
+			this.vchVersion = _Network.GetVersionBytes(Type, false);
 			wifData = _Network.NetworkStringParser.GetBase58CheckEncoder().EncodeData(vchVersion.Concat(vchData).ToArray());
+#endif
 
 			if (!IsValid)
 				throw new FormatException("Invalid " + this.GetType().Name);

--- a/NBitcoin/BitcoinSegwitAddress.cs
+++ b/NBitcoin/BitcoinSegwitAddress.cs
@@ -22,6 +22,10 @@ namespace NBitcoin
 			else
 				throw expectedNetwork.Bech32NotSupported(Bech32Type.WITNESS_PUBKEY_ADDRESS);
 		}
+		internal BitcoinWitPubKeyAddress(string str, byte[] key, Network network) : base(str, network)
+		{
+			_Hash = new WitKeyId(key);
+		}
 
 		private static string Validate(string bech32, Network expectedNetwork)
 		{
@@ -113,6 +117,11 @@ namespace NBitcoin
 			}
 			else
 				throw expectedNetwork.Bech32NotSupported(Bech32Type.WITNESS_SCRIPT_ADDRESS);
+		}
+
+		internal BitcoinWitScriptAddress(string str, byte[] keyId, Network network) : base(str, network)
+		{
+			_Hash = new WitScriptId(keyId);
 		}
 
 		private static string Validate(string bech32, Network expectedNetwork)

--- a/NBitcoin/DataEncoders/ASCIIEncoder.cs
+++ b/NBitcoin/DataEncoders/ASCIIEncoder.cs
@@ -22,12 +22,22 @@ namespace NBitcoin.DataEncoders
 			{
 				r[i] = (byte)encoded[i];
 			}
-#if HA_SPAN
-			return r;
-#else
+#if HAS_SPAN
 			return r.ToArray();
+#else
+			return r;
 #endif
 		}
+#if HAS_SPAN
+		public void DecodeData(string encoded, Span<byte> output)
+		{
+			var l = encoded.Length;
+			for (int i = 0; i < l; i++)
+			{
+				output[i] = (byte)encoded[i];
+			}
+		}
+#endif
 
 		public override string EncodeData(byte[] data, int offset, int count)
 		{

--- a/NBitcoin/Network.cs
+++ b/NBitcoin/Network.cs
@@ -112,6 +112,15 @@ namespace NBitcoin
 				throw Base58NotSupported(type);
 			return prefix?.ToArray();
 		}
+#if HAS_SPAN
+		public ReadOnlyMemory<byte>? GetVersionMemory(Base58Type type, bool throws)
+		{
+			var prefix = base58Prefixes[(int)type];
+			if (prefix == null && throws)
+				throw Base58NotSupported(type);
+			return prefix?.AsMemory();
+		}
+#endif
 
 		internal NotSupportedException Base58NotSupported(Base58Type type)
 		{

--- a/NBitcoin/Network.cs
+++ b/NBitcoin/Network.cs
@@ -2388,7 +2388,10 @@ namespace NBitcoin
 
 		private Base58Type? GetBase58Type(string base58)
 		{
-			var bytes = NetworkStringParser.GetBase58CheckEncoder().DecodeData(base58);
+			return GetBase58Type(NetworkStringParser.GetBase58CheckEncoder().DecodeData(base58), out _);
+		}
+		private Base58Type? GetBase58Type(byte[] bytes, out int prefixLength)
+		{
 			for (int i = 0; i < base58Prefixes.Length; i++)
 			{
 				var prefix = base58Prefixes[i];
@@ -2397,8 +2400,12 @@ namespace NBitcoin
 				if (bytes.Length < prefix.Length)
 					continue;
 				if (Utils.ArrayEqual(bytes, 0, prefix, 0, prefix.Length))
+				{
+					prefixLength = prefix.Length;
 					return (Base58Type)i;
+				}
 			}
+			prefixLength = 0;
 			return null;
 		}
 
@@ -2448,14 +2455,15 @@ namespace NBitcoin
 			var maybeb58 = base58Encoder.IsMaybeEncoded(str);
 			if (maybeb58)
 			{
+				byte[]? decoded = null;
 				try
 				{
-					base58Encoder.DecodeData(str);
+					decoded = base58Encoder.DecodeData(str);
 				}
 				catch (FormatException) { maybeb58 = false; }
 				if (maybeb58)
 				{
-					var candidate = GetCandidate(str);
+					var candidate = GetCandidate(str, decoded!);
 					if (candidate!= null && targetType.GetTypeInfo().IsAssignableFrom((candidate.GetType().GetTypeInfo())))
 						return candidate;
 					throw new FormatException("Invalid base58 string");
@@ -2475,16 +2483,16 @@ namespace NBitcoin
 					var bytes = encoder.Decode(str, out witVersion);
 					IBitcoinString? candidate = null;
 					if (witVersion == 0 && bytes.Length == 20 && type == Bech32Type.WITNESS_PUBKEY_ADDRESS)
-						candidate = new BitcoinWitPubKeyAddress(str, this);
+						candidate = new BitcoinWitPubKeyAddress(str.ToLowerInvariant(), bytes, this);
 					if (witVersion == 0 && bytes.Length == 32 && type == Bech32Type.WITNESS_SCRIPT_ADDRESS)
-						candidate = new BitcoinWitScriptAddress(str, this);
+						candidate = new BitcoinWitScriptAddress(str.ToLowerInvariant(), bytes, this);
 
 					if (candidate != null && targetType.GetTypeInfo().IsAssignableFrom((candidate.GetType().GetTypeInfo())))
 						return candidate;
 				}
 				catch (Bech32FormatException) { throw; }
 				catch (FormatException) { continue; }
-			}
+		}
 			throw new FormatException("Invalid string");
 		}
 
@@ -2506,11 +2514,11 @@ namespace NBitcoin
 			return expectedNetwork.Parse<T>(str);
 		}
 
-		private IBase58Data? GetCandidate(string base58)
+		private IBase58Data? GetCandidate(string base58, byte[] decoded)
 		{
 			if (base58 == null)
 				throw new ArgumentNullException(nameof(base58));
-			var maybeType = GetBase58Type(base58);
+			var maybeType = GetBase58Type(decoded, out var prefixLength);
 			if (maybeType is Base58Type type)
 			{
 				if (type == Base58Type.COLORED_ADDRESS)
@@ -2529,6 +2537,10 @@ namespace NBitcoin
 				}
 				try
 				{
+					if (type is Base58Type.PUBKEY_ADDRESS && decoded.Length == 20 + prefixLength)
+						return new BitcoinPubKeyAddress(new KeyId(decoded.Skip(prefixLength).ToArray()), this);
+					if (type is Base58Type.SCRIPT_ADDRESS && decoded.Length == 20 + prefixLength)
+						return new BitcoinScriptAddress(new ScriptId(decoded.Skip(prefixLength).ToArray()), this);
 					return CreateBase58Data(type, base58);
 				}
 				catch (FormatException) { }


### PR DESCRIPTION
It turns out that we were de serializing twice in the address parsing logic.

Before

|            Method |      Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------ |----------:|----------:|----------:|-------:|------:|------:|----------:|
| DeserializeBase58 |  9.638 us | 0.1620 us | 0.1353 us | 0.2747 |     - |     - |   2.26 KB |
|   DeserializeBech |  3.593 us | 0.0146 us | 0.0137 us | 0.1335 |     - |     - |   1.11 KB |
|   DeserializeXPub | 30.870 us | 0.3133 us | 0.2616 us | 0.1831 |     - |     - |   1.97 KB

After
|            Method |      Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------ |----------:|----------:|----------:|-------:|------:|------:|----------:|
| DeserializeBase58 |  5.308 us | 0.0504 us | 0.0393 us | 0.1526 |     - |     - |    1328 B |
|   DeserializeBech |  1.445 us | 0.0100 us | 0.0089 us | 0.0420 |     - |     - |     360 B |
|   DeserializeXPub | 32.865 us | 0.3623 us | 0.3389 us | 0.1831 |     - |     - |    1912 B |