### PR TITLE
Renamed Hashes.Hash256 to Hashes.DoubleSHA256, to make it clear what the method actually does

### DIFF
--- a/NBitcoin.Altcoins/Elements/ElementsTransaction.cs
+++ b/NBitcoin.Altcoins/Elements/ElementsTransaction.cs
@@ -257,7 +257,7 @@ namespace NBitcoin.Altcoins.Elements
 			if (AssetIssuance?.BlindingNonce != uint256.Zero)
 				return null;
 			var assetEntropy = new MerkleNode(
-				new MerkleNode(Hashes.Hash256(PrevOut.ToBytes())),
+				new MerkleNode(Hashes.DoubleSHA256(PrevOut.ToBytes())),
 				new MerkleNode(new uint256(AssetIssuance.Entropy.ToBytes())));
 			UpdateFastHash(assetEntropy);
 

--- a/NBitcoin.Altcoins/Stratis.cs
+++ b/NBitcoin.Altcoins/Stratis.cs
@@ -223,7 +223,7 @@ namespace NBitcoin.Altcoins
 				byte[] hashData = data.SafeSubarray(offset, count);
 				uint256 hash = null;
 				if (this.nVersion > 6)
-					hash = Hashes.Hash256(hashData);
+					hash = Hashes.DoubleSHA256(hashData);
 				else
 				{
 					var x13 = new X13();

--- a/NBitcoin.TestFramework/NodeBuilder.cs
+++ b/NBitcoin.TestFramework/NodeBuilder.cs
@@ -281,7 +281,7 @@ namespace NBitcoin.Tests
 			_State = CoreNodeState.Stopped;
 
 			dataDir = Path.Combine(folder, "data");
-			var pass = Hashes.Hash256(Encoding.UTF8.GetBytes(folder)).ToString();
+			var pass = Hashes.DoubleSHA256(Encoding.UTF8.GetBytes(folder)).ToString();
 			creds = new NetworkCredential(pass, pass);
 			_Config = Path.Combine(dataDir, "bitcoin.conf");
 			ConfigParameters.Import(builder.ConfigParameters, true);

--- a/NBitcoin.Tests/AssertEx.cs
+++ b/NBitcoin.Tests/AssertEx.cs
@@ -37,8 +37,8 @@ namespace NBitcoin.Tests
 		[DebuggerHidden]
 		internal static void StackEquals(ContextStack<byte[]> stack1, ContextStack<byte[]> stack2)
 		{
-			var hash1 = stack1.Select(o => Hashes.Hash256(o)).ToArray();
-			var hash2 = stack2.Select(o => Hashes.Hash256(o)).ToArray();
+			var hash1 = stack1.Select(o => Hashes.DoubleSHA256(o)).ToArray();
+			var hash2 = stack2.Select(o => Hashes.DoubleSHA256(o)).ToArray();
 			AssertEx.CollectionEquals(hash1, hash2);
 		}
 

--- a/NBitcoin.Tests/Bip158_tests.cs
+++ b/NBitcoin.Tests/Bip158_tests.cs
@@ -55,7 +55,7 @@ namespace NBitcoin.Tests
 			var byteArray2 = new byte[] { 1, 2, 3, 4 };
 
 			var filter = new GolombRiceFilterBuilder()
-				.SetKey(Hashes.Hash256(new byte[] { 99, 99, 99, 99 }))
+				.SetKey(Hashes.DoubleSHA256(new byte[] { 99, 99, 99, 99 }))
 				.AddEntries(new[] { byteArray0, byteArray1, byteArray2 })
 				.AddScriptPubkey(Script.FromBytesUnsafe(byteArray0))
 				.AddScriptPubkey(Script.FromBytesUnsafe(byteArray1))
@@ -71,7 +71,7 @@ namespace NBitcoin.Tests
 			var names = from name in new[] { "New York", "Amsterdam", "Paris", "Buenos Aires", "La Habana" }
 						select Encoding.ASCII.GetBytes(name);
 
-			var key = Hashes.Hash256(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 });
+			var key = Hashes.DoubleSHA256(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 });
 			var filter = new GolombRiceFilterBuilder()
 				.SetKey(key)
 				.AddEntries(names)
