### PR TITLE
Add maxArraySize parameter for Transaction.GetHash to allow calculation of hash for bigger transactions

### DIFF
--- a/NBitcoin.Tests/NBitcoin.Tests.csproj
+++ b/NBitcoin.Tests/NBitcoin.Tests.csproj
@@ -157,6 +157,9 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup>
+    <None Update="data\big_tx.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="data\bip39_vectors.cz.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/NBitcoin.Tests/transaction_tests.cs
+++ b/NBitcoin.Tests/transaction_tests.cs
@@ -4645,5 +4645,22 @@ namespace NBitcoin.Tests
 			tx = builder.BuildTransaction(false);
 			Assert.Equal(2u, tx.Version);
 		}
+
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void GetHashFromBigTransaction()
+		{
+			var stream = new MemoryStream(Encoders.Hex.DecodeData(File.ReadAllText(@"data/big_tx.txt")));
+			Assert.True(stream.Length > BitcoinStream.DefaultArraySize);
+			var bStream = new BitcoinStream(stream, false)
+			{
+				MaxArraySize = int.MaxValue
+			};
+
+			var tx = Transaction.Create(Network.Main);
+			tx.ReadWrite(bStream);
+			Assert.Throws<ArgumentOutOfRangeException>(() => tx.GetHash());
+			Assert.True(tx.GetHash(int.MaxValue) != uint256.Zero);
+		}
 	}
 }

--- a/NBitcoin/BitcoinStream.cs
+++ b/NBitcoin/BitcoinStream.cs
@@ -53,7 +53,10 @@ namespace NBitcoin
 	}
 	public partial class BitcoinStream
 	{
-		int _MaxArraySize = 1024 * 1024;
+		public const int DefaultArraySize = 1024 * 1024;
+
+		int _MaxArraySize = DefaultArraySize;
+
 		public int MaxArraySize
 		{
 			get

--- a/NBitcoin/Transaction.cs
+++ b/NBitcoin/Transaction.cs
@@ -1495,6 +1495,11 @@ namespace NBitcoin
 
 		public uint256 GetHash()
 		{
+			return GetHash(BitcoinStream.DefaultArraySize);
+		}
+
+		public uint256 GetHash(int maxArraySize)
+		{
 			uint256 h = null;
 			var hashes = _Hashes;
 			if (hashes != null)
@@ -1510,6 +1515,7 @@ namespace NBitcoin
 				{
 					TransactionOptions = TransactionOptions.None,
 					ConsensusFactory = GetConsensusFactory(),
+					MaxArraySize = maxArraySize
 				};
 				stream.SerializationTypeScope(SerializationType.Hash);
 				this.ReadWrite(stream);


### PR DESCRIPTION
NBitcoin already has option to set the `BitcoinStream.MaxArraySize` field to a size greater than 1MB when creating the Transaction object from a byte[]. But if you are trying to calculate the hash of such transaction, an exception occurs since GetHash method defaults the `MaxArraySize` parameter to 1MB and you cannot override this value