### PR TITLE
Update NBitcoin to support RPC changes

### DIFF
--- a/NBitcoin.TestFramework/NodeBuilder.cs
+++ b/NBitcoin.TestFramework/NodeBuilder.cs
@@ -582,8 +582,10 @@ namespace NBitcoin.Tests
 			{
 				UseShellExecute = _Builder.ShowNodeConsole
 			};
-			using var walletToolProcess = Process.Start(info); 
-			walletToolProcess.WaitForExit();
+			using (var walletToolProcess = Process.Start(info))
+			{ 
+				walletToolProcess.WaitForExit();
+			}
 		}
 
 		Process _Process;

--- a/NBitcoin.TestFramework/NodeBuilder.cs
+++ b/NBitcoin.TestFramework/NodeBuilder.cs
@@ -578,17 +578,11 @@ namespace NBitcoin.Tests
 			var walletToolPath = Path.Combine(Path.GetDirectoryName(this._Builder.BitcoinD), "bitcoin-wallet");
 			string walletToolArgs = $"-regtest -wallet=\"wallet.dat\" -datadir=\"{dataDir}\" create";
 
-			Process walletToolProcess; 
-			if (_Builder.ShowNodeConsole)
+			var info = new ProcessStartInfo(walletToolPath, walletToolArgs)
 			{
-				ProcessStartInfo info = new ProcessStartInfo(walletToolPath, walletToolArgs);
-				info.UseShellExecute = true;
-				walletToolProcess = Process.Start(info);
-			}
-			else
-			{
-				walletToolProcess = Process.Start(walletToolPath, walletToolArgs);
-			}
+				UseShellExecute = _Builder.ShowNodeConsole
+			};
+			using var walletToolProcess = Process.Start(info); 
 			walletToolProcess.WaitForExit();
 		}
 

--- a/NBitcoin.TestFramework/NodeBuilder.cs
+++ b/NBitcoin.TestFramework/NodeBuilder.cs
@@ -100,6 +100,11 @@ namespace NBitcoin.Tests
 		}
 		public string RegtestFolderName { get; set; }
 
+		public bool CreateWallet
+		{
+			get; set;
+		}
+
 		/// <summary>
 		/// For blockchains that use an arbitrary chain (e.g. instead of main, testnet and regtest
 		/// Elements can use chain=elementsregtest).
@@ -286,14 +291,6 @@ namespace NBitcoin.Tests
 			_Config = Path.Combine(dataDir, "bitcoin.conf");
 			ConfigParameters.Import(builder.ConfigParameters, true);
 			ports = new int[2];
-
-			if (Version.TryParse(builder.NodeImplementation.Version, out var version))
-			{
-				if (builder.Network.NetworkSet is Bitcoin && version >= new Version(0, 21))
-				{
-					RequiresWalletCreation = true;
-				}
-			}
 
 			if (builder.CleanBeforeStartingNode && File.Exists(_Config))
 			{
@@ -508,7 +505,7 @@ namespace NBitcoin.Tests
 					configStr.AppendLine($"[{NodeImplementation.Chain}]");
 				}
 			}
-			if (RequiresWalletCreation)
+			if (NodeImplementation.CreateWallet)
 				config.Add("wallet", "wallet.dat");
 
 			config.Add("rest", "1");
@@ -543,7 +540,7 @@ namespace NBitcoin.Tests
 		{
 			lock (l)
 			{
-				if (RequiresWalletCreation)
+				if (_Builder.NodeImplementation.CreateWallet)
 					CreateDefaultWallet();
 
 				string appPath = new FileInfo(this._Builder.BitcoinD).FullName;
@@ -679,12 +676,6 @@ namespace NBitcoin.Tests
 			get;
 			set;
 		} = true;
-
-		public bool RequiresWalletCreation
-		{
-			get;
-			set;
-		} = false;
 
 		class TransactionNode
 		{

--- a/NBitcoin.TestFramework/NodeBuilder.cs
+++ b/NBitcoin.TestFramework/NodeBuilder.cs
@@ -500,6 +500,7 @@ namespace NBitcoin.Tests
 					configStr.AppendLine($"[{NodeImplementation.Chain}]");
 				}
 			}
+			config.Add("wallet", "wallet.dat");
 			config.Add("rest", "1");
 			config.Add("server", "1");
 			config.Add("txindex", "1");
