### PR TITLE
Refactor the NetworkAddress

### DIFF
--- a/NBitcoin.Tests/NetworkAddressTests.cs
+++ b/NBitcoin.Tests/NetworkAddressTests.cs
@@ -20,7 +20,7 @@ namespace NBitcoin.Tests
 
 			// TORv2
 			Assert.True(addr.SetSpecial("6hzph5hv6337r6p2.onion"));
-			Assert.True(addr.IsTor);
+			Assert.True(addr.AddressType == NetworkAddressType.Onion);
 
 			Assert.True(addr.IsAddrV1Compatible);
 			Assert.Equal("6hzph5hv6337r6p2.onion", addr.ToAddressString());
@@ -28,7 +28,7 @@ namespace NBitcoin.Tests
 			// TORv3
 			var torv3_addr = "pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion";
 			Assert.True(addr.SetSpecial(torv3_addr));
-			Assert.True(addr.IsTor);
+			Assert.True(addr.AddressType == NetworkAddressType.Onion);
 
 			Assert.False(addr.IsAddrV1Compatible);
 			Assert.Equal(addr.ToAddressString(), torv3_addr);
@@ -51,7 +51,7 @@ namespace NBitcoin.Tests
 			// I2P
 			var i2p_addr = "udhdrtrcetjm5sxzskjyr5ztpeszydbh4dpl3pl4utgqqw2v4jna.b32.i2p";
 			Assert.True(addr.SetSpecial(i2p_addr));
-			Assert.True(addr.IsI2P);
+			Assert.True(addr.AddressType == NetworkAddressType.I2P);
 			Assert.False(addr.IsAddrV1Compatible);
 			Assert.Equal(addr.ToAddressString(), i2p_addr);
 
@@ -182,7 +182,7 @@ namespace NBitcoin.Tests
 			var stream = MakeNewStream(payload);
 			stream.ReadWrite(ref addr);
 			Assert.True(addr.Endpoint.IsValid());
-			Assert.True(addr.IsIPv4);
+			Assert.True(addr.AddressType == NetworkAddressType.IPv4);
 			Assert.True(addr.IsAddrV1Compatible);
 			Assert.Equal("1.2.3.4", addr.ToAddressString());
 			Assert.Equal(stream.Inner.Length, stream.Inner.Position);
@@ -220,7 +220,7 @@ namespace NBitcoin.Tests
 			stream.ReadWrite(ref addr);
 
 			Assert.True(addr.Endpoint.IsValid());
-			Assert.True(addr.IsIPv6);
+			Assert.True(addr.AddressType == NetworkAddressType.IPv6);
 			Assert.True(addr.IsAddrV1Compatible);
 			Assert.Equal("102:304:506:708:90a:b0c:d0e:f10", addr.ToAddressString());
 			Assert.Equal(stream.Inner.Length, stream.Inner.Position);
@@ -270,7 +270,7 @@ namespace NBitcoin.Tests
 			stream = MakeNewStream(payload);
 			stream.ReadWrite(ref addr);
 			Assert.True(addr.Endpoint.IsValid());
-			Assert.True(addr.IsTor);
+			Assert.True(addr.AddressType == NetworkAddressType.Onion);
 			Assert.True(addr.IsAddrV1Compatible);
 			Assert.Equal("6hzph5hv6337r6p2.onion", addr.ToAddressString());
 			Assert.Equal(stream.Inner.Length, stream.Inner.Position);
@@ -295,7 +295,7 @@ namespace NBitcoin.Tests
 			stream = MakeNewStream(payload);
 			stream.ReadWrite(ref addr);
 			Assert.True(addr.Endpoint.IsValid());
-			Assert.True(addr.IsTor);
+			Assert.True(addr.AddressType == NetworkAddressType.Onion);
 			Assert.False(addr.IsAddrV1Compatible);
 			Assert.Equal("pg6mmjiyjmcrsslvykfwnntlaru7p5svn6y2ymmju6nubxndf4pscryd.onion", addr.ToAddressString());
 			Assert.Equal(stream.Inner.Length, stream.Inner.Position);
@@ -321,7 +321,7 @@ namespace NBitcoin.Tests
 			stream = MakeNewStream(payload);
 			stream.ReadWrite(ref addr);
 			Assert.True(addr.Endpoint.IsValid());
-			Assert.True(addr.IsI2P);
+			Assert.True(addr.AddressType == NetworkAddressType.I2P);
 			Assert.False(addr.IsAddrV1Compatible);
 			Assert.Equal("ukeu3k5oycgaauneqgtnvselmt4yemvoilkln7jpvamvfx7dnkdq.b32.i2p", addr.ToAddressString());
 			Assert.Equal(stream.Inner.Length, stream.Inner.Position);
