### PR TITLE
Remove PSBT sanity check for containing both Witness and NonWitness UTXO.

### DIFF
--- a/NBitcoin/BIP174/PSBTInput.cs
+++ b/NBitcoin/BIP174/PSBTInput.cs
@@ -462,8 +462,8 @@ namespace NBitcoin
 					errors.Add(new PSBTError(Index, "Input finalized, but witness script is not null"));
 			}
 
-			if (witness_utxo != null && non_witness_utxo != null)
-				errors.Add(new PSBTError(Index, "witness utxo and non witness utxo simultaneously present"));
+			// if (witness_utxo != null && non_witness_utxo != null)
+			// 	errors.Add(new PSBTError(Index, "witness utxo and non witness utxo simultaneously present"));
 
 			if (witness_script != null && witness_utxo == null)
 				errors.Add(new PSBTError(Index, "witness script present but no witness utxo"));
@@ -889,23 +889,23 @@ namespace NBitcoin
 		/// </summary>
 		public bool TrySlimUTXO()
 		{
-			if (NonWitnessUtxo == null)
-				return false;
-			var coin = GetSignableCoin();
-			if (coin == null)
-				return false;
+			// if (NonWitnessUtxo == null)
+			// 	return false;
+			// var coin = GetSignableCoin();
+			// if (coin == null)
+			// 	return false;
 
-			if (Parent.Network.Consensus.NeverNeedPreviousTxForSigning ||
-				coin.GetHashVersion() == HashVersion.Witness)
-			{
-				if (WitnessUtxo == null)
-				{
-					if (TxIn.PrevOut.N < NonWitnessUtxo.Outputs.Count)
-						WitnessUtxo = NonWitnessUtxo.Outputs[TxIn.PrevOut.N];
-				}
-				NonWitnessUtxo = null;
-				return true;
-			}
+			// if (Parent.Network.Consensus.NeverNeedPreviousTxForSigning ||
+			// 	coin.GetHashVersion() == HashVersion.Witness)
+			// {
+			// 	if (WitnessUtxo == null)
+			// 	{
+			// 		if (TxIn.PrevOut.N < NonWitnessUtxo.Outputs.Count)
+			// 			WitnessUtxo = NonWitnessUtxo.Outputs[TxIn.PrevOut.N];
+			// 	}
+			// 	NonWitnessUtxo = null;
+			// 	return true;
+			// }
 			return false;
 		}
 

--- a/NBitcoin/BIP174/PSBTInput.cs
+++ b/NBitcoin/BIP174/PSBTInput.cs
@@ -462,9 +462,6 @@ namespace NBitcoin
 					errors.Add(new PSBTError(Index, "Input finalized, but witness script is not null"));
 			}
 
-			// if (witness_utxo != null && non_witness_utxo != null)
-			// 	errors.Add(new PSBTError(Index, "witness utxo and non witness utxo simultaneously present"));
-
 			if (witness_script != null && witness_utxo == null)
 				errors.Add(new PSBTError(Index, "witness script present but no witness utxo"));
 
@@ -889,23 +886,23 @@ namespace NBitcoin
 		/// </summary>
 		public bool TrySlimUTXO()
 		{
-			// if (NonWitnessUtxo == null)
-			// 	return false;
-			// var coin = GetSignableCoin();
-			// if (coin == null)
-			// 	return false;
+			if (NonWitnessUtxo == null)
+				return false;
+			var coin = GetSignableCoin();
+			if (coin == null)
+				return false;
 
-			// if (Parent.Network.Consensus.NeverNeedPreviousTxForSigning ||
-			// 	coin.GetHashVersion() == HashVersion.Witness)
-			// {
-			// 	if (WitnessUtxo == null)
-			// 	{
-			// 		if (TxIn.PrevOut.N < NonWitnessUtxo.Outputs.Count)
-			// 			WitnessUtxo = NonWitnessUtxo.Outputs[TxIn.PrevOut.N];
-			// 	}
-			// 	NonWitnessUtxo = null;
-			// 	return true;
-			// }
+			if (Parent.Network.Consensus.NeverNeedPreviousTxForSigning ||
+				coin.GetHashVersion() == HashVersion.Witness)
+			{
+				if (WitnessUtxo == null)
+				{
+					if (TxIn.PrevOut.N < NonWitnessUtxo.Outputs.Count)
+						WitnessUtxo = NonWitnessUtxo.Outputs[TxIn.PrevOut.N];
+				}
+				NonWitnessUtxo = null;
+				return true;
+			}
 			return false;
 		}
 


### PR DESCRIPTION
This PR disables the sanity check when there's both Witness/NonWitness utxo in it. This is needed for Wasabi Wallet's fixes for the latest firmware of Trezor hardware wallet devices.

Apologies for the mess, still trying to make heads and tails of the codebase haha :)

This issue contributes to https://github.com/zkSNACKs/WalletWasabi/issues/3734 ;