### PR TITLE
Fix blockheader parse logic for QTUM

### DIFF
--- a/NBitcoin.Altcoins/Qtum.cs
+++ b/NBitcoin.Altcoins/Qtum.cs
@@ -84,9 +84,9 @@ namespace NBitcoin.Altcoins
 				}
 			}
 
-			Script blockSignature = Script.Empty;
+			byte[] blockSignature = null;
 
-			public Script BlockSignature
+			public byte[] BlockSignature
 			{
 				get
 				{
@@ -103,7 +103,7 @@ namespace NBitcoin.Altcoins
 				stream.ReadWrite(ref hashStateRoot);
 				stream.ReadWrite(ref hashUtxoRoot);
 				stream.ReadWrite(ref prevoutStake);
-				stream.ReadWrite(ref blockSignature);
+				stream.ReadWriteAsVarString(ref blockSignature);
 			}
 		}
 


### PR DESCRIPTION
QTUM was only working on regtest (PoW) so this will help parsing of PoS block headers.