### PR TITLE
Expose MultiExponentiation Method

### DIFF
--- a/NBitcoin.Bench/MultiexponentiationBench.cs
+++ b/NBitcoin.Bench/MultiexponentiationBench.cs
@@ -1,0 +1,51 @@
+using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.IO;
+using NBitcoin.Bench;
+using NBitcoin.Secp256k1;
+
+namespace NBitcoin.Bench
+{
+	[RPlotExporter, RankColumn]
+	public class Multiexponentiation
+	{
+		[Params(2, 10, 100)]
+		public int count;
+
+		public Scalar[] ns;
+		public GEJ[] gs;
+		public GE me;
+		public GE em;
+
+		[GlobalSetup]
+		public void Setup()
+		{
+			ns = Enumerable.Range(1, count).Select(x => new Scalar((uint)x)).ToArray();
+			gs = Enumerable.Repeat(EC.G.ToGroupElementJacobian(), count).ToArray();
+		}
+
+		[Benchmark]
+		public void MultiExp()
+		{
+			me = ECMultContext.Instance.Mult(gs, ns).ToGroupElement();
+		}
+
+		[Benchmark]
+		public void ExpMulti()
+		{
+			em =Enumerable.Aggregate(
+				Enumerable.Zip(ns, gs, (n, g) => n * g.ToGroupElement()), (acc, elem) => acc + elem.ToGroupElement()).ToGroupElement();
+		}
+
+		[GlobalCleanup]
+		public void CleanUp()
+		{
+			if (!me.Equals(em))
+				throw new Exception("No equals");
+		}
+ 	}
+}

--- a/NBitcoin.Bench/NBitcoin.Bench.csproj
+++ b/NBitcoin.Bench/NBitcoin.Bench.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+  		<ProjectReference Include="..\NBitcoin.Secp256k1\NBitcoin.Secp256k1.csproj" />
   		<ProjectReference Include="..\NBitcoin\NBitcoin.csproj" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">

--- a/NBitcoin.Tests/Secp256k1Tests.cs
+++ b/NBitcoin.Tests/Secp256k1Tests.cs
@@ -1339,6 +1339,21 @@ namespace NBitcoin.Tests
 
 		[Fact]
 		[Trait("UnitTest", "UnitTest")]
+		public void CanMultiplyInBatch()
+		{
+			var ns = Enumerable.Range(1, count).Select(x => new Scalar((uint)x)).ToArray();
+			var gs = Enumerable.Repeat(EC.G.ToGroupElementJacobian(), count).ToArray();
+			var me = ecmult_ctx.Mult(gs, ns).ToGroupElement();
+
+			var mult = Enumerable.Zip(ns, gs, (n, g) => n * g.ToGroupElement());
+			var em = mult.Aggregate(
+				(acc, elem) => (acc + elem.ToGroupElement()));
+
+			Assert.Equal(me, em.ToGroupElement());
+		}
+
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
 		public void CanSerializeScalar()
 		{
 			Span<byte> output = stackalloc byte[32];

--- a/NBitcoin/Secp256k1/ECMultContext.cs
+++ b/NBitcoin/Secp256k1/ECMultContext.cs
@@ -224,7 +224,12 @@ namespace NBitcoin.Secp256k1
 		}
 
 #if SECP256K1_LIB
-		public GEJ Mult(in Span<GEJ> @as, in Span<Scalar> nas)
+		public
+#else
+		internal
+#endif
+
+		GEJ Mult(in Span<GEJ> @as, in Span<Scalar> nas)
 		{
 			var n = @as.Length;
 			unsafe
@@ -244,7 +249,6 @@ namespace NBitcoin.Secp256k1
 				return ECMultiply(state, @as, nas, null, n);
 			}
 		}
