### PR TITLE
Estimatesmartfee parameter causing issue for DOGE

### DIFF
--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -2011,7 +2011,13 @@ namespace NBitcoin.RPC
 		{
 			if (Capabilities == null || Capabilities.SupportEstimateSmartFee)
 			{
-				var request = new RPCRequest(RPCOperations.estimatesmartfee.ToString(), new object[] { confirmationTarget, estimateMode.ToString().ToUpperInvariant() });
+				var parameters = new List<object>() { confirmationTarget };
+				if (estimateMode != EstimateSmartFeeMode.Conservative)
+				{
+					parameters.Add(estimateMode.ToString().ToUpperInvariant());
+				}
+
+				var request = new RPCRequest(RPCOperations.estimatesmartfee.ToString(), parameters.ToArray());
 
 				var response = await SendCommandAsync(request, throwIfRPCError: false).ConfigureAwait(false);
 


### PR DESCRIPTION
Dogecore latest version as of writing is `1.14.2`
It fails when calling `estimatesmartfee` with more than one parameter.

After some research I found that the default `estimatesmartfee` uses the `CONSERVATIVE` mode when the second parameter is omitted, so no real reason to send in a default parameter. Making this change _will_ solve the issue for DOGE as the RPC call will be successful and _should_ not have any negative side effects for other coins when calling with default or `ECONOMICAL` mode. (eg. [Bitcore 0.16.0 RPC estimatesmartfee](https://bitcoin-rpc.github.io/en/doc/0.16.0/rpc/util/estimatesmartfee/))

Calling DOGE RPC `estimatesmartfee` with more than one parameters returns this error response:
```
error code: -1
error message:
estimatesmartfee nblocks

WARNING: This interface is unstable and may disappear or change!

Estimates the approximate fee per kilobyte needed for a transaction to begin  
confirmation within nblocks blocks if possible and return the number of blocks
for which the estimate is valid. Uses virtual transaction size as defined     
in BIP 141 (witness data is discounted).

Arguments:
1. nblocks     (numeric)

Result:
{
  "feerate" : x.x,     (numeric) estimate fee-per-kilobyte (in BTC)
  "blocks" : n         (numeric) block number where estimate was found        
}

A negative value is returned if not enough transactions and blocks
have been observed to make an estimate for any number of blocks.
However it will not return a value below the mempool reject fee.

Example:
> dogecoin-cli estimatesmartfee 6
```

Solves issue #901 