### PR TITLE
TransactionBuilder: shuffle inputs too in Shuffle() method

### DIFF
--- a/NBitcoin/Sequence.cs
+++ b/NBitcoin/Sequence.cs
@@ -62,7 +62,7 @@ namespace NBitcoin
 		/// relative lock-time. Setting the most significant bit of a
 		/// sequence number disabled relative lock-time.
 		/// </remarks>
-		public const uint SEQUENCE_FINAL = 0xffffffff;
+		public const uint SEQUENCE_FINAL = UINT_MAX_VALUE;
 
 		/// <summary>
 		/// Setting nSequence to this value on any input in a transaction
@@ -82,17 +82,19 @@ namespace NBitcoin
 		internal const int SEQUENCE_LOCKTIME_GRANULARITY = 9;
 
 
+		internal const uint UINT_MAX_VALUE = 0xFFFFFFFF;
+
 		uint _ValueInv;
 		public uint Value
 		{
 			get
 			{
-				return 0xFFFFFFFF - _ValueInv;
+				return UINT_MAX_VALUE - _ValueInv;
 			}
 		}
 		public Sequence(uint value)
 		{
-			_ValueInv = 0xFFFFFFFF - value;
+			_ValueInv = UINT_MAX_VALUE - value;
 		}
 
 		public Sequence(int lockHeight)
@@ -107,7 +109,7 @@ namespace NBitcoin
 				throw new ArgumentOutOfRangeException("Relative lock time must be positive and lower or equals to " + (0xFFFF * 512) + " seconds (approx 388 days)");
 			var value = (uint)(period.TotalSeconds / (1 << Sequence.SEQUENCE_LOCKTIME_GRANULARITY));
 			value |= SEQUENCE_LOCKTIME_TYPE_FLAG;
-			_ValueInv = 0xFFFFFFFF - (uint)value;
+			_ValueInv = UINT_MAX_VALUE - (uint)value;
 		}
 
 		public bool IsRelativeLock

--- a/NBitcoin/Transaction.cs
+++ b/NBitcoin/Transaction.cs
@@ -1291,7 +1291,7 @@ namespace NBitcoin
 		{
 			get
 			{
-				return Inputs.Any(i => i.Sequence < 0xffffffff - 1);
+				return Inputs.Any(i => i.Sequence < Sequence.UINT_MAX_VALUE - 1);
 			}
 		}
 


### PR DESCRIPTION
While we are at it, we improve the obsolete message of the Shuffle
method and put the shuffle operations closer together in the
BuildTransaction method.