### PR TITLE
Obsolete NetworkType, replace with ChainName

### DIFF
--- a/NBitcoin.Tests/AltcoinTests.cs
+++ b/NBitcoin.Tests/AltcoinTests.cs
@@ -31,9 +31,14 @@ namespace NBitcoin.Tests
 				Assert.Equal(network.Regtest.NetworkSet, network.Testnet.NetworkSet);
 				Assert.Equal(network.Mainnet.NetworkSet, network.Testnet.NetworkSet);
 				Assert.Equal(network, network.Testnet.NetworkSet);
+#pragma warning disable CS0618 // Type or member is obsolete
 				Assert.Equal(NetworkType.Mainnet, network.Mainnet.NetworkType);
 				Assert.Equal(NetworkType.Testnet, network.Testnet.NetworkType);
 				Assert.Equal(NetworkType.Regtest, network.Regtest.NetworkType);
+#pragma warning restore CS0618 // Type or member is obsolete
+				Assert.Equal(ChainName.Mainnet, network.Mainnet.ChainName);
+				Assert.Equal(ChainName.Testnet, network.Testnet.ChainName);
+				Assert.Equal(ChainName.Regtest, network.Regtest.ChainName);
 				Assert.Equal(network.CryptoCode, network.CryptoCode.ToUpperInvariant());
 				Assert.Equal(network.Mainnet, Network.GetNetwork(network.CryptoCode.ToLowerInvariant() + "-mainnet"));
 				Assert.Equal(network.Testnet, Network.GetNetwork(network.CryptoCode.ToLowerInvariant() + "-testnet"));

--- a/NBitcoin.Tests/Generators/ChainParamsGenerator.cs
+++ b/NBitcoin.Tests/Generators/ChainParamsGenerator.cs
@@ -16,7 +16,7 @@ namespace NBitcoin.Tests.Generators
 					Gen.Constant(Network.RegTest)
 			});
 
-		public static Gen<NetworkType> NetworkType =>
-			NetworkGen().Select(n => n.NetworkType);
+		public static Gen<ChainName> NetworkType =>
+			NetworkGen().Select(n => n.ChainName);
 	}
 }

