### PR TITLE
Support Qtum hardfork

### DIFF
--- a/NBitcoin.Altcoins/Qtum.cs
+++ b/NBitcoin.Altcoins/Qtum.cs
@@ -179,7 +179,7 @@ namespace NBitcoin.Altcoins
 			.SetMagic(0xd3a6cff1)
 			.SetPort(3888)
 			.SetRPCPort(3889)
-			.SetMaxP2PVersion(70017)
+			.SetMaxP2PVersion(70018)
 			.SetName("qtum-main")
 			.AddAlias("qtum-mainnet")
 			.AddDNSSeeds(new[]{
@@ -219,7 +219,7 @@ namespace NBitcoin.Altcoins
 			.SetMagic(0x0615220d)
 			.SetPort(13888)
 			.SetRPCPort(13889)
-			.SetMaxP2PVersion(70017)
+			.SetMaxP2PVersion(70018)
 			.SetName("qtum-test")
 			.AddAlias("qtum-testnet")
 			.AddDNSSeeds(new[]{
@@ -260,7 +260,7 @@ namespace NBitcoin.Altcoins
 			.SetMagic(0xe1c6ddfd)
 			.SetPort(23888)
 			.SetRPCPort(13889)
-			.SetMaxP2PVersion(70017)
+			.SetMaxP2PVersion(70018)
 			.SetName("qtum-reg")
 			.AddAlias("qtum-regtest")
 			.AddSeeds(new NetworkAddress[0])


### PR DESCRIPTION
Qtum had a hardfork and now it rejects peers using old P2P version.

Please also update NBXplorer and BTCPayServer once this is pushed. Thank you.