@@ -524,6 +525,7 @@ namespace NBitcoin.Tests
 			if (NodeImplementation.AdditionalRegtestConfig != null)
 				configStr.AppendLine(NodeImplementation.AdditionalRegtestConfig);
 			File.WriteAllText(_Config, configStr.ToString());
+			
 			await Run();
 		}
 
@@ -531,6 +533,8 @@ namespace NBitcoin.Tests
 		{
 			lock (l)
 			{
+				CreateDefaultWallet();
+
 				string appPath = new FileInfo(this._Builder.BitcoinD).FullName;
 				string args = "-conf=bitcoin.conf" + " -datadir=" + dataDir + " -debug=net";
 
@@ -561,6 +565,24 @@ namespace NBitcoin.Tests
 			}
 		}
 
+		private void CreateDefaultWallet()
+		{
+			var walletToolPath = Path.Combine(Path.GetDirectoryName(this._Builder.BitcoinD), "bitcoin-wallet");
+			string walletToolArgs = $"-regtest -wallet=\"wallet.dat\" -datadir=\"{dataDir}\" create";
+
+			Process walletToolProcess; 
+			if (_Builder.ShowNodeConsole)
+			{
+				ProcessStartInfo info = new ProcessStartInfo(walletToolPath, walletToolArgs);
+				info.UseShellExecute = true;
+				walletToolProcess = Process.Start(info);
+			}
+			else
+			{
+				walletToolProcess = Process.Start(walletToolPath, walletToolArgs);
+			}
+			walletToolProcess.WaitForExit();
+		}
 
 		Process _Process;
 		private readonly string dataDir;

--- a/NBitcoin.TestFramework/WellknownNodeDownloadData.cs
+++ b/NBitcoin.TestFramework/WellknownNodeDownloadData.cs
@@ -246,7 +246,8 @@ namespace NBitcoin.Tests
 					Archive = "bitcoin-{0}rc2-win64.zip",
 					Hash = "6406e1ef94472ad257e9fd5a5ff84dc3fb5ce88e1e3e3ed91c20728bc78b1858"
 				},
-				UseSectionInConfigFile = true
+				UseSectionInConfigFile = true,
+				CreateWallet = true
 			};
 
 		}

--- a/NBitcoin.TestFramework/WellknownNodeDownloadData.cs
+++ b/NBitcoin.TestFramework/WellknownNodeDownloadData.cs
@@ -221,6 +221,34 @@ namespace NBitcoin.Tests
 				},
 				UseSectionInConfigFile = true
 			};
+
+			public NodeDownloadData v0_21_0 = new NodeDownloadData()
+			{
+				Version = "0.21.0",
+				Linux = new NodeOSDownloadData()
+				{
+					Archive = "bitcoin-{0}rc2-x86_64-linux-gnu.tar.gz",
+					DownloadLink = "https://bitcoincore.org/bin/bitcoin-core-{0}/test.rc2/bitcoin-{0}rc2-x86_64-linux-gnu.tar.gz",
+					Executable = "bitcoin-{0}rc2/bin/bitcoind",
+					Hash = "8fe08cd05bc76446c2fa9ad90d7029c85db6413316408b3fb83ef19cc8f2a2a6"
+				},
+				Mac = new NodeOSDownloadData()
+				{
+					Archive = "bitcoin-{0}rc2-osx64.tar.gz",
+					DownloadLink = "https://bitcoincore.org/bin/bitcoin-core-{0}/test.rc2/bitcoin-{0}rc2-osx64.tar.gz",
+					Executable = "bitcoin-{0}rc2/bin/bitcoind",
+					Hash = "a8749320ba1a500e70007843ea4b9f25aced5281afbc32e45fd7be49c5d01dd2"
+				},
+				Windows = new NodeOSDownloadData()
+				{
+					Executable = "bitcoin-{0}rc2/bin/bitcoind.exe",
+					DownloadLink = "https://bitcoincore.org/bin/bitcoin-core-{0}/test.rc2/bitcoin-{0}rc2-win64.zip",
+					Archive = "bitcoin-{0}rc2-win64.zip",
+					Hash = "6406e1ef94472ad257e9fd5a5ff84dc3fb5ce88e1e3e3ed91c20728bc78b1858"
+				},
+				UseSectionInConfigFile = true
+			};
+
 		}
 
 		public class LitecoinNodeDownloadData