--- a/NBitcoin/Bitcoin.cs
+++ b/NBitcoin/Bitcoin.cs
@@ -1,5 +1,7 @@
-﻿using System;
+﻿using NBitcoin.Crypto;
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -10,8 +12,76 @@ namespace NBitcoin
 	{
 		private Bitcoin()
 		{
-
 		}
+
+		private Network CreateSignet()
+		{
+			NetworkBuilder builder = new NetworkBuilder();
+			builder.SetChainName(SignetName);
+			builder.SetNetworkSet(this);
+			builder.SetConsensus(new Consensus()
+			{
+				SubsidyHalvingInterval = 210000,
+				MajorityEnforceBlockUpgrade = 750,
+				MajorityRejectBlockOutdated = 950,
+				MajorityWindow = 1000,
+				BIP34Hash = new uint256(),
+				PowLimit = new Target(new uint256("00000377ae000000000000000000000000000000000000000000000000000000")),
+				PowTargetTimespan = TimeSpan.FromSeconds(14 * 24 * 60 * 60),
+				PowTargetSpacing = TimeSpan.FromSeconds(10 * 60),
+				PowAllowMinDifficultyBlocks = false,
+				PowNoRetargeting = false,
+				RuleChangeActivationThreshold = 1916,
+				MinerConfirmationWindow = 2016,
+				CoinbaseMaturity = 100,
+				//ConsensusFactory = LitecoinConsensusFactory.Instance
+			})
+			.SetBase58Bytes(Base58Type.PUBKEY_ADDRESS, new byte[] { 111 })
+			.SetBase58Bytes(Base58Type.SCRIPT_ADDRESS, new byte[] { 196 })
+			.SetBase58Bytes(Base58Type.SECRET_KEY, new byte[] { 239 })
+			.SetBase58Bytes(Base58Type.EXT_PUBLIC_KEY, new byte[] { 0x04, 0x35, 0x87, 0xCF })
+			.SetBase58Bytes(Base58Type.EXT_SECRET_KEY, new byte[] { 0x04, 0x35, 0x83, 0x94 })
+			.SetBech32(Bech32Type.WITNESS_PUBKEY_ADDRESS, "tb")
+			.SetBech32(Bech32Type.WITNESS_SCRIPT_ADDRESS, "tb")
+			//.SetNetworkStringParser(new LitecoinMainnetAddressStringParser())
+			//.SetBech32(Bech32Type.WITNESS_PUBKEY_ADDRESS, Encoders.Bech32("ltc"))
+			//.SetBech32(Bech32Type.WITNESS_SCRIPT_ADDRESS, Encoders.Bech32("ltc"))
+			.SetMagic(GetSignetMagic())
+			.SetPort(38333)
+			.SetRPCPort(38332)
+			.SetName("signet")
+			.AddAlias("bitcoin-signet")
+			.AddAlias("btc-signet")
+			//.AddDNSSeeds(new[]
+			//{
+			//	new DNSSeedData("loshan.co.uk", "seed-a.litecoin.loshan.co.uk"),
+			//	new DNSSeedData("thrasher.io", "dnsseed.thrasher.io"),
+			//	new DNSSeedData("litecointools.com", "dnsseed.litecointools.com"),
+			//	new DNSSeedData("litecoinpool.org", "dnsseed.litecoinpool.org"),
+			//	new DNSSeedData("koin-project.com", "dnsseed.koin-project.com"),
+			//})
+			//.AddSeeds(ToSeed(pnSeed6_main))
+			.SetGenesis("0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a008f4d5fae77031e8ad222030101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff4d04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73ffffffff0100f2052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac00000000");
+			var network = builder.BuildAndRegister();
+#if !NOFILEIO
+			var data = Network.GetDefaultDataFolder("bitcoin");
+			var signetCookie = Path.Combine(data, "signet", ".cookie");
+			RPC.RPCClient.RegisterDefaultCookiePath(network, signetCookie);
+#endif
+			return network;
+		}
+
+		private static uint GetSignetMagic()
+		{
+			var challengeBytes = DataEncoders.Encoders.Hex.DecodeData("512103ad5e0edad18cb1f0fc0d28a3d4f1f3e445640337489abb10404f2d1e086be430210359ef5021964fe22d6f8e05b2463c9540ce96883fe3b278760f048f5189f2e6c452ae");
+			var challenge = new Script(challengeBytes);
+			MemoryStream ms = new MemoryStream();
+			BitcoinStream bitcoinStream = new BitcoinStream(ms, true);
+			bitcoinStream.ReadWrite(challenge);
+			var h = Hashes.DoubleSHA256RawBytes(ms.ToArray(), 0, (int)ms.Length);
+			return Utils.ToUInt32(h, true);
+		}
+
 		public static Bitcoin Instance { get; } = new Bitcoin();
 
 		public Network Mainnet => Network.Main;
@@ -36,7 +106,9 @@ namespace NBitcoin
 			}
 			throw new NotSupportedException(networkType.ToString());
 		}
+		static readonly ChainName SignetName = new ChainName("Signet");
 
+		public Network Signet { get; private set; }
 		public Network GetNetwork(ChainName chainName)
 		{
 			if (chainName == null)
@@ -47,7 +119,14 @@ namespace NBitcoin
 				return Testnet;
 			if (chainName == ChainName.Regtest)
 				return Regtest;
+			if (chainName == SignetName)
+				return Signet;
 			throw new NotSupportedException(chainName.ToString());
+		}
+
+		internal void InitSignet()
+		{
+			Signet = CreateSignet();
 		}
 	}
 }

--- a/NBitcoin/Bitcoin.cs
+++ b/NBitcoin/Bitcoin.cs
@@ -22,6 +22,7 @@ namespace NBitcoin
 
 		public string CryptoCode => "BTC";
 
+		[Obsolete("Use GetNetwork(ChainName.Mainnet/Testnet/Regtest) instead.")]
 		public Network GetNetwork(NetworkType networkType)
 		{
 			switch (networkType)
@@ -34,6 +35,19 @@ namespace NBitcoin
 					return Regtest;
 			}
 			throw new NotSupportedException(networkType.ToString());
