### PR TITLE
Allow restrict connections depending their height

### DIFF
--- a/NBitcoin/Protocol/Node.cs
+++ b/NBitcoin/Protocol/Node.cs
@@ -60,6 +60,12 @@ namespace NBitcoin.Protocol
 			set;
 		}
 
+		public int? MinStartHeight
+		{
+			get;
+			set;
+		}
+
 		public bool SupportSPV
 		{
 			get;
@@ -80,6 +86,12 @@ namespace NBitcoin.Protocol
 			if (SupportSPV)
 			{
 				if (capabilities.SupportNodeBloom && ((version.Services & NodeServices.NODE_BLOOM) == 0))
+					return false;
+			}
+
+			if (MinStartHeight is { } minStartHeight)
+			{
+				if (version.StartHeight < minStartHeight)
 					return false;
 			}
 


### PR DESCRIPTION
This PR is for allowing clients to restrict connections to nodes that are at a minimum height (they can be in the synchronizing, for example). Clients that need to download mostly recent blocks could be interested in connecting only with those nodes that have more blocks than what they already know.

For example, here we can see nodes with different heights (one is synchronizing):

![image](https://user-images.githubusercontent.com/127973/106805942-17532180-6646-11eb-9dd5-6152bf3cd8b8.png)
 