### PR TITLE
Save mempool rpc call

### DIFF
--- a/NBitcoin.Tests/RPCClientTests.cs
+++ b/NBitcoin.Tests/RPCClientTests.cs
@@ -194,6 +194,25 @@ namespace NBitcoin.Tests
 		}
 
 		[Fact]
+		public void CanSaveMemPool()
+		{
+			using (var builder = NodeBuilderEx.Create())
+			{
+				var node = builder.CreateNode();
+				var rpc = node.CreateRPCClient();
+				builder.StartAll();
+				node.Generate(101);
+
+				var mempoolFilePath = Path.Combine(node.Folder, "data", "regtest", "mempool.dat");
+				File.Delete(mempoolFilePath);
+				Assert.False(File.Exists(mempoolFilePath));
+				rpc.SendToAddress(new Key().PubKey.GetAddress(ScriptPubKeyType.Legacy, rpc.Network), Money.Coins(1.0m), "hello", "world");
+				rpc.SaveMempool();
+				Assert.True(File.Exists(mempoolFilePath));
+			}
+		}
+
+		[Fact]
 		public async Task RPCBatchingCanFallbackIfAccessForbidden()
 		{
 			using (var builder = NodeBuilderEx.Create())

--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -57,6 +57,7 @@ namespace NBitcoin.RPC
 		blockchain		verifytxoutproof
 		blockchain		gettxoutsetinfo				Yes
 		blockchain		verifychain
+		blockchain		savemempool					Yes
 
 		------------------ Mining
 		mining			 getblocktemplate
@@ -1689,6 +1690,16 @@ namespace NBitcoin.RPC
 				SpentBy = jobj["spentby"]?.Select(x => uint256.Parse((string)x)).ToArray()
 			};
 		}
+
+		public async Task SaveMempoolAsync()
+		{
+			await SendCommandAsync(RPCOperations.savemempool).ConfigureAwait(false);
+		} 
+
+		public void SaveMempool()
+		{
+			SaveMempoolAsync().GetAwaiter().GetResult();
+		} 
 
 		private FeeRate AbsurdlyHighFee { get; } = new FeeRate(10_000M);
 

--- a/NBitcoin/RPC/RPCOperations.cs
+++ b/NBitcoin/RPC/RPCOperations.cs
@@ -122,5 +122,6 @@ namespace NBitcoin.RPC
 		loadwallet,
 		unloadwallet,
 		addpeeraddress,
+		savemempool,
 	}
 }


### PR DESCRIPTION
This PR implements the `savemempool` rpc method that is useful for dumping the mempool to disk periodically to be sure we don't lose it by corruption when kill the bitcoin process, the process crashes or the is a power outstage. 

Side note: this file is loaded automatically when bitcoin node starts (the behavior can be disabled by -persistmempool switch) 