+		}
+
+		public Network GetNetwork(ChainName chainName)
+		{
+			if (chainName == null)
+				throw new ArgumentNullException(nameof(chainName));
+			if (chainName == ChainName.Mainnet)
+				return Mainnet;
+			if (chainName == ChainName.Testnet)
+				return Testnet;
+			if (chainName == ChainName.Regtest)
+				return Regtest;
+			throw new NotSupportedException(chainName.ToString());
 		}
 	}
 }

--- a/NBitcoin/Network.cs
+++ b/NBitcoin/Network.cs
@@ -11,6 +11,7 @@ using NBitcoin.Protocol;
 using NBitcoin.Stealth;
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
+using System.ComponentModel;
 
 namespace NBitcoin
 {
@@ -49,11 +50,92 @@ namespace NBitcoin
 		}
 	}
 
+	[Obsolete("Use ChainName.Mainnet/Testnet/Regtest instead")]
 	public enum NetworkType
 	{
 		Mainnet,
 		Testnet,
 		Regtest
+	}
+	public class ChainName
+	{
+		static ChainName()
+		{
+			Mainnet = new ChainName("Mainnet");
+			Testnet = new ChainName("Testnet");
+			Regtest = new ChainName("Regtest");
+		}
+		public static ChainName Mainnet { get; }
+		public static ChainName Testnet { get; }
+		public static ChainName Regtest { get; }
+
+		private readonly string name;
+		private readonly string nameInvariant;
+
+		public ChainName(string chainName)
+		{
+			if (chainName == null)
+				throw new ArgumentNullException(nameof(chainName));
+			this.name = chainName;
+			this.nameInvariant = chainName.ToUpperInvariant();
+		}
+
+		public override bool Equals(object obj)
+		{
+			ChainName? item = obj as ChainName;
+			if (item is null)
+				return false;
+			return nameInvariant.Equals(item.nameInvariant);
+		}
+		public static bool operator ==(ChainName a, ChainName b)
+		{
+			if (a is ChainName && b is ChainName)
+				return a.nameInvariant == b.nameInvariant;
+			if (a is null && b is null)
+				return true;
+			return false;
+		}
+
+		public static bool operator !=(ChainName a, ChainName b)
+		{
+			return !(a == b);
+		}
+
+		public override int GetHashCode()
+		{
+			return nameInvariant.GetHashCode();
+		}
+		public override string ToString()
+		{
+			return name;
+		}
+
+		[Obsolete("Do not use NetworkType anymore, use ChainName instead")]
+		public NetworkType ToNetworkType()
+		{
+			if (this == ChainName.Mainnet)
+				return NetworkType.Mainnet;
+			if (this == ChainName.Testnet)
+				return NetworkType.Testnet;
+			if (this == ChainName.Regtest)
+				return NetworkType.Regtest;
+			throw new NotSupportedException($"Impossible to convert ChainName {name} to NetworkType");
+		}
+		[Obsolete("Do not use NetworkType anymore, use ChainName instead")]
+		public static ChainName FromNetworkType(NetworkType network)
+		{
+			switch(network)
+			{
+				case NetworkType.Mainnet:
+					return ChainName.Mainnet;
+				case NetworkType.Testnet:
+					return ChainName.Testnet;
+				case NetworkType.Regtest:
+					return ChainName.Regtest;
+				default:
+					throw new NotSupportedException($"Unsupported network type {network}");
+			}
+		}
 	}
 
 	public enum Base58Type
@@ -1994,12 +2076,22 @@ namespace NBitcoin
 			}
 		}
 
-		private NetworkType networkType;
+		private ChainName? chainName;
+		[Obsolete("Use ChainName instead")]
 		public NetworkType NetworkType
 		{
 			get
 			{
-				return networkType;
+				return ChainName.ToNetworkType();
+			}
+		}
+		public ChainName ChainName
+		{
+			get
+			{
+				if (chainName is null)
+					throw new InvalidOperationException("Network.ChainName is not set"); 
+				return chainName;
 			}
 		}
 