@@ -130,7 +130,7 @@ namespace NBitcoin.Tests
 			const int avgTxoutPushDataSize = 20;        // P2PKH scripts has 20 bytes.
 			const int walletAddressCount = 1_000;       // We estimate that our user will have 1000 addresses.
 
-			var key = Hashes.Hash256(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 });
+			var key = Hashes.DoubleSHA256(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 });
 			var testKey = key.ToBytes().SafeSubarray(0, 16);
 
 			// Generation of data to be added into the filter
@@ -197,7 +197,7 @@ namespace NBitcoin.Tests
 			var byteArray1 = new byte[] { 2, 3, 4 };
 			var byteArray2 = new byte[] { 3, 4 };
 
-			var key = Hashes.Hash256(new byte[] { 99, 99, 99, 99 });
+			var key = Hashes.DoubleSHA256(new byte[] { 99, 99, 99, 99 });
 			var testKey = key.ToBytes().SafeSubarray(0, 16);
 
 			var filter = new GolombRiceFilterBuilder()
@@ -432,7 +432,7 @@ namespace NBitcoin.Tests
 				scripts.Add(script);
 			}
 
-			var key = Hashes.Hash256(Encoding.ASCII.GetBytes("A key for testing"));
+			var key = Hashes.DoubleSHA256(Encoding.ASCII.GetBytes("A key for testing"));
 			var builder = new GolombRiceFilterBuilder()
 				.SetKey(key)
 				.SetP(0x20);

--- a/NBitcoin.Tests/DeterministicSignatureTests.cs
+++ b/NBitcoin.Tests/DeterministicSignatureTests.cs
@@ -264,7 +264,7 @@ namespace NBitcoin.Tests
 				var msg = new byte[msgLen];
 				rnd.NextBytes(msg);
 
-				var sig = key.Sign(Hashes.Hash256(msg));
+				var sig = key.Sign(Hashes.DoubleSHA256(msg));
 				Assert.True(sig.IsLowR);
 				Assert.True(sig.ToDER().Length <= 70);
 			}

--- a/NBitcoin.Tests/PropertyTest/LegacyTransactionTest.cs
+++ b/NBitcoin.Tests/PropertyTest/LegacyTransactionTest.cs
@@ -31,7 +31,7 @@ namespace NBitcoin.Tests.PropertyTest
 		[Trait("UnitTest", "UnitTest")]
 		public bool TxIdMustMatchHexSha256(Transaction tx)
 		{
-			return tx.GetHash() == Hashes.Hash256(tx.ToBytes());
+			return tx.GetHash() == Hashes.DoubleSHA256(tx.ToBytes());
 		}
 
 	}

--- a/NBitcoin.Tests/PropertyTest/SegwitTransactionTest.cs
+++ b/NBitcoin.Tests/PropertyTest/SegwitTransactionTest.cs
@@ -20,7 +20,7 @@ namespace NBitcoin.Tests.PropertyTest
 		public void WitnessTxIdProp(Tuple<Transaction, Network> testcase)
 		{
 			var tx = testcase.Item1;
-			Assert.Equal(tx.GetWitHash(), Hashes.Hash256(tx.ToBytes()));
+			Assert.Equal(tx.GetWitHash(), Hashes.DoubleSHA256(tx.ToBytes()));
 			Assert.NotEqual(tx.GetHash(), tx.GetWitHash());
 			var tx2 = Transaction.Parse(tx.ToHex(), testcase.Item2);
 			Assert.Equal(tx, tx2, new TransactionComparer());

--- a/NBitcoin.Tests/key_tests.cs
+++ b/NBitcoin.Tests/key_tests.cs
@@ -24,7 +24,7 @@ namespace NBitcoin.Tests
 
 
 		BitcoinAddress addrLocal = Network.Main.CreateBitcoinAddress("1Q1wVsNNiUo68caU7BfyFFQ8fVBqxC2DSc");
-		uint256 msgLocal = Hashes.Hash256(TestUtils.ToBytes("Localbitcoins.com will change the world"));
+		uint256 msgLocal = Hashes.DoubleSHA256(TestUtils.ToBytes("Localbitcoins.com will change the world"));
 		byte[] signatureLocal = Convert.FromBase64String("IJ/17TjGGUqmEppAliYBUesKHoHzfY4gR4DW0Yg7QzrHUB5FwX1uTJ/H21CF8ncY8HHNB5/lh8kPAOeD5QxV8Xc=");
 
 
@@ -225,7 +225,7 @@ namespace NBitcoin.Tests
 					//Test one long message
 					strMsg = String.Join(",", Enumerable.Range(0, 2000).Select(i => i.ToString()).ToArray());
 				}
