### PR TITLE
Unload Methods Update

### DIFF
--- a/NBitcoin/RPC/RPCClient.Wallet.cs
+++ b/NBitcoin/RPC/RPCClient.Wallet.cs
@@ -209,14 +209,14 @@ namespace NBitcoin.RPC
 			return GetWallet(result.Result.Value<string>("name"));
 		}
 
-		public async Task UnloadAsync(bool? loadOnStartup = null)
+		public async Task UnloadWalletAsync(string filename, bool? loadOnStartup = null)
 		{
-			var result = await SendCommandAsync(RPCOperations.loadwallet, loadOnStartup).ConfigureAwait(false);
+			var result = await SendCommandAsync(RPCOperations.loadwallet, filename, loadOnStartup).ConfigureAwait(false);
 		}
 
-		public void Unload(bool? loadOnStartup = null)
+		public void UnloadWallet(string filename, bool? loadOnStartup = null)
 		{
-			SendCommandAsync(RPCOperations.unloadwallet, loadOnStartup).GetAwaiter().GetResult();
+			SendCommandAsync(RPCOperations.unloadwallet, filename, loadOnStartup).GetAwaiter().GetResult();
 		}
 
 		#nullable restore


### PR DESCRIPTION
added string variable to Unload and UnloadAsync methods, as rpc command unloadwallet requires a "walletname" reference

changed method names from Unload to UnloadWallet and UnloadAsync to UnloadWalletAsync