@@ -2074,7 +2166,7 @@ namespace NBitcoin
 			if (GetNetwork(builder._Name) != null)
 				throw new InvalidOperationException("The network " + builder._Name + " is already registered");
 			Network network = new Network(builder._Name, builder._Genesis.ToArray(), builder._Magic, builder._NetworkSet);
-			network.networkType = builder._NetworkType;
+			network.chainName = builder._ChainName;
 			network.consensus = builder._Consensus;
 			network.nDefaultPort = builder._Port;
 			network.nRPCPort = builder._RPCPort;
@@ -2117,7 +2209,7 @@ namespace NBitcoin
 					_OtherAliases.Add(alias.ToLowerInvariant(), network);
 				}
 				_OtherAliases.Add(network.name.ToLowerInvariant(), network);
-				var defaultAlias = network._NetworkSet.CryptoCode.ToLowerInvariant() + "-" + network.NetworkType.ToString().ToLowerInvariant();
+				var defaultAlias = network._NetworkSet.CryptoCode.ToLowerInvariant() + "-" + network.ChainName.ToString().ToLowerInvariant();
 				if (!_OtherAliases.ContainsKey(defaultAlias))
 					_OtherAliases.Add(defaultAlias, network);
 			}
@@ -2135,7 +2227,7 @@ namespace NBitcoin
 		const uint BITCOIN_MAX_P2P_VERSION = 70012;
 		private void InitMain()
 		{
-			networkType = NetworkType.Mainnet;
+			chainName = ChainName.Mainnet;
 			MaxP2PVersion = BITCOIN_MAX_P2P_VERSION;
 			consensus.CoinbaseMaturity = 100;
 			consensus.SubsidyHalvingInterval = 210000;
@@ -2212,8 +2304,8 @@ namespace NBitcoin
 		}
 		private void InitTest()
 		{
-			_TestNet.networkType = NetworkType.Testnet;
-			networkType = NetworkType.Testnet;
+			_TestNet.chainName = ChainName.Testnet;
+			chainName = ChainName.Testnet;
 			MaxP2PVersion = BITCOIN_MAX_P2P_VERSION;
 			consensus.SubsidyHalvingInterval = 210000;
 			consensus.MajorityEnforceBlockUpgrade = 51;
@@ -2288,7 +2380,7 @@ namespace NBitcoin
 		}
 		private void InitReg()
 		{
-			networkType = NetworkType.Regtest;
+			chainName = ChainName.Regtest;
 			MaxP2PVersion = BITCOIN_MAX_P2P_VERSION;
 			consensus.SubsidyHalvingInterval = 150;
 			consensus.MajorityEnforceBlockUpgrade = 750;

--- a/NBitcoin/Network.cs
+++ b/NBitcoin/Network.cs
@@ -644,6 +644,19 @@ namespace NBitcoin
 				throw new InvalidOperationException("This instance can't be modified");
 		}
 
+		bool _SupportTaproot = true;
+		public bool SupportTaproot
+		{
+			get
+			{
+				return _SupportTaproot;
+			}
+			set
+			{
+				EnsureNotFrozen();
+				_SupportTaproot = value;
+			}
+		}
 
 		bool _SupportSegwit = true;
 		public bool SupportSegwit
@@ -712,6 +725,7 @@ namespace NBitcoin
 			consensus._ConsensusFactory = _ConsensusFactory;
 			consensus._LitecoinWorkCalculation = _LitecoinWorkCalculation;
 			consensus._SupportSegwit = _SupportSegwit;
+			consensus._SupportTaproot = _SupportTaproot;
 			consensus._NeverNeedPreviousTxForSigning = _NeverNeedPreviousTxForSigning;
 		}
 	}
@@ -2117,6 +2131,7 @@ namespace NBitcoin
 				NBitcoin.Bitcoin.Instance);
 			_RegTest.InitReg();
 			_RegTest.Consensus.Freeze();
+			Bitcoin.Instance.InitSignet();
 		}
 
 		static Network _Main;
@@ -2158,6 +2173,25 @@ namespace NBitcoin
 				return _NetworkSet;
 			}
 		}