-				uint256 hashMsg = Hashes.Hash256(TestUtils.ToBytes(strMsg));
+				uint256 hashMsg = Hashes.DoubleSHA256(TestUtils.ToBytes(strMsg));
 
 				// normal signatures
 

--- a/NBitcoin/BIP158/GolombRiceFilter.cs
+++ b/NBitcoin/BIP158/GolombRiceFilter.cs
@@ -144,9 +144,9 @@ namespace NBitcoin
 		/// <returns>The filter header.</returns>
 		public uint256 GetHeader(uint256 previousHeader)
 		{
-			var curFilterHashBytes = Hashes.Hash256(ToBytes()).ToBytes();
+			var curFilterHashBytes = Hashes.DoubleSHA256(ToBytes()).ToBytes();
 			var prvFilterHashBytes = previousHeader.ToBytes();
-			return Hashes.Hash256(curFilterHashBytes.Concat(prvFilterHashBytes));
+			return Hashes.DoubleSHA256(curFilterHashBytes.Concat(prvFilterHashBytes));
 		}
 
 		/// <summary>

--- a/NBitcoin/BIP32/ExtPubKey.cs
+++ b/NBitcoin/BIP32/ExtPubKey.cs
@@ -213,7 +213,7 @@ namespace NBitcoin
 		{
 			get
 			{
-				return Hashes.Hash256(this.ToBytes());
+				return Hashes.DoubleSHA256(this.ToBytes());
 			}
 		}
 

--- a/NBitcoin/BIP38/BitcoinEncryptedSecret.cs
+++ b/NBitcoin/BIP38/BitcoinEncryptedSecret.cs
@@ -40,7 +40,7 @@ namespace NBitcoin
 			//Compute the Bitcoin address (ASCII),
 			var addressBytes = Encoders.ASCII.DecodeData(key.PubKey.GetAddress(ScriptPubKeyType.Legacy, network).ToString());
 			// and take the first four bytes of SHA256(SHA256()) of it. Let's call this "addresshash".
-			var addresshash = Hashes.Hash256(addressBytes).ToBytes().SafeSubarray(0, 4);
+			var addresshash = Hashes.DoubleSHA256(addressBytes).ToBytes().SafeSubarray(0, 4);
 
 			var derived = SCrypt.BitcoinComputeDerivedKey(Encoding.UTF8.GetBytes(password), addresshash);
 
@@ -94,7 +94,7 @@ namespace NBitcoin
 			var key = new Key(bitcoinprivkey, fCompressedIn: IsCompressed);
 
 			var addressBytes = Encoders.ASCII.DecodeData(key.PubKey.GetAddress(ScriptPubKeyType.Legacy, Network).ToString());
-			var salt = Hashes.Hash256(addressBytes).ToBytes().SafeSubarray(0, 4);
+			var salt = Hashes.DoubleSHA256(addressBytes).ToBytes().SafeSubarray(0, 4);
 
 			if (!Utils.ArrayEqual(salt, AddressHash))
 				throw new SecurityException("Invalid password (or invalid Network)");
@@ -189,7 +189,7 @@ namespace NBitcoin
 
 			//Decrypt encryptedpart1 to yield the remainder of seedb.
 			var seedb = DecryptSeed(encrypted, derived);
-			var factorb = Hashes.Hash256(seedb).ToBytes();
+			var factorb = Hashes.DoubleSHA256(seedb).ToBytes();
 #if HAS_SPAN
 			var eckey = NBitcoinContext.Instance.CreateECPrivKey(passfactor).TweakMul(factorb);
 			var key = new Key(eckey, IsCompressed);
