### PR TITLE
Allow setting version number with TransactionBuilder

### DIFF
--- a/NBitcoin.Tests/transaction_tests.cs
+++ b/NBitcoin.Tests/transaction_tests.cs
@@ -4602,5 +4602,32 @@ namespace NBitcoin.Tests
 				);
 			}
 		}
+
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void CanSetVersion() {
+			var k = new Key();
+			var address = k.PubKey.WitHash.GetAddress(Network.Main);
+			var coins = new[] { RandomCoin(Money.Coins(10), k.ScriptPubKey, false) };
+
+			TransactionBuilder builder = Network.CreateTransactionBuilder();
+			builder.AddCoins(coins);
+			builder.AddKeys(k);
+			builder.Send(new Key().ScriptPubKey, Money.Coins(1));
+			builder.SendFees(Money.Coins(0.001m));
+			builder.SetChange(address);
+			var tx = builder.BuildTransaction(false);
+			Assert.Equal(1u, tx.Version);
+
+			builder = Network.CreateTransactionBuilder();
+			builder.AddCoins(coins);
+			builder.AddKeys(k);
+			builder.Send(new Key().ScriptPubKey, Money.Coins(1));
+			builder.SendFees(Money.Coins(0.001m));
+			builder.SetChange(address);
+			builder.SetVersion(2);
+			tx = builder.BuildTransaction(false);
+			Assert.Equal(2u, tx.Version);
+		}
 	}
 }

--- a/NBitcoin/TransactionBuilder.cs
+++ b/NBitcoin/TransactionBuilder.cs
@@ -851,6 +851,13 @@ namespace NBitcoin
 			return this;
 		}
 
+		uint _Version = 1;
+		public TransactionBuilder SetVersion(uint version)
+		{
+			_Version = version;
+			return this;
+		}
+
 		internal List<Key> _Keys = new List<Key>();
 
 		public TransactionBuilder AddKeys(params ISecret[] keys)
@@ -1669,6 +1676,7 @@ namespace NBitcoin
 			}
 			if (_LockTime != null)
 				ctx.Transaction.LockTime = _LockTime.Value;
+			ctx.Transaction.Version = _Version;
 			foreach (var group in _BuilderGroups)
 			{
 				ctx.SetGroup(group);


### PR DESCRIPTION
This PR allows setting the version number of a transaction built using `TransactionBuilder` via a new `TransactionBuilder.SetVersion(uint version)` method.

A test for this has also been added.