+#if !NOFILEIO
+		/// <summary>
+		/// Returns the default data directory of bitcoin correctly accross OS
+		/// </summary>
+		/// <param name="folderName">The name of the folder</param>
+		/// <returns>The full path to the data directory of Bitcoin</returns>
+		public static string? GetDefaultDataFolder(string folderName)
+		{
+			var home = Environment.GetEnvironmentVariable("HOME");
+			var localAppData = Environment.GetEnvironmentVariable("APPDATA");
+			if (string.IsNullOrEmpty(home) && string.IsNullOrEmpty(localAppData))
+				return null;
+			if (!string.IsNullOrEmpty(home) && string.IsNullOrEmpty(localAppData))
+				return Path.Combine(home, "." + folderName.ToLowerInvariant());
+			else if (!string.IsNullOrEmpty(localAppData))
+				return Path.Combine(localAppData, char.ToUpperInvariant(folderName[0]) + folderName.Substring(1));
+			return null;
+		}
+#endif
 
 		internal static Network Register(NetworkBuilder builder)
 		{

--- a/NBitcoin/NetworkBuilder.cs
+++ b/NBitcoin/NetworkBuilder.cs
@@ -14,7 +14,7 @@ namespace NBitcoin
 	{
 		internal NetworkStringParser _NetworkStringParser = new NetworkStringParser();
 		internal string _Name;
-		internal NetworkType _NetworkType;
+		internal ChainName _ChainName;
 		internal Dictionary<Base58Type, byte[]> _Base58Prefixes = new Dictionary<Base58Type, byte[]>();
 		internal Dictionary<Bech32Type, Bech32Encoder> _Bech32Prefixes = new Dictionary<Bech32Type, Bech32Encoder>();
 		internal List<string> _Aliases = new List<string>();
@@ -69,7 +69,7 @@ namespace NBitcoin
 			SetRPCPort(network.RPCPort);
 			SetNetworkStringParser(network.NetworkStringParser);
 			SetNetworkSet(network.NetworkSet);
-			SetNetworkType(network.NetworkType);
+			SetChainName(network.ChainName);
 		}
 
 		public NetworkBuilder SetNetworkStringParser(NetworkStringParser networkStringParser)
@@ -144,9 +144,15 @@ namespace NBitcoin
 			return this;
 		}
 
+		[Obsolete("Use SetChainName instead")]
 		public NetworkBuilder SetNetworkType(NetworkType network)
 		{
-			_NetworkType = network;
+			_ChainName = ChainName.FromNetworkType(network);
+			return this;
+		}
+		public NetworkBuilder SetChainName(ChainName chainName)
+		{
+			_ChainName = chainName;
 			return this;
 		}
 

