### PR TITLE
Make sure to clean the key material

### DIFF
--- a/NBitcoin/Key.cs
+++ b/NBitcoin/Key.cs
@@ -483,29 +483,37 @@ namespace NBitcoin
 #endif
 		}
 
+		bool disposed = false;
 
-#if HAS_SPAN
-		void AssertNotDiposed()
-		{
-			if (_ECKey.cleared)
-				throw new ObjectDisposedException(nameof(NBitcoin.Key));
-		}
 		public void Dispose()
 		{
-			_ECKey.Clear();
+			Dispose(true);
+			GC.SuppressFinalize(this);
 		}
-#else
-		bool disposed = false;
+
 		void AssertNotDiposed()
 		{
 			if (disposed)
 				throw new ObjectDisposedException(nameof(NBitcoin.Key));
 		}
-		public void Dispose()
+
+		protected virtual void Dispose(bool disposing)
 		{
+			if (disposed)
+				return;
+			
+			if (disposing)
+			{
+				if (_ECKey is IDisposable keyMaterial)
+					keyMaterial.Dispose();
+			}
 			disposed = true;
 		}
-#endif
+
+		~Key()
+		{
+			Dispose(false);
+		}
 	}
 }
 #nullable disable

--- a/NBitcoin/Secp256k1/ECPrivKey.cs
+++ b/NBitcoin/Secp256k1/ECPrivKey.cs
@@ -879,9 +879,23 @@ namespace NBitcoin.Secp256k1
 			return true;
 		}
 
+		protected virtual void Dispose(bool disposing)
+		{
+			if (this.cleared)
+				return;
+				
+			Clear();
+		}
+
 		public void Dispose()
 		{
-			Clear();
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
+
+		~ECPrivKey()
+		{
+			Dispose(false);
 		}
 
 		public void Clear()


### PR DESCRIPTION
The `Key` type was not always `IDisposable` and for that reason I would expect many projects do not dispose the keys explicitly nor using an `using` statement neither. However, I think it is important to clean the key from memory so keys are not leaked by a core crash dump or other means.

This PR implements a destructor/finalizer that disposes the private keys in case the `Dispose` is not invoked, what I think could be the case in some projects.  