### PR TITLE
Add fee rate histogram

### DIFF
--- a/NBitcoin/MemPoolInfo.cs
+++ b/NBitcoin/MemPoolInfo.cs
@@ -1,4 +1,7 @@
-﻿namespace NBitcoin
+﻿using System;
+using System.Collections.Generic;
+
+namespace NBitcoin
 {
 	public class MemPoolInfo
 	{
@@ -14,6 +17,18 @@
 
 		public double MinRelayTxFee { get; set; }
 
+		public IEnumerable<FeeRateGroup> Hisotgram { get; set; }
+
 		public MemPoolInfo() { }
 	}
+
+	public class FeeRateGroup
+	{
+		public int Group { get;  set; }
+		public ulong Sizes { get; set; }
+		public uint Count { get; set; }
+		public Money Fees { get; set; }
+		public FeeRate From { get; set; }
+		public FeeRate To { get; set; }
+	}	
 }


### PR DESCRIPTION
This PR https://github.com/bitcoin/bitcoin/pull/15836 provides statistical information about the fees paid by transactions currently waiting in the mempool and it has already been merged into Bitcoin Knots. IMO that information is useful for users to decide how much to pay, in fact, that's what some people do in the real world when they visit mempool.info or similar.