--- a/NBitcoin.Tests/NodeBuilderEx.cs
+++ b/NBitcoin.Tests/NodeBuilderEx.cs
@@ -68,7 +68,7 @@ namespace NBitcoin.Tests
 
 			//var builder = Create(NodeDownloadData.Bitcoin.v0_19_0_1, caller);
 
-			var builder = Create(NodeDownloadData.Bitcoin.v0_20_1, caller);
+			var builder = Create(NodeDownloadData.Bitcoin.v0_21_0, caller);
 			return builder;
 		}
 

--- a/NBitcoin.Tests/ProtocolTests.cs
+++ b/NBitcoin.Tests/ProtocolTests.cs
@@ -245,6 +245,35 @@ namespace NBitcoin.Tests
 
 		[Fact]
 		[Trait("Protocol", "Protocol")]
+		public void CanProcessAddressGossip()
+		{
+			using (var builder = NodeBuilderEx.Create())
+			{
+				var node = builder.CreateNode(true);
+				var rpc = node.CreateRPCClient();
+				for (var i = 1; i < 101; i++)
+				{
+					for (var j = 1; j < 101; j++)
+					{
+						var ip = IPAddress.Parse($"{i}.{j}.1.1");
+						rpc.AddPeerAddress(ip, 8333);
+					}
+				}
+
+				var nodeClient = node.CreateNodeClient();
+				nodeClient.VersionHandshake();
+				using (var list = nodeClient.CreateListener().Where(m => m.Message.Payload is AddrPayload))
+				{
+					nodeClient.SendMessage(new GetAddrPayload());
+
+					var addr = list.ReceivePayload<AddrPayload>();
+					Assert.Equal(1000, addr.Addresses.Length);
+				}
+			}
+		}
+
+		[Fact]
+		[Trait("Protocol", "Protocol")]
 		public void CanHandshakeWithSeveralTemplateBehaviors()
 		{
 			using (var builder = NodeBuilderEx.Create())

--- a/NBitcoin/RPC/CreateWalletOptions.cs
+++ b/NBitcoin/RPC/CreateWalletOptions.cs
@@ -4,12 +4,12 @@ namespace NBitcoin.RPC
 {
 	public class CreateWalletOptions
 	{
-		public bool DisablePrivateKeys { get; set; } 
-		public bool Blank { get; set; } 
+		public bool? DisablePrivateKeys { get; set; } 
+		public bool? Blank { get; set; } 
 		public string? Passphrase { get; set; } 
-		public bool AvoidReuse { get; set; }
-		public bool Descriptors { get; set; }
-		public bool? LoadOnStartup { get; set; } = null;
+		public bool? AvoidReuse { get; set; }
+		public bool? Descriptors { get; set; }
+		public bool? LoadOnStartup { get; set; }
 	}
 }
 

--- a/NBitcoin/RPC/CreateWalletOptions.cs
+++ b/NBitcoin/RPC/CreateWalletOptions.cs
@@ -1,0 +1,16 @@
+#nullable enable
+
+namespace NBitcoin.RPC
+{
+	public class CreateWalletOptions
+	{
+		public bool DisablePrivateKeys { get; set; } 
+		public bool Blank { get; set; } 
+		public string? Passphrase { get; set; } 
+		public bool AvoidReuse { get; set; }
+		public bool Descriptors { get; set; }
+		public bool? LoadOnStartup { get; set; } = null;
+	}
+}
+
+#nullable restore

--- a/NBitcoin/RPC/RPCClient.Wallet.cs
+++ b/NBitcoin/RPC/RPCClient.Wallet.cs
@@ -126,170 +126,10 @@ namespace NBitcoin.RPC
 		wallet			 walletcreatefundedpsbt
 	*/
 
-	public interface IRPCWalletClient
+	public partial class RPCClient
 	{
-		BitcoinAddress GetNewAddress();
+		#nullable enable
 
-		BitcoinAddress GetNewAddress(GetNewAddressRequest request);
-
-		Task<BitcoinAddress> GetNewAddressAsync();
-
-		Task<BitcoinAddress> GetNewAddressAsync(GetNewAddressRequest request);
-
-		BitcoinAddress GetRawChangeAddress();
-
-		Task<BitcoinAddress> GetRawChangeAddressAsync();
-
-		Task UnloadAsync(bool? loadOnStartup = null);
-
-		void Unload(bool? loadOnStartup = null);
-
-		void ImportPrivKey(BitcoinSecret secret);
-
-		void ImportPrivKey(BitcoinSecret secret, string label, bool rescan);
-
-		Task ImportPrivKeyAsync(BitcoinSecret secret);
-
-		Task ImportPrivKeyAsync(BitcoinSecret secret, string label, bool rescan);
-
-		void ImportAddress(IDestination address);
-
-		void ImportAddress(IDestination address, string label, bool rescan);
-
-		void ImportAddress(Script scriptPubKey);
-
-		void ImportAddress(Script scriptPubKey, string label, bool rescan);
-
-		Task ImportAddressAsync(Script scriptPubKey);
-
-		Task ImportAddressAsync(Script scriptPubKey, string label, bool rescan);
-
-		Task ImportAddressAsync(BitcoinAddress address);
-
-		Task ImportAddressAsync(BitcoinAddress address, string label, bool rescan);
-
-		void ImportMulti(ImportMultiAddress[] addresses, bool rescan);
-
-		void ImportMulti(ImportMultiAddress[] addresses, bool rescan, ISigningRepository signingRepository);
-
-		Task ImportMultiAsync(ImportMultiAddress[] addresses, bool rescan);
-
-		Task ImportMultiAsync(ImportMultiAddress[] addresses, bool rescan, ISigningRepository signingRepository);
-
-		BitcoinSecret DumpPrivKey(BitcoinAddress address);
-
-		Task<BitcoinSecret> DumpPrivKeyAsync(BitcoinAddress address);
-
-		Money GetReceivedByAddress(BitcoinAddress address);
-
-		Task<Money> GetReceivedByAddressAsync(BitcoinAddress address);
-
-		Money GetReceivedByAddress(BitcoinAddress address, int confirmations);
-
-		Task<Money> GetReceivedByAddressAsync(BitcoinAddress address, int confirmations);
-
-		GetAddressInfoResponse GetAddressInfo(IDestination address);
-
-		Task<GetAddressInfoResponse> GetAddressInfoAsync(IDestination address);
-
-		Money GetBalance(int minConf, bool includeWatchOnly);
-
-		Money GetBalance();
-
-		Task<Money> GetBalanceAsync();
-
-		Task<Money> GetBalanceAsync(int minConf, bool includeWatchOnly);
-
-		void AbandonTransaction(uint256 txId);
-
-		Task AbandonTransactionAsync(uint256 txId);
-
-		void BackupWallet(string path);
-
-		Task BackupWalletAsync(string path);
-
-		void WalletPassphrase(string passphrase, int timeout);
-
-		Task WalletPassphraseAsync(string passphrase, int timeout);
-		
-		Task<OutPoint[]> ListLockUnspentAsync();
-
-		OutPoint[] ListLockUnspent();
-
-		UnspentCoin[] ListUnspent();
-
-		UnspentCoin[] ListUnspent(int minconf, int maxconf, params BitcoinAddress[] addresses);
-
-		Task<UnspentCoin[]> ListUnspentAsync();
-
-		Task<UnspentCoin[]> ListUnspentAsync(int minconf, int maxconf, params BitcoinAddress[] addresses);
-
-		Task<UnspentCoin[]> ListUnspentAsync(ListUnspentOptions options, params BitcoinAddress[] addresses);
-
-		FundRawTransactionResponse FundRawTransaction(Transaction transaction, FundRawTransactionOptions options = null);
-		
-		Task<FundRawTransactionResponse> FundRawTransactionAsync(Transaction transaction, FundRawTransactionOptions options = null);
-
-		IEnumerable<AddressGrouping> ListAddressGroupings();
-
-		IEnumerable<BitcoinSecret> ListSecrets();
-
-		void LockUnspent(params OutPoint[] outpoints);
-
-		Task LockUnspentAsync(params OutPoint[] outpoints);
-
-		void UnlockUnspent(params OutPoint[] outpoints);
-
-		Task UnlockUnspentAsync(params OutPoint[] outpoints);
-
-		Transaction SignRawTransaction(Transaction tx);
-
-		Task<Transaction> SignRawTransactionAsync(Transaction tx);
-
-		SignRawTransactionResponse SignRawTransactionWithWallet(SignRawTransactionRequest request);
-
-		Task<SignRawTransactionResponse> SignRawTransactionWithWalletAsync(SignRawTransactionRequest request);
-
-		WalletProcessPSBTResponse WalletProcessPSBT(PSBT psbt, bool sign = true, SigHash hashType = SigHash.All, bool bip32derivs = false);
-		Task<WalletProcessPSBTResponse> WalletProcessPSBTAsync(PSBT psbt, bool sign = true, SigHash sighashType = SigHash.All, bool bip32derivs = false);
-		WalletCreateFundedPSBTResponse WalletCreateFundedPSBT(
-			TxIn[] inputs,
-			Tuple<Dictionary<BitcoinAddress, Money>, Dictionary<string, string>> outputs,
-			LockTime locktime,
-			FundRawTransactionOptions options = null,
-			bool bip32derivs = false
-			);
-
-		Task<WalletCreateFundedPSBTResponse> WalletCreateFundedPSBTAsync(
-		TxIn[] inputs,
-		Tuple<Dictionary<BitcoinAddress, Money>, Dictionary<string, string>> outputs,
-		LockTime locktime = default(LockTime),
-		FundRawTransactionOptions options = null,
-		bool bip32derivs = false
-		);
-
-		WalletCreateFundedPSBTResponse WalletCreateFundedPSBT(
-			TxIn[] inputs,
-			Dictionary<BitcoinAddress, Money> outputs,
-			LockTime locktime,
-			FundRawTransactionOptions options = null,
-			bool bip32derivs = false
-		);
-
-		WalletCreateFundedPSBTResponse WalletCreateFundedPSBT(
-			TxIn[] inputs,
-			Dictionary<string, string> outputs,
-			LockTime locktime,
-			FundRawTransactionOptions options = null,
-			bool bip32derivs = false
-		);
-
-		Task<RPCResponse> SendCommandAsync(RPCOperations commandName, params object[] parameters);
-
-	}
-
-	public partial class RPCClient : IRPCWalletClient
-	{
 		public RPCClient GetWallet(string walletName)
 		{
 			RPCCredentialString credentialString;;
@@ -321,37 +161,38 @@ namespace NBitcoin.RPC
 			};
 		}
 
-		public async Task<IRPCWalletClient> CreateWalletAsync(string walletNameOrPath, 
-			bool disablePrivateKeys = false, 
-			bool blank = false, 
-			string passphrase = null, 
-			bool avoidReuse = false,
-			bool descriptors = false,
-			bool? loadOnStartup = null)
+		public async Task<RPCClient> CreateWalletAsync(string walletNameOrPath, CreateWalletOptions? options = null)
 		{
-			var result = await SendCommandAsync(RPCOperations.createwallet, walletNameOrPath, disablePrivateKeys, blank, passphrase, avoidReuse, descriptors, loadOnStartup).ConfigureAwait(false);
+			var parameters = new Dictionary<string, object>();
+			parameters.Add("wallet_name", walletNameOrPath);
+			if (options is { })
+			{
+				parameters.Add("disable_private_keys", options.DisablePrivateKeys.ToString());
+				parameters.Add("blank", options.Blank.ToString());
+				if (!string.IsNullOrEmpty(options.Passphrase))
+					parameters.Add("passphrase", options.Passphrase);
+
+				parameters.Add("avoid_reuse", options.AvoidReuse.ToString());
+				parameters.Add("descriptors", options.Descriptors.ToString());
+				if (options.LoadOnStartup.HasValue)
+					parameters.Add("load_on_startup", options.LoadOnStartup.ToString());
+			}
+			var result = await SendCommandWithNamedArgsAsync(RPCOperations.createwallet.ToString(), parameters).ConfigureAwait(false);
 			return GetWallet(result.Result.Value<string>("name"));
 		}
 
-		public IRPCWalletClient CreateWallet(string walletNameOrPath, 
-			bool disablePrivateKeys = false, 
-			bool blank = false, 
-			string passphrase = null, 
-			bool avoidReuse = false,
-			bool descriptors = false,
-			bool? loadOnStartup = null)
+		public RPCClient CreateWallet(string walletNameOrPath, CreateWalletOptions? options = null)
 		{
-			var result = SendCommandAsync(RPCOperations.createwallet, walletNameOrPath, disablePrivateKeys, blank, passphrase, avoidReuse, descriptors, loadOnStartup).GetAwaiter().GetResult();
-			return GetWallet(result.Result.Value<string>("name"));
+			return CreateWalletAsync(walletNameOrPath, options).GetAwaiter().GetResult();
 		}
 
-		public async Task<IRPCWalletClient> LoadWalletAsync(string filename, bool? loadOnStartup = null)
+		public async Task<RPCClient> LoadWalletAsync(string filename, bool? loadOnStartup = null)
 		{
 			var result =  await SendCommandAsync(RPCOperations.loadwallet, filename, loadOnStartup).ConfigureAwait(false);
 			return GetWallet(result.Result.Value<string>("name"));
 		}
 
-		public IRPCWalletClient LoadWallet(string filename, bool? loadOnStartup = null)
+		public RPCClient LoadWallet(string filename, bool? loadOnStartup = null)
 		{
 			var result = SendCommandAsync(RPCOperations.loadwallet, filename, loadOnStartup).GetAwaiter().GetResult();
 			return GetWallet(result.Result.Value<string>("name"));
@@ -366,6 +207,8 @@ namespace NBitcoin.RPC
 		{
 			SendCommandAsync(RPCOperations.unloadwallet, loadOnStartup).GetAwaiter().GetResult();
 		}
+
+		#nullable restore
 
 		// backupwallet
 		public void BackupWallet(string path)

--- a/NBitcoin/RPC/RPCClient.Wallet.cs
+++ b/NBitcoin/RPC/RPCClient.Wallet.cs
@@ -782,7 +782,7 @@ namespace NBitcoin.RPC
 			return ListLockUnspentAsync().GetAwaiter().GetResult();
 		}
 
-		// abandom transaction
+		// abandon transaction
 
 		/// <summary>
 		/// Marks a transaction and all its in-wallet descendants as abandoned which will allow

--- a/NBitcoin/RPC/RPCClient.Wallet.cs
+++ b/NBitcoin/RPC/RPCClient.Wallet.cs
@@ -163,19 +163,24 @@ namespace NBitcoin.RPC
 
 		public async Task<RPCClient> CreateWalletAsync(string walletNameOrPath, CreateWalletOptions? options = null)
 		{
+			if (string.IsNullOrEmpty(walletNameOrPath)) throw new ArgumentNullException(nameof(walletNameOrPath));
+
 			var parameters = new Dictionary<string, object>();
 			parameters.Add("wallet_name", walletNameOrPath);
 			if (options is { })
 			{
-				parameters.Add("disable_private_keys", options.DisablePrivateKeys.ToString());
-				parameters.Add("blank", options.Blank.ToString());
-				if (!string.IsNullOrEmpty(options.Passphrase))
-					parameters.Add("passphrase", options.Passphrase);
-
-				parameters.Add("avoid_reuse", options.AvoidReuse.ToString());
-				parameters.Add("descriptors", options.Descriptors.ToString());
-				if (options.LoadOnStartup.HasValue)
-					parameters.Add("load_on_startup", options.LoadOnStartup.ToString());
+				if (options.DisablePrivateKeys is { })
+					parameters.Add("disable_private_keys", options.DisablePrivateKeys.ToString());
+				if (options.Blank is { })
+					parameters.Add("blank", options.Blank.ToString());
+				if (options.Passphrase is string passphrase && passphrase.Length > 0)
+					parameters.Add("passphrase", passphrase);
+				if (options.AvoidReuse is { })
+					parameters.Add("avoid_reuse", options.AvoidReuse.ToString());
+				if (options.AvoidReuse is { })
+					parameters.Add("descriptors", options.Descriptors.ToString());
+				if (options.LoadOnStartup is bool loadOnStartup)
+					parameters.Add("load_on_startup", loadOnStartup.ToString());
 			}
 			var result = await SendCommandWithNamedArgsAsync(RPCOperations.createwallet.ToString(), parameters).ConfigureAwait(false);
 			return GetWallet(result.Result.Value<string>("name"));
@@ -183,17 +188,23 @@ namespace NBitcoin.RPC
 
 		public RPCClient CreateWallet(string walletNameOrPath, CreateWalletOptions? options = null)
 		{
+			if (string.IsNullOrEmpty(walletNameOrPath)) throw new ArgumentNullException(nameof(walletNameOrPath));
+
 			return CreateWalletAsync(walletNameOrPath, options).GetAwaiter().GetResult();
 		}
 
 		public async Task<RPCClient> LoadWalletAsync(string filename, bool? loadOnStartup = null)
 		{
+			if (string.IsNullOrEmpty(filename)) throw new ArgumentNullException(nameof(filename));
+
 			var result =  await SendCommandAsync(RPCOperations.loadwallet, filename, loadOnStartup).ConfigureAwait(false);
 			return GetWallet(result.Result.Value<string>("name"));
 		}
 
 		public RPCClient LoadWallet(string filename, bool? loadOnStartup = null)
 		{
+			if (string.IsNullOrEmpty(filename)) throw new ArgumentNullException(nameof(filename));
+
 			var result = SendCommandAsync(RPCOperations.loadwallet, filename, loadOnStartup).GetAwaiter().GetResult();
 			return GetWallet(result.Result.Value<string>("name"));
 		}
@@ -791,6 +802,8 @@ namespace NBitcoin.RPC
 		/// <param name="txId">the transaction id to be marked as abandoned.</param>
 		public void AbandonTransaction(uint256 txId)
 		{
+			if (txId is null) throw new ArgumentNullException(nameof(txId));
+
 			SendCommand(RPCOperations.abandontransaction, txId.ToString());
 		}
 
@@ -801,6 +814,8 @@ namespace NBitcoin.RPC
 		/// <param name="txId">the transaction id to be marked as abandoned.</param>
 		public async Task AbandonTransactionAsync(uint256 txId)
 		{
+			if (txId is null) throw new ArgumentNullException(nameof(txId));
+
 			await SendCommandAsync(RPCOperations.abandontransaction, txId.ToString()).ConfigureAwait(false);
 		}
 

--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -2282,7 +2282,7 @@ namespace NBitcoin.RPC
 				catch (RPCException rpc) when (
 					rpc.RPCCode == RPCErrorCode.RPC_METHOD_DEPRECATED 
 					|| rpc.RPCCode == RPCErrorCode.RPC_METHOD_NOT_FOUND 
-					|| (rpc.RPCCode == RPCErrorCode.RPC_MISC_ERROR && rpc.Message.StartsWith("generate\nhas been replaced by the -generate cli option")))
+					|| (rpc.RPCCode == RPCErrorCode.RPC_MISC_ERROR))
 				{
 					var address = await GetNewAddressAsync();
 					return await GenerateToAddressAsync(nBlocks, address);
@@ -2337,6 +2337,8 @@ namespace NBitcoin.RPC
 		/// </summary>
 		public bool AddPeerAddress(IPAddress ip, int port)
 		{
+			if (ip is null) throw new ArgumentNullException(nameof(ip));
+
 			return AddPeerAddressAsync(ip, port).GetAwaiter().GetResult();
 		}
 
@@ -2345,6 +2347,8 @@ namespace NBitcoin.RPC
 		/// </summary>
 		public async Task<bool> AddPeerAddressAsync(IPAddress ip, int port)
 		{
+			if (ip is null) throw new ArgumentNullException(nameof(ip));
+
 			var result = await SendCommandAsync(RPCOperations.addpeeraddress, ip.ToString(), port).ConfigureAwait(false);
 			return result.Result["success"].Value<bool>();
 		}

--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -2346,7 +2346,7 @@ namespace NBitcoin.RPC
 		public async Task<bool> AddPeerAddressAsync(IPAddress ip, int port)
 		{
 			var result = await SendCommandAsync(RPCOperations.addpeeraddress, ip.ToString(), port).ConfigureAwait(false);
-			return ((JValue)result.Result).Value<bool>();
+			return result.Result["success"].Value<bool>();
 		}
 
 #endif 

--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -1183,7 +1183,7 @@ namespace NBitcoin.RPC
 					StartingHeight = (int)peer["startingheight"],
 					SynchronizedBlocks = (int)peer["synced_blocks"],
 					SynchronizedHeaders = (int)peer["synced_headers"],
-					IsWhiteListed = (bool)peer["whitelisted"],
+					IsWhiteListed = peer["whitelisted"] != null ? (bool)peer["whitelisted"] : false,
 					BanScore = peer["banscore"] == null ? 0 : (int)peer["banscore"],
 					Inflight = peer["inflight"].Select(x => uint.Parse((string)x)).ToArray()
 				};
@@ -2279,7 +2279,10 @@ namespace NBitcoin.RPC
 					var result = (JArray)(await SendCommandAsync(RPCOperations.generate, nBlocks).ConfigureAwait(false)).Result;
 					return result.Select(r => new uint256(r.Value<string>())).ToArray();
 				}
