### PR TITLE
Scalar (ulong) ctor

### DIFF
--- a/NBitcoin.Tests/Secp256k1Tests.cs
+++ b/NBitcoin.Tests/Secp256k1Tests.cs
@@ -1319,6 +1319,22 @@ namespace NBitcoin.Tests
 
 		[Fact]
 		[Trait("UnitTest", "UnitTest")]
+		public void CanCreateScalarFromULong()
+		{
+			var fromUInt = new Scalar(uint.MaxValue);
+			fromUInt = fromUInt.Multiply(new Scalar(17));
+
+			var fromULong = new Scalar(17UL * uint.MaxValue);
+			Assert.Equal(fromULong, fromUInt);
+
+			var two = Scalar.One + Scalar.One;
+			var max = two.Sqr(6) + two.Negate();
+			var maxULong = new Scalar(ulong.MaxValue-1);
+			Assert.Equal(maxULong, max);
+		}
+
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
 		public void CanSerializeScalar()
 		{
 			Span<byte> output = stackalloc byte[32];

--- a/NBitcoin/Secp256k1/Scalar.cs
+++ b/NBitcoin/Secp256k1/Scalar.cs
@@ -99,6 +99,11 @@ namespace NBitcoin.Secp256k1
 			d0 = value;
 		}
 		
+#if SECP256K1_LIB
+		public
+#else
+		internal
+#endif
 		Scalar(ulong value)
 		{
 			d0 = d1 = d2 = d3 = d4 = d5 = d6 = d7 = 0;

--- a/NBitcoin/Secp256k1/Scalar.cs
+++ b/NBitcoin/Secp256k1/Scalar.cs
@@ -98,6 +98,14 @@ namespace NBitcoin.Secp256k1
 			d0 = d1 = d2 = d3 = d4 = d5 = d6 = d7 = 0;
 			d0 = value;
 		}
+		
+		Scalar(ulong value)
+		{
+			d0 = d1 = d2 = d3 = d4 = d5 = d6 = d7 = 0;
+			d0 = (uint)(value & uint.MaxValue);
+			d1 = (uint)((value >> 32) & uint.MaxValue);
+		}
+	
 #if SECP256K1_LIB
 		public
 #else


### PR DESCRIPTION
Adds a new Scalar ctor that accepts ulong. 

Nore: This will be useful for WabiSabi. Of course it is not absolutely necessary and we can perfectly live without this so, feel free to reject it if you think it is not okay for some reason.