@@ -220,7 +220,7 @@ namespace NBitcoin
 		/// <returns></returns>
 		internal static byte[] HashAddress(BitcoinAddress address)
 		{
-			return Hashes.Hash256(Encoders.ASCII.DecodeData(address.ToString())).ToBytes().Take(4).ToArray();
+			return Hashes.DoubleSHA256(Encoders.ASCII.DecodeData(address.ToString())).ToBytes().Take(4).ToArray();
 		}
 
 		internal static byte[] CalculatePassPoint(byte[] passfactor)
@@ -239,7 +239,7 @@ namespace NBitcoin
 			{
 				var ownersalt = ownerEntropy.SafeSubarray(0, 4);
 				var prefactor = SCrypt.BitcoinComputeDerivedKey(Encoding.UTF8.GetBytes(password), ownersalt, 32);
-				passfactor = Hashes.Hash256(prefactor.Concat(ownerEntropy).ToArray()).ToBytes();
+				passfactor = Hashes.DoubleSHA256(prefactor.Concat(ownerEntropy).ToArray()).ToBytes();
 			}
 			return passfactor;
 		}

--- a/NBitcoin/BIP38/BitcoinPassphraseCode.cs
+++ b/NBitcoin/BIP38/BitcoinPassphraseCode.cs
@@ -178,7 +178,7 @@ namespace NBitcoin
 			var passfactor = prefactor;
 			if (hasLotSequence)
 			{
-				passfactor = Hashes.Hash256(prefactor.Concat(ownerEntropy).ToArray()).ToBytes();
+				passfactor = Hashes.DoubleSHA256(prefactor.Concat(ownerEntropy).ToArray()).ToBytes();
 			}
 
 			var passpoint = new Key(passfactor, fCompressedIn: true).PubKey.ToBytes();
@@ -220,7 +220,7 @@ namespace NBitcoin
 			//Generate 24 random bytes, call this seedb. Take SHA256(SHA256(seedb)) to yield 32 bytes, call this factorb.
 			seedb = seedb ?? RandomUtils.GetBytes(24);
 
-			var factorb = Hashes.Hash256(seedb).ToBytes();
+			var factorb = Hashes.DoubleSHA256(seedb).ToBytes();
 
 			//ECMultiply passpoint by factorb.
 #if HAS_SPAN