--- a/NBitcoin/NetworkSet.cs
+++ b/NBitcoin/NetworkSet.cs
@@ -12,7 +12,9 @@ namespace NBitcoin
 {
 	public interface INetworkSet
 	{
+		[Obsolete("Use GetNetwork(ChainName.Mainnet/Testnet/Regtest) instead.")]
 		Network GetNetwork(NetworkType networkType);
+		Network GetNetwork(ChainName chainName);
 		Network Mainnet
 		{
 			get;
@@ -36,6 +38,7 @@ namespace NBitcoin
 		public NetworkSetBase()
 		{
 		}
+		[Obsolete("Use GetNetwork(ChainName.Mainnet/Testnet/Regtest) instead.")]
 		public Network GetNetwork(NetworkType networkType)
 		{
 			switch (networkType)
@@ -48,6 +51,18 @@ namespace NBitcoin
 					return Regtest;
 			}
 			throw new NotSupportedException(networkType.ToString());
+		}
+		public virtual Network GetNetwork(ChainName chainName)
+		{
+			if (chainName == null)
+				throw new ArgumentNullException(nameof(chainName));
+			if (chainName == ChainName.Mainnet)
+				return Mainnet;
+			if (chainName == ChainName.Testnet)
+				return Testnet;
+			if (chainName == ChainName.Regtest)
+				return Regtest;
+			throw new NotSupportedException(chainName.ToString());
 		}
 
 		volatile bool _Registered;
@@ -66,21 +81,21 @@ namespace NBitcoin
 				var builder = CreateMainnet();
 				if (builder != null)
 				{
-					builder.SetNetworkType(NetworkType.Mainnet);
+					builder.SetChainName(ChainName.Mainnet);
 					builder.SetNetworkSet(this);
 					_Mainnet = builder.BuildAndRegister();
 				}
 				builder = CreateTestnet();
 				if (builder != null)
 				{
-					builder.SetNetworkType(NetworkType.Testnet);
+					builder.SetChainName(ChainName.Testnet);
 					builder.SetNetworkSet(this);
 					_Testnet = builder.BuildAndRegister();
 				}
 				builder = CreateRegtest();
 				if (builder != null)
 				{
-					builder.SetNetworkType(NetworkType.Regtest);
+					builder.SetChainName(ChainName.Regtest);
 					builder.SetNetworkSet(this);
 					_Regtest = builder.BuildAndRegister();
 				}

--- a/NBitcoin/NetworkSet.cs
+++ b/NBitcoin/NetworkSet.cs
@@ -165,57 +165,27 @@ namespace NBitcoin
 		protected void RegisterDefaultCookiePath(string folderName, FolderName folder = null)
 		{
 			folder = folder ?? new FolderName();
-			var home = Environment.GetEnvironmentVariable("HOME");
-			var localAppData = Environment.GetEnvironmentVariable("APPDATA");
-
-			if (string.IsNullOrEmpty(home) && string.IsNullOrEmpty(localAppData))
+			var bitcoinFolder = Network.GetDefaultDataFolder(folderName);
+			if (bitcoinFolder is null)
 				return;
 
-			if (!string.IsNullOrEmpty(home) && string.IsNullOrEmpty(localAppData))
+			if (Mainnet != null)
 			{
-				var bitcoinFolder = Path.Combine(home, "." + folderName.ToLowerInvariant());
-
-				if (Mainnet != null)
-				{
-					var mainnet = folder.MainnetFolder == null ? Path.Combine(bitcoinFolder, ".cookie")
-															   : Path.Combine(bitcoinFolder, folder.MainnetFolder, ".cookie");
-					;
-					RPCClient.RegisterDefaultCookiePath(Mainnet, mainnet);
-				}
-
-				if (Testnet != null)
-				{
-					var testnet = Path.Combine(bitcoinFolder, folder.TestnetFolder, ".cookie");
-					RPCClient.RegisterDefaultCookiePath(Testnet, testnet);
-				}
-
-				if (Regtest != null)
-				{
-					var regtest = Path.Combine(bitcoinFolder, folder.RegtestFolder, ".cookie");
-					RPCClient.RegisterDefaultCookiePath(Regtest, regtest);
-				}
+				var mainnet = folder.MainnetFolder == null ? Path.Combine(bitcoinFolder, ".cookie")
+														   : Path.Combine(bitcoinFolder, folder.MainnetFolder, ".cookie");
+				RPCClient.RegisterDefaultCookiePath(Mainnet, mainnet);
 			}
-			else if (!string.IsNullOrEmpty(localAppData))
+
+			if (Testnet != null)
 			{
-				var bitcoinFolder = Path.Combine(localAppData, char.ToUpperInvariant(folderName[0]) + folderName.Substring(1));
-				if (Mainnet != null)
-				{
-					var mainnet = folder.MainnetFolder == null ? Path.Combine(bitcoinFolder, ".cookie")
-															   : Path.Combine(bitcoinFolder, folder.MainnetFolder, ".cookie");
-					RPCClient.RegisterDefaultCookiePath(Mainnet, mainnet);
-				}
+				var testnet = Path.Combine(bitcoinFolder, folder.TestnetFolder, ".cookie");
+				RPCClient.RegisterDefaultCookiePath(Testnet, testnet);
+			}
 
-				if (Testnet != null)
-				{
-					var testnet = Path.Combine(bitcoinFolder, folder.TestnetFolder, ".cookie");
-					RPCClient.RegisterDefaultCookiePath(Testnet, testnet);
-				}
-
-				if (Regtest != null)
-				{
-					var regtest = Path.Combine(bitcoinFolder, folder.RegtestFolder, ".cookie");
-					RPCClient.RegisterDefaultCookiePath(Regtest, regtest);
-				}
+			if (Regtest != null)
+			{
+				var regtest = Path.Combine(bitcoinFolder, folder.RegtestFolder, ".cookie");
+				RPCClient.RegisterDefaultCookiePath(Regtest, regtest);
 			}
 		}
 

--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -266,39 +266,20 @@ namespace NBitcoin.RPC
 		static ConcurrentDictionary<Network, string> _DefaultPaths = new ConcurrentDictionary<Network, string>();
 		static RPCClient()
 		{
-#if !NOFILEIO
-			var home = Environment.GetEnvironmentVariable("HOME");
-			var localAppData = Environment.GetEnvironmentVariable("APPDATA");
 
-			if (string.IsNullOrEmpty(home) && string.IsNullOrEmpty(localAppData))
+#if !NOFILEIO
+			var bitcoinFolder = Network.GetDefaultDataFolder("bitcoin");
+			if (bitcoinFolder is null)
 				return;
 
-			if (!string.IsNullOrEmpty(home) && string.IsNullOrEmpty(localAppData))
-			{
-				var bitcoinFolder = Path.Combine(home, ".bitcoin");
+			var mainnet = Path.Combine(bitcoinFolder, ".cookie");
+			RegisterDefaultCookiePath(Network.Main, mainnet);
 
-				var mainnet = Path.Combine(bitcoinFolder, ".cookie");
-				RegisterDefaultCookiePath(Network.Main, mainnet);
+			var testnet = Path.Combine(bitcoinFolder, "testnet3", ".cookie");
+			RegisterDefaultCookiePath(Network.TestNet, testnet);
 
-				var testnet = Path.Combine(bitcoinFolder, "testnet3", ".cookie");
-				RegisterDefaultCookiePath(Network.TestNet, testnet);
-
-				var regtest = Path.Combine(bitcoinFolder, "regtest", ".cookie");
-				RegisterDefaultCookiePath(Network.RegTest, regtest);
-			}
-			else if (!string.IsNullOrEmpty(localAppData))
-			{
-				var bitcoinFolder = Path.Combine(localAppData, "Bitcoin");
-
-				var mainnet = Path.Combine(bitcoinFolder, ".cookie");
-				RegisterDefaultCookiePath(Network.Main, mainnet);
-
-				var testnet = Path.Combine(bitcoinFolder, "testnet3", ".cookie");
-				RegisterDefaultCookiePath(Network.TestNet, testnet);
-
-				var regtest = Path.Combine(bitcoinFolder, "regtest", ".cookie");
-				RegisterDefaultCookiePath(Network.RegTest, regtest);
-			}
+			var regtest = Path.Combine(bitcoinFolder, "regtest", ".cookie");
+			RegisterDefaultCookiePath(Network.RegTest, regtest);
 #endif
 		}
 		public static void RegisterDefaultCookiePath(Network network, string path)

--- a/NBitcoin/Utils.cs
+++ b/NBitcoin/Utils.cs
@@ -164,6 +164,17 @@ namespace NBitcoin
 			return repository.GetBlockAsync(blockId).GetAwaiter().GetResult();
 		}
 
+		public static T ToNetwork<T>(this T obj, ChainName chainName) where T : IBitcoinString
+		{
+			if (obj == null)
+				throw new ArgumentNullException(nameof(obj));
+			if (chainName == null)
+				throw new ArgumentNullException(nameof(chainName));
+			if (obj.Network.ChainName == chainName)
+				return obj;
+			return obj.ToNetwork(obj.Network.NetworkSet.GetNetwork(chainName));
+		}
+		[Obsolete("Use ToNetwork(ChainName) instead")]
 		public static T ToNetwork<T>(this T obj, NetworkType networkType) where T : IBitcoinString
 		{
 			if (obj.Network.NetworkType == networkType)


### PR DESCRIPTION
We want to support the next signet, as well as potentially new testnets.
Rather than changing the NetworkType enum everytimes there is a new type of network, I replace it by `ChainName` which can be a custom string.