-#endif
 
 		unsafe GEJ ECMultiply(in StraussState state, in Span<GEJ> a, in Span<Scalar> na, in Scalar? ng, int num)
 		{

--- a/NBitcoin/Secp256k1/ECMultContext.cs
+++ b/NBitcoin/Secp256k1/ECMultContext.cs
@@ -234,19 +234,26 @@ namespace NBitcoin.Secp256k1
 			var n = @as.Length;
 			unsafe
 			{
-				GEJ* prej = stackalloc GEJ[n * ArraySize_A];
-				FE* zr = stackalloc FE[n * ArraySize_A];
-				GE* pre_a = stackalloc GE[n * ArraySize_A];
-				GE* pre_a_lam = stackalloc GE[n * ArraySize_A];
-				StraussPointState* ps = stackalloc StraussPointState[n];
+				GEJ[] prej = new GEJ[n * ArraySize_A];
+				FE[] zr = new FE[n * ArraySize_A];
+				GE[] pre_a = new GE[n * ArraySize_A];
+				GE[] pre_a_lam = new GE[n * ArraySize_A];
+				StraussPointState[] ps = new StraussPointState[n];
 
-				StraussState state = default;
-				state.prej = prej;
-				state.zr = zr;
-				state.pre_a = pre_a;
-				state.pre_a_lam = pre_a_lam;
-				state.ps = ps;
-				return ECMultiply(state, @as, nas, null, n);
+				fixed (GEJ* fixed_prej = &prej[0])
+				fixed (FE* fixed_zr = &zr[0])
+				fixed (GE* fixed_pre_a = &pre_a[0])
+				fixed (GE* fixed_pre_a_lam = &pre_a_lam[0])
+				fixed (StraussPointState* fixed_ps = &ps[0])
+				{
+					StraussState state = default;
+					state.prej = fixed_prej;
+					state.zr = fixed_zr;
+					state.pre_a = fixed_pre_a;
+					state.pre_a_lam = fixed_pre_a_lam;
+					state.ps = fixed_ps;
+					return ECMultiply(state, @as, nas, null, n);
+				}
 			}
 		}
 

--- a/NBitcoin/Secp256k1/ECMultContext.cs
+++ b/NBitcoin/Secp256k1/ECMultContext.cs
@@ -222,6 +222,30 @@ namespace NBitcoin.Secp256k1
 				return ECMultiply(state, @as, nas, ng, 1);
 			}
 		}
+
+#if SECP256K1_LIB
+		public GEJ Mult(in Span<GEJ> @as, in Span<Scalar> nas)
+		{
+			var n = @as.Length;
+			unsafe
+			{
+				GEJ* prej = stackalloc GEJ[n * ArraySize_A];
+				FE* zr = stackalloc FE[n * ArraySize_A];
+				GE* pre_a = stackalloc GE[n * ArraySize_A];
+				GE* pre_a_lam = stackalloc GE[n * ArraySize_A];
+				StraussPointState* ps = stackalloc StraussPointState[n];
+
+				StraussState state = default;
+				state.prej = prej;
+				state.zr = zr;
+				state.pre_a = pre_a;
+				state.pre_a_lam = pre_a_lam;
+				state.ps = ps;
+				return ECMultiply(state, @as, nas, null, n);
+			}
+		}
+#endif
+
 		unsafe GEJ ECMultiply(in StraussState state, in Span<GEJ> a, in Span<Scalar> na, in Scalar? ng, int num)
 		{
 			var r = GEJ.Infinity;


### PR DESCRIPTION
This PR publishes a new method in the NBitcoin.Secp256k1 library. This is necessary for WabiSabi because it implements a range proof algorithm that involves tens of group element multiplications that makes the algorithm performance really bad. With this exposed method the performance is 10x faster:

```
|   Method | count |         Mean |      Error |       StdDev |       Median | Rank |
|--------- |------ |-------------:|-----------:|-------------:|-------------:|-----:|
| MultiExp |     2 |     64.03 us |   2.127 us |     5.965 us |     62.15 us |    1 |
| ExpMulti |     2 |    745.40 us |  16.678 us |    46.768 us |    728.23 us |    3 |
| MultiExp |    10 |    251.95 us |   4.753 us |     4.668 us |    251.49 us |    2 |
| ExpMulti |    10 |  3,640.58 us |  51.402 us |    42.923 us |  3,633.79 us |    5 |
| MultiExp |   100 |  2,686.49 us |  57.672 us |   167.318 us |  2,632.45 us |    4 |
| ExpMulti |   100 | 36,844.23 us | 720.093 us | 1,503.102 us | 36,264.07 us |    6 |
```

*    MultiExp is `multiexponentiation(IE<Scalar> ns, IE<GEJ> gs)`
*    ExpMulti is `n0 *G0 + n1 * G1 + ....+ nn * Gn `

@nothingmuch could you take a look at this?