-				catch (RPCException rpc) when (rpc.RPCCode == RPCErrorCode.RPC_METHOD_DEPRECATED || rpc.RPCCode == RPCErrorCode.RPC_METHOD_NOT_FOUND)
+				catch (RPCException rpc) when (
+					rpc.RPCCode == RPCErrorCode.RPC_METHOD_DEPRECATED 
+					|| rpc.RPCCode == RPCErrorCode.RPC_METHOD_NOT_FOUND 
+					|| (rpc.RPCCode == RPCErrorCode.RPC_MISC_ERROR && rpc.Message.StartsWith("generate\nhas been replaced by the -generate cli option")))
 				{
 					var address = await GetNewAddressAsync();
 					return await GenerateToAddressAsync(nBlocks, address);
@@ -2327,25 +2330,26 @@ namespace NBitcoin.RPC
 			await SendCommandAsync(RPCOperations.invalidateblock, blockhash).ConfigureAwait(false);
 		}
 
+#if !NOSOCKET
+
 		/// <summary>
-		/// Marks a transaction and all its in-wallet descendants as abandoned which will allow
-		/// for their inputs to be respent.
+		/// Add the address of a potential peer to the address manager. This RPC is for testing only.
 		/// </summary>
-		/// <param name="txId">the transaction id to be marked as abandoned.</param>
-		public void AbandonTransaction(uint256 txId)
+		public bool AddPeerAddress(IPAddress ip, int port)
 		{
-			SendCommand(RPCOperations.abandontransaction, txId.ToString());
+			return AddPeerAddressAsync(ip, port).GetAwaiter().GetResult();
 		}
 
 		/// <summary>