--- a/NBitcoin/Crypto/Hashes.cs
+++ b/NBitcoin/Crypto/Hashes.cs
@@ -18,24 +18,48 @@ namespace NBitcoin.Crypto
 {
 	public static class Hashes
 	{
-		#region Hash256
+		#region DoubleSHA256
+		[Obsolete("Method name changed to DoubleSHA256(byte[]) to make it clearer what the implementation does.")]
 		public static uint256 Hash256(byte[] data)
 		{
 			return Hash256(data, 0, data.Length);
 		}
 
+		[Obsolete("Method name changed to DoubleSHA256(byte[], int ) to make it clearer what the implementation does.")]
 		public static uint256 Hash256(byte[] data, int count)
 		{
 			return Hash256(data, 0, count);
 		}
 
+		[Obsolete("Method name changed to DoubleSHA256(byte[], int, int) to make it clearer what the implementation does.")]
 		public static uint256 Hash256(byte[] data, int offset, int count)
 		{
-			return new uint256(Hash256RawBytes(data, offset, count));
+			return new uint256(DoubleSHA256RawBytes(data, offset, count));
+		}
+
+		[Obsolete("Method name changed to DoubleSHA256RawBytes(byte[], int, int) to make it clearer what the implementation does.")]
+		public static byte[] Hash256RawBytes(byte[] data, int offset, int count)
+		{
+			return DoubleSHA256RawBytes(data, offset, count);
+		}
+
+		public static uint256 DoubleSHA256(byte[] data)
+		{
+			return DoubleSHA256(data, 0, data.Length);
+		}
+
+		public static uint256 DoubleSHA256(byte[] data, int count)
+		{
+			return DoubleSHA256(data, 0, count);
+		}
+
+		public static uint256 DoubleSHA256(byte[] data, int offset, int count)
+		{
+			return new uint256(DoubleSHA256RawBytes(data, offset, count));
 		}
 		#endregion
 
-		public static byte[] Hash256RawBytes(byte[] data, int offset, int count)
+		public static byte[] DoubleSHA256RawBytes(byte[] data, int offset, int count)
 		{
 #if NONATIVEHASH
 			Sha256Digest sha256 = new Sha256Digest();

--- a/NBitcoin/DataEncoders/Base58Encoder.cs
+++ b/NBitcoin/DataEncoders/Base58Encoder.cs
@@ -51,7 +51,7 @@ namespace NBitcoin.DataEncoders
 
 		protected virtual byte[] CalculateHash(byte[] bytes, int offset, int length)
 		{
-			return Hashes.Hash256RawBytes(bytes, offset, length);
+			return Hashes.DoubleSHA256RawBytes(bytes, offset, length);
 		}
 	}
 

--- a/NBitcoin/Key.cs
+++ b/NBitcoin/Key.cs
@@ -178,7 +178,7 @@ namespace NBitcoin
 				throw new ArgumentNullException(nameof(messageBytes));
 			AssertNotDiposed();
 			byte[] data = Utils.FormatMessageForSigning(messageBytes);
-			var hash = Hashes.Hash256(data);
+			var hash = Hashes.DoubleSHA256(data);
 			return Convert.ToBase64String(SignCompact(hash, forceLowR));
 		}
 

--- a/NBitcoin/MerkleNode.cs
+++ b/NBitcoin/MerkleNode.cs
@@ -68,7 +68,7 @@ namespace NBitcoin
 		{
 			var right = Right ?? Left;
 			if (Left != null && Left.Hash != null && right.Hash != null)
-				_Hash = Hashes.Hash256(Left.Hash.ToBytes().Concat(right.Hash.ToBytes()).ToArray());
+				_Hash = Hashes.DoubleSHA256(Left.Hash.ToBytes().Concat(right.Hash.ToBytes()).ToArray());
 		}
 
 		public bool IsLeaf

--- a/NBitcoin/Protocol/AddressManager.cs
+++ b/NBitcoin/Protocol/AddressManager.cs
@@ -166,13 +166,13 @@ namespace NBitcoin.Protocol
 			internal int GetNewBucket(uint256 nKey, IPAddress src)
 			{
 				byte[] vchSourceGroupKey = src.GetGroup();
-				UInt64 hash1 = Cheap(Hashes.Hash256(
+				UInt64 hash1 = Cheap(Hashes.DoubleSHA256(
 					nKey.ToBytes(true)
 					.Concat(Address.Endpoint.Address.GetGroup())
 					.Concat(vchSourceGroupKey)
 					.ToArray()));
 
-				UInt64 hash2 = Cheap(Hashes.Hash256(
+				UInt64 hash2 = Cheap(Hashes.DoubleSHA256(
 					nKey.ToBytes(true)
 					.Concat(vchSourceGroupKey)
 					.Concat(Utils.ToBytes(hash1 % AddressManager.ADDRMAN_NEW_BUCKETS_PER_SOURCE_GROUP, true))
@@ -188,7 +188,7 @@ namespace NBitcoin.Protocol
 			internal int GetBucketPosition(uint256 nKey, bool fNew, int nBucket)
 			{
 				UInt64 hash1 = Cheap(
-					Hashes.Hash256(
+					Hashes.DoubleSHA256(
 						nKey.ToBytes()
 						.Concat(new byte[] { (fNew ? (byte)'N' : (byte)'K') })
 						.Concat(Utils.ToBytes((uint)nBucket, false))
@@ -199,8 +199,8 @@ namespace NBitcoin.Protocol
 
 			internal int GetTriedBucket(uint256 nKey)
 			{
-				UInt64 hash1 = Cheap(Hashes.Hash256(nKey.ToBytes().Concat(Address.GetKey()).ToArray()));
-				UInt64 hash2 = Cheap(Hashes.Hash256(nKey.ToBytes().Concat(Address.Endpoint.Address.GetGroup()).Concat(Utils.ToBytes(hash1 % AddressManager.ADDRMAN_TRIED_BUCKETS_PER_GROUP, true)).ToArray()));
+				UInt64 hash1 = Cheap(Hashes.DoubleSHA256(nKey.ToBytes().Concat(Address.GetKey()).ToArray()));
+				UInt64 hash2 = Cheap(Hashes.DoubleSHA256(nKey.ToBytes().Concat(Address.Endpoint.Address.GetGroup()).Concat(Utils.ToBytes(hash1 % AddressManager.ADDRMAN_TRIED_BUCKETS_PER_GROUP, true)).ToArray()));
 				return (int)(hash2 % ADDRMAN_TRIED_BUCKET_COUNT);
 			}
 
@@ -312,7 +312,7 @@ namespace NBitcoin.Protocol
 				hash = new byte[32];
 				fs.Read(hash, 0, 32);
 			}
-			var actual = Hashes.Hash256(data);
+			var actual = Hashes.DoubleSHA256(data);
 			var expected = new uint256(hash);
 			if (expected != actual)
 				throw new FormatException("Invalid address manager file");
@@ -340,7 +340,7 @@ namespace NBitcoin.Protocol
 			stream.Type = SerializationType.Disk;
 			stream.ReadWrite(network.Magic);
 			stream.ReadWrite(this);
-			var hash = Hashes.Hash256(ms.ToArray());
+			var hash = Hashes.DoubleSHA256(ms.ToArray());
 			stream.ReadWrite(hash.AsBitcoinSerializable());
 
 			string dirPath = Path.GetDirectoryName(filePath);

--- a/NBitcoin/PubKey.cs
+++ b/NBitcoin/PubKey.cs
@@ -447,13 +447,13 @@ namespace NBitcoin
 		{
 #if HAS_SPAN
 			var messageToSign = Utils.FormatMessageForSigning(message);
-			var hash = Hashes.Hash256(messageToSign);
+			var hash = Hashes.DoubleSHA256(messageToSign);
 			Span<byte> msg = stackalloc byte[32];
 			hash.ToBytes(msg);
 			return _ECKey.SigVerify(signature.ToSecpECDSASignature(), msg);
 #else
 			var messageToSign = Utils.FormatMessageForSigning(message);
-			var hash = Hashes.Hash256(messageToSign);
+			var hash = Hashes.DoubleSHA256(messageToSign);
 			return ECKey.Verify(hash, signature);
 #endif
 		}
@@ -509,14 +509,14 @@ namespace NBitcoin
 		{
 			var signatureEncoded = Encoders.Base64.DecodeData(signatureText);
 			var message = Utils.FormatMessageForSigning(messageBytes);
-			var hash = Hashes.Hash256(message);
+			var hash = Hashes.DoubleSHA256(message);
 			return RecoverCompact(hash, signatureEncoded);
 		}
 
 		public static PubKey RecoverFromMessage(byte[] messageBytes, byte[] signatureEncoded)
 		{
 			var message = Utils.FormatMessageForSigning(messageBytes);
-			var hash = Hashes.Hash256(message);
+			var hash = Hashes.DoubleSHA256(message);
 			return RecoverCompact(hash, signatureEncoded);
 		}
 

--- a/NBitcoin/ScriptEvaluationContext.cs
+++ b/NBitcoin/ScriptEvaluationContext.cs
@@ -1306,7 +1306,7 @@ namespace NBitcoin
 									else if (opcode.Code == OpcodeType.OP_HASH160)
 										vchHash = Hashes.Hash160(vch, 0, vch.Length).ToBytes();
 									else if (opcode.Code == OpcodeType.OP_HASH256)
-										vchHash = Hashes.Hash256(vch, 0, vch.Length).ToBytes();
+										vchHash = Hashes.DoubleSHA256(vch, 0, vch.Length).ToBytes();
 									_stack.Pop();
 									_stack.Push(vchHash);
 									break;

--- a/NBitcoin/Stealth/StealthMetadata.cs
+++ b/NBitcoin/Stealth/StealthMetadata.cs
@@ -78,7 +78,7 @@ namespace NBitcoin.Stealth
 			output.Nonce = ms.ReadBytes(4);
 			output.EphemKey = new PubKey(ms.ReadBytes(33));
 			output.Script = metadata;
-			output.Hash = Hashes.Hash256(data);
+			output.Hash = Hashes.DoubleSHA256(data);
 			var msprefix = new MemoryStream(output.Hash.ToBytes(false));
 			output.BitField = Utils.ToUInt32(msprefix.ReadBytes(4), true);
 			return true;


### PR DESCRIPTION
Recently i was trying to verify some payload with the signature and lost a few hours because i wasn't aware that Hash256 method is actually doing a double hash, because the name of the method suggests that it does a single hash.
