### PR TITLE
Add TryCombine function for ECPubKey

### DIFF
--- a/NBitcoin.Tests/Secp256k1Tests.cs
+++ b/NBitcoin.Tests/Secp256k1Tests.cs
@@ -3114,6 +3114,31 @@ namespace NBitcoin.Tests
 				Assert.False(pubkeyc.SigVerify(sig, msg32));
 			}
 		}
+
+		/// https://github.com/bitcoin-core/secp256k1/blob/2ed54da18add295668ec71c91534b640d2cc029b/src/tests.c#L2378
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void test_ec_combine()
+		{
+			var d = new ECPubKey[6];
+			var sum = Scalar.Zero;
+			var ctx = Context.Instance;
+			for (int i = 1; i <= 6; i++)
+			{
+				Scalar s = random_scalar_order_test();
+				sum = sum.Add(s);
+				GEJ qj = ctx.EcMultGenContext.MultGen(in s);
+				GE q = qj.ToGroupElementVariable();
+
+				d[i - 1] = new ECPubKey(in q, ctx);
+
+				qj = ctx.EcMultGenContext.MultGen(in sum);
+				q = qj.ToGroupElementVariable();
+				ECPubKey sd = new ECPubKey(in q, ctx);
+				Assert.True(ECPubKey.TryCombine(Context.Instance, d[0..i], out var sd2));
+				Assert.Equal(sd, sd2);
+			}
+		}
 	}
 }
 #endif

--- a/NBitcoin/Secp256k1/ECPubKey.cs
+++ b/NBitcoin/Secp256k1/ECPubKey.cs
@@ -312,10 +312,11 @@ namespace NBitcoin.Secp256k1
 		{
 			if (pubkeys == null)
 				throw new ArgumentNullException(nameof(pubkeys));
-			combinedPubKey = null;
+
 			var count = pubkeys.Count();
 			if (count == 0)
 			{
+				combinedPubKey = null;
 				return false;
 			}
 			var ptj = GEJ.Infinity;
@@ -323,8 +324,7 @@ namespace NBitcoin.Secp256k1
 			{
 				ptj = ptj.Add(in p.Q);
 			}
-			var pt = ptj.ToGroupElement();
-			combinedPubKey = new ECPubKey(new GE(pt.x.Normalize(), pt.y.Normalize()), ctx);
+			combinedPubKey = new ECPubKey(ptj.ToGroupElement(), ctx);
 			return true;
 		}
 

--- a/NBitcoin/Secp256k1/ECPubKey.cs
+++ b/NBitcoin/Secp256k1/ECPubKey.cs
@@ -308,17 +308,12 @@ namespace NBitcoin.Secp256k1
 		/// <summary>
 		/// The original function name is `secp256k1_ec_pubkey_combine`
 		/// </summary>
-		public static bool TryCombine(Context ctx, ECPubKey[] pubkeys, out ECPubKey? combinedPubKey)
+		public static bool TryCombine(Context ctx, IEnumerable<ECPubKey> pubkeys, out ECPubKey? combinedPubKey)
 		{
 			if (pubkeys == null)
 				throw new ArgumentNullException(nameof(pubkeys));
 
 			combinedPubKey = null;
-			var n = pubkeys.Count();
-			if (n == 0)
-			{
-				return false;
-			}
 			var qj = GEJ.Infinity;
 			foreach (var p in pubkeys)
 			{

--- a/NBitcoin/Secp256k1/ECPubKey.cs
+++ b/NBitcoin/Secp256k1/ECPubKey.cs
@@ -1,6 +1,7 @@
 ﻿#if HAS_SPAN
 #nullable enable
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Text;
 
@@ -301,6 +302,29 @@ namespace NBitcoin.Secp256k1
 				return false;
 			}
 			key = pt.ToGroupElement();
+			return true;
+		}
+
+		/// <summary>
+		/// The original function name is `secp256k1_ec_pubkey_combine`
+		/// </summary>
+		public static bool TryCombine(Context ctx, IEnumerable<ECPubKey> pubkeys, out ECPubKey? combinedPubKey)
+		{
+			if (pubkeys == null)
+				throw new ArgumentNullException(nameof(pubkeys));
+			combinedPubKey = null;
+			var count = pubkeys.Count();
+			if (count == 0)
+			{
+				return false;
+			}
+			var ptj = GEJ.Infinity;
+			foreach (var p in pubkeys)
+			{
+				ptj = ptj.Add(in p.Q);
+			}
+			var pt = ptj.ToGroupElement();
+			combinedPubKey = new ECPubKey(new GE(pt.x.Normalize(), pt.y.Normalize()), ctx);
 			return true;
 		}
 

--- a/NBitcoin/Secp256k1/ECPubKey.cs
+++ b/NBitcoin/Secp256k1/ECPubKey.cs
@@ -308,23 +308,26 @@ namespace NBitcoin.Secp256k1
 		/// <summary>
 		/// The original function name is `secp256k1_ec_pubkey_combine`
 		/// </summary>
-		public static bool TryCombine(Context ctx, IEnumerable<ECPubKey> pubkeys, out ECPubKey? combinedPubKey)
+		public static bool TryCombine(Context ctx, ECPubKey[] pubkeys, out ECPubKey? combinedPubKey)
 		{
 			if (pubkeys == null)
 				throw new ArgumentNullException(nameof(pubkeys));
 
-			var count = pubkeys.Count();
-			if (count == 0)
+			combinedPubKey = null;
+			var n = pubkeys.Count();
+			if (n == 0)
 			{
-				combinedPubKey = null;
 				return false;
 			}
-			var ptj = GEJ.Infinity;
+			var qj = GEJ.Infinity;
 			foreach (var p in pubkeys)
 			{
-				ptj = ptj.Add(in p.Q);
+				qj = qj.Add(in p.Q);
 			}
-			combinedPubKey = new ECPubKey(ptj.ToGroupElement(), ctx);
+			if (qj.IsInfinity)
+				return false;
+
+			combinedPubKey = new ECPubKey(qj.ToGroupElement(), ctx);
 			return true;
 		}
 


### PR DESCRIPTION
* This is a port of `secp256k1_ec_pubkey_combine` from
  original secp256k1 implementation.
* It also have one unit test. In the original implementation,
  there is also a test named `run_eckey_edge_case_test`.
  Ideally this test should be ported too. But since the test is
  not only for combining pubkey, I've omitted from this commit.

This is necessary for deriving remote pubkey in LN.