-		/// Marks a transaction and all its in-wallet descendants as abandoned which will allow
-		/// for their inputs to be respent.
+		/// Add the address of a potential peer to the address manager. This RPC is for testing only.
 		/// </summary>
-		/// <param name="txId">the transaction id to be marked as abandoned.</param>
-		public async Task AbandonTransactionAsync(uint256 txId)
+		public async Task<bool> AddPeerAddressAsync(IPAddress ip, int port)
 		{
-			await SendCommandAsync(RPCOperations.abandontransaction, txId.ToString()).ConfigureAwait(false);
+			var result = await SendCommandAsync(RPCOperations.addpeeraddress, ip.ToString(), port).ConfigureAwait(false);
+			return ((JValue)result.Result).Value<bool>();
 		}
+
+#endif 
 
 		#endregion
 	}

--- a/NBitcoin/RPC/RPCOperations.cs
+++ b/NBitcoin/RPC/RPCOperations.cs
@@ -117,6 +117,10 @@ namespace NBitcoin.RPC
 		scantxoutset,
 		getmempoolentry,
 		stop,
-		uptime
+		uptime,
+		createwallet,
+		loadwallet,
+		unloadwallet,
+		addpeeraddress,
 	}
 }


### PR DESCRIPTION
## Update NBitcoin to support RPC changes in Bitcoin Core 0.21.0.

Bitcoin core doesn't start a default wallet anymore and for that reason all the RPC tests that need a wallet fail. The solution implemented in this PR is to create an empty wallet called `wallet.dat` using the `bitcoin-wallet` command line tool.

Additionally I have created a new interface called `IRPCWalletClient` that improves usability of the rpc interface when we need to invoke wallet related rpc calls because it lists only the wallet-related calls.

The batch rpc can only work with one wallet at a time, that restriction is not new and it is because the wallet name is parts of the URL.

 I added the `CreateWallet`, `LoadWallet` and `UnloadWallet` rpc calls.

--------------

It would be good if this PR can be reviewed and merged (after all the recommendations/suggestions/fixes) because this is needed to test the other PR https://github.com/MetacoSA/NBitcoin/pull/940 given it needs 0.21.0 which implements the bip155.