@@ -346,7 +346,7 @@ namespace NBitcoin.Tests
 			stream = MakeNewStream(payload);
 			stream.ReadWrite(ref addr);
 			Assert.True(addr.Endpoint.IsValid());
-			Assert.True(addr.IsCjdns);
+			Assert.True(addr.AddressType == NetworkAddressType.Cjdns);
 			Assert.False(addr.IsAddrV1Compatible);
 			Assert.Equal("fc00:1:2:3:4:5:6:7", addr.ToAddressString());
 			Assert.Equal(stream.Inner.Length, stream.Inner.Position);

--- a/NBitcoin.Tests/addrman_tests.cs
+++ b/NBitcoin.Tests/addrman_tests.cs
@@ -46,7 +46,7 @@ namespace NBitcoin.Tests
 		{
 			AddressManager addrman = new AddressManager();
 			var netaddr = new NetworkAddress(new DnsEndPoint("wasabiukrxmkdgve5kynjztuovbg43uxcbcxn6y2okcrsg7gb6jdmbad.onion", 8333));
-			Assert.True(netaddr.IsTor);
+			Assert.True(netaddr.AddressType == NetworkAddressType.Onion);
 			addrman.Add(netaddr);
 			addrman.SavePeerFile("serializerPeerBIP155.dat", Network.Main);
 			var loaddedAddrMgr = AddressManager.LoadPeerFile("serializerPeerBIP155.dat", Network.Main);

--- a/NBitcoin/NBitcoin.csproj
+++ b/NBitcoin/NBitcoin.csproj
@@ -12,7 +12,7 @@
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>
 	<PropertyGroup>
-		<Version Condition=" '$(Version)' == '' ">5.0.79</Version>
+		<Version Condition=" '$(Version)' == '' ">5.0.80</Version>
 		<LangVersion>8.0</LangVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/NBitcoin/Protocol/AddressManager.cs
+++ b/NBitcoin/Protocol/AddressManager.cs
@@ -1242,7 +1242,7 @@ namespace NBitcoin.Protocol
 									var addrman = param2.TemplateBehaviors.Find<AddressManagerBehavior>();
 									param2.TemplateBehaviors.Clear();
 									param2.TemplateBehaviors.Add(addrman);
-									n = Node.Connect(network, p.Endpoint, param2);
+									n = Node.Connect(network, p, param2);
 									n.VersionHandshake(cancelConnection.Token);
 									n.MessageReceived += (s, a) =>
 									{

--- a/NBitcoin/Protocol/Behaviors/SocksSettingsBehavior.cs
+++ b/NBitcoin/Protocol/Behaviors/SocksSettingsBehavior.cs
@@ -55,6 +55,17 @@ namespace NBitcoin.Protocol.Behaviors
 				(StreamIsolation ? GenerateCredentials() : null);
 		}
 
+		public DnsSocksResolver CreateDnsResolver()
+		{
+			if (SocksEndpoint is null)
+				throw new InvalidOperationException("SocksEndpoint is not set");
+			return new DnsSocksResolver(SocksEndpoint)
+			{
+				NetworkCredential = NetworkCredential,
+				StreamIsolation = StreamIsolation
+			};
+		}
+
 		private NetworkCredential GenerateCredentials()
 		{
 			const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";

--- a/NBitcoin/Protocol/DnsResolver.cs
+++ b/NBitcoin/Protocol/DnsResolver.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,9 +18,15 @@ namespace NBitcoin.Protocol
 		}
 		private static DnsResolver _Instance = new DnsResolver();
 		public static DnsResolver Instance => _Instance;
-		public Task<IPAddress[]> GetHostAddressesAsync(string hostNameOrAddress, CancellationToken cancellationToken)
+		public async Task<IPAddress[]> GetHostAddressesAsync(string hostNameOrAddress, CancellationToken cancellationToken)
 		{
-			return Dns.GetHostAddressesAsync(hostNameOrAddress).WithCancellation(cancellationToken);
+			var dns = new DnsEndPoint(hostNameOrAddress, 0);
+			if (dns.IsTor() || dns.IsI2P())
+				throw new SocketException(11001);
+			var addr = await Dns.GetHostAddressesAsync(hostNameOrAddress).WithCancellation(cancellationToken).ConfigureAwait(false);
+			if (addr.Length is 0)
+				throw new SocketException(11001);
+			return addr;
 		}
 	}
 }


### PR DESCRIPTION
This make sure we don't do clear DNS queries if socks proxy is setup.
This expose the enum of NetworkAddress, and make sure that `Node.Connect` does not pick other things than IPv4/6 nodes if no socks is configured.

ping @lontivero 