### PR TITLE
Implementing musig2

### DIFF
--- a/NBitcoin.Tests/Secp256k1Tests.Utilities.cs
+++ b/NBitcoin.Tests/Secp256k1Tests.Utilities.cs
@@ -24,6 +24,13 @@ namespace NBitcoin.Tests
 			RandomUtils.GetBytes(output);
 		}
 
+		private byte[] secp256k1_rand256()
+		{
+			var output = new byte[32];
+			RandomUtils.GetBytes(output);
+			return output;
+		}
+
 		private void secp256k1_rand256_test(Span<byte> output)
 		{
 			secp256k1_rand_bytes_test(output, 32);

--- a/NBitcoin.Tests/transaction_tests.cs
+++ b/NBitcoin.Tests/transaction_tests.cs
@@ -2483,7 +2483,9 @@ namespace NBitcoin.Tests
 			builder.AddKeys(k);
 			builder.SignTransactionInPlace(tx);
 			var rate = tx.GetFeeRate(builder.FindSpentCoins(tx));
-			Assert.Equal(new FeeRate(1.0m), rate);
+			// We can overshoot slightly, never undershoot
+			Assert.True(new FeeRate(1.0m).SatoshiPerByte <= rate.SatoshiPerByte);
+			Assert.Equal(new FeeRate(1.0m).SatoshiPerByte, rate.SatoshiPerByte, 1);
 		}
 
 		[Fact]

--- a/NBitcoin/Secp256k1/Context.cs
+++ b/NBitcoin/Secp256k1/Context.cs
@@ -1,5 +1,6 @@
 ﻿#if HAS_SPAN
 #nullable enable
+using NBitcoin.Secp256k1.Musig;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/NBitcoin/Secp256k1/ECPrivKey.cs
+++ b/NBitcoin/Secp256k1/ECPrivKey.cs
@@ -871,7 +871,7 @@ namespace NBitcoin.Secp256k1
 			return ret;
 		}
 
-		private bool secp256k1_eckey_privkey_tweak_mul(ref Scalar key, in Scalar tweak)
+		internal static bool secp256k1_eckey_privkey_tweak_mul(ref Scalar key, in Scalar tweak)
 		{
 			if (tweak.IsZero)
 				return false;

--- a/NBitcoin/Secp256k1/ECXOnlyPubKey.cs
+++ b/NBitcoin/Secp256k1/ECXOnlyPubKey.cs
@@ -15,8 +15,7 @@ namespace NBitcoin.Secp256k1
 #if SECP256K1_LIB
 	public
 #endif
-
-	class ECXOnlyPubKey : IComparable<ECXOnlyPubKey>
+	partial class ECXOnlyPubKey : IComparable<ECXOnlyPubKey>
 	{
 		internal static byte[] TAG_BIP0340Challenge = ASCIIEncoding.ASCII.GetBytes("BIP0340/challenge");
 #if SECP256K1_LIB
@@ -144,8 +143,7 @@ namespace NBitcoin.Secp256k1
 			if (tweak32.Length != 32)
 				throw new ArgumentException(nameof(tweak32), "tweak32 should be 32 bytes");
 			tweakedPubKey = null;
-			var internal_pubkey = this;
-			GE pk = internal_pubkey.Q;
+			var pk = Q;
 			if (!ECPubKey.secp256k1_ec_pubkey_tweak_add_helper(ctx.EcMultContext, ref pk, tweak32))
 				return false;
 			tweakedPubKey = new ECPubKey(pk, ctx);

--- a/NBitcoin/Secp256k1/Musig/ECXOnlyPubKey.cs
+++ b/NBitcoin/Secp256k1/Musig/ECXOnlyPubKey.cs
@@ -1,0 +1,135 @@
+﻿#if HAS_SPAN
+#nullable enable
+using NBitcoin.Secp256k1.Musig;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NBitcoin.Secp256k1
+{
+#if SECP256K1_LIB
+	public
+#else
+	internal
+#endif
+	partial class ECXOnlyPubKey
+	{
+		/* Computes ell = SHA256(pk[0], ..., pk[np-1]) */
+		static void secp256k1_musig_compute_ell(Span<byte> ell32, ECXOnlyPubKey[] pk)
+		{
+			using SHA256 sha = new SHA256();
+			sha.Initialize();
+			Span<byte> ser = stackalloc byte[32];
+			for (int i = 0; i < pk.Length; i++)
+			{
+				pk[i].WriteToSpan(ser);
+				sha.Write(ser);
+			}
+			sha.GetHash(ell32);
+		}
+
+		internal static void secp256k1_musig_compute_messagehash(Span<byte> msghash, ReadOnlySpan<byte> combined_nonce32, ReadOnlySpan<byte> combined_pk32, ReadOnlySpan<byte> msg)
+		{
+			using SHA256 sha = new SHA256();
+			sha.InitializeTagged(TAG_BIP0340Challenge);
+			sha.Write(combined_nonce32.Slice(0, 32));
+			sha.Write(combined_pk32.Slice(0, 32));
+			sha.Write(msg.Slice(0, 32));
+			sha.GetHash(msghash);
+		}
+
+		internal static void secp256k1_xonly_ge_serialize(Span<byte> output32, ref GE ge)
+		{
+			if (ge.IsInfinity)
+			{
+				throw new InvalidOperationException("ge should not be infinite");
+			}
+
+			ge = ge.NormalizeXVariable();
+			ge.x.WriteToSpan(output32);
+		}
+
+		/* Compute MuSig coefficient which is constant 1 for the second pubkey and
+	* SHA256(ell, x) otherwise. second_pk_x can be NULL in case there is no
+	* second_pk. Assumes both field elements x and second_pk_x are normalized. */
+		static Scalar secp256k1_musig_coefficient_internal(ReadOnlySpan<byte> ell, in FE x, in FE second_pk_x)
+		{
+
+			using SHA256 sha = new SHA256();
+			Span<byte> buf = stackalloc byte[32];
+
+			if (x.CompareToVariable(second_pk_x) == 0)
+			{
+				return Scalar.One;
+			}
+			else
+			{
+				sha.InitializeTagged(MusigTag);
+				sha.Write(ell.Slice(0, 32));
+				x.WriteToSpan(buf);
+				sha.Write(buf);
+				sha.GetHash(buf);
+				return new Scalar(buf);
+			}
+		}
+
+		internal static Scalar secp256k1_musig_coefficient(MusigContext pre_session, in FE x)
+		{
+			return secp256k1_musig_coefficient_internal(pre_session.pk_hash, x, pre_session.second_pk_x);
+		}
+
+		const string MusigTag = "MuSig coefficient";
+
+		public static ECXOnlyPubKey MusigCombine(ECXOnlyPubKey[] pubkeys)
+		{
+			return MusigCombine(pubkeys, null);
+		}
+
+		internal static ECXOnlyPubKey MusigCombine(ECXOnlyPubKey[] pubkeys, MusigContext? preSession)
+		{
+			if (pubkeys == null)
+				throw new ArgumentNullException(nameof(pubkeys));
+			if (pubkeys.Length is 0)
+				throw new ArgumentNullException(nameof(pubkeys), "At least one pubkey should be passed");
+			/* No point on the curve has an X coordinate equal to 0 */
+			var second_pk_x = FE.Zero;
+			for (int i = 1; i < pubkeys.Length; i++)
+			{
+				if (pubkeys[0] != pubkeys[i])
+				{
+					second_pk_x = pubkeys[i].Q.x;
+					break;
+				}
+			}
+
+			Span<byte> ell = stackalloc byte[32];
+			secp256k1_musig_compute_ell(ell, pubkeys);
+			var ctx = pubkeys[0].ctx;
+
+			var s = new Scalar[pubkeys.Length];
+			var p = new GE[pubkeys.Length];
+
+			for (int i = 0; i < pubkeys.Length; i++)
+			{
+				p[i] = pubkeys[i].Q;
+				s[i] = secp256k1_musig_coefficient_internal(ell, p[i].x, second_pk_x);
+			}
+			var pkj = ctx.EcMultContext.MultBatch(s, p);
+			var pkp = pkj.ToGroupElement().NormalizeYVariable();
+			pkp = pkp.ToEvenY(out var pk_parity);
+			var combined_pk = new ECXOnlyPubKey(pkp, ctx);
+			if (preSession is MusigContext)
+			{
+				ell.CopyTo(preSession.pk_hash);
+				preSession.pk_parity = pk_parity;
+				preSession.is_tweaked = false;
+				preSession.second_pk_x = second_pk_x;
+			}
+			return combined_pk;
+		}
+	}
+}
+#endif

--- a/NBitcoin/Secp256k1/Musig/MusigContext.cs
+++ b/NBitcoin/Secp256k1/Musig/MusigContext.cs
@@ -1,0 +1,483 @@
+﻿#if HAS_SPAN
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NBitcoin.Secp256k1.Musig
+{
+	class MusigSessionCache
+	{
+		internal bool CombinedNonceParity;
+		internal Scalar B;
+		internal Scalar E;
+		internal MusigSessionCache Clone()
+		{
+			return new MusigSessionCache()
+			{
+				CombinedNonceParity = CombinedNonceParity,
+				B = B,
+				E = E
+			};
+		}
+	}
+#if SECP256K1_LIB
+	public
+#else
+	internal
+#endif
+	class MusigContext
+	{
+		internal byte[] pk_hash = new byte[32];
+		internal FE second_pk_x;
+		internal bool pk_parity;
+		internal bool is_tweaked;
+		internal Scalar scalar_tweak;
+		internal readonly byte[] msg32;
+		internal bool internal_key_parity;
+		internal bool processed_nonce;
+		internal MusigSessionCache? SessionCache;
+		internal SecpSchnorrSignature? Template;
+
+		private ECXOnlyPubKey[] pubKeys;
+		private MusigPubNonce? combinedNonce;
+		public MusigPubNonce? CombinedNonce => combinedNonce;
+		public ECXOnlyPubKey CombinedPubKey => combinedPubKey;
+		ECPubKey? tweakedPubKey;
+		ECXOnlyPubKey? xonlyTweakedPubKey;
+		public ECPubKey? TweakedPubKey => tweakedPubKey;
+		public ECXOnlyPubKey? XOnlyTweakedPubKey => xonlyTweakedPubKey ??= tweakedPubKey?.ToXOnlyPubKey();
+
+
+		public ECXOnlyPubKey SigningPubKey => XOnlyTweakedPubKey ?? CombinedPubKey;
+		private ECXOnlyPubKey combinedPubKey;
+		private Context ctx;
+
+
+		public MusigContext(MusigContext musigContext)
+		{
+			if (musigContext == null)
+				throw new ArgumentNullException(nameof(musigContext));
+			musigContext.pk_hash.CopyTo(pk_hash.AsSpan());
+			second_pk_x = musigContext.second_pk_x;
+			pk_parity = musigContext.pk_parity;
+			is_tweaked = musigContext.is_tweaked;
+			scalar_tweak = musigContext.scalar_tweak;
+			internal_key_parity = musigContext.internal_key_parity;
+			processed_nonce = musigContext.processed_nonce;
+			SessionCache = musigContext.SessionCache?.Clone();
+			Template = musigContext.Template;
+			pubKeys = musigContext.pubKeys.ToArray();
+			combinedNonce = musigContext.combinedNonce;
+			combinedPubKey = musigContext.combinedPubKey;
+			tweakedPubKey = musigContext.tweakedPubKey;
+			ctx = musigContext.ctx;
+			msg32 = musigContext.msg32;
+		}
+
+		public MusigContext Clone()
+		{
+			return new MusigContext(this);
+		}
+
+		internal MusigContext(ECXOnlyPubKey[] pubKeys, ReadOnlySpan<byte> msg32)
+		{
+			if (pubKeys == null)
+				throw new ArgumentNullException(nameof(pubKeys));
+			if (pubKeys.Length is 0)
+				throw new ArgumentException(nameof(pubKeys), "There should be at least one pubkey in pubKeys");
+			if (!(msg32.Length is 32))
+				throw new ArgumentNullException(nameof(msg32), "msg32 should be 32 bytes.");
+			this.pubKeys = pubKeys;
+			this.combinedPubKey = ECXOnlyPubKey.MusigCombine(pubKeys, this);
+			this.ctx = pubKeys[0].ctx;
+			this.msg32 = msg32.ToArray();
+		}
+
+		public ECPubKey Tweak(ReadOnlySpan<byte> tweak32)
+		{
+			if (processed_nonce)
+				throw new InvalidOperationException("This function can only be called before MusigContext.Process");
+			if (is_tweaked)
+				throw new InvalidOperationException("This function can only be called once");
+			if (tweak32.Length != 32)
+				throw new ArgumentException(nameof(tweak32), "The tweak should have a size of 32 bytes");
+			scalar_tweak = new Scalar(tweak32, out int overflow);
+			if (overflow == 1)
+				throw new ArgumentException(nameof(tweak32), "The tweak is overflowing");
+			var output = combinedPubKey.AddTweak(tweak32);
+			internal_key_parity = pk_parity;
+			pk_parity = output.Q.y.IsOdd;
+			is_tweaked = true;
+			tweakedPubKey = output;
+			return output;
+		}
+		ECPubKey? adaptor;
+		public void UseAdaptor(ECPubKey adaptor)
+		{
+			if (processed_nonce)
+				throw new InvalidOperationException("This function can only be called before MusigContext.Process");
+			this.adaptor = adaptor;
+		}
+
+		public void ProcessNonces(MusigPubNonce[] nonces)
+		{
+			Process(MusigPubNonce.Combine(nonces));
+		}
+		public void Process(MusigPubNonce combinedNonce)
+		{
+			if (processed_nonce)
+				throw new InvalidOperationException($"Nonce already processed");
+			var combined_pk = this.SigningPubKey;
+
+			MusigSessionCache session_cache = new MusigSessionCache();
+			Span<byte> noncehash = stackalloc byte[32];
+			Span<byte> sig_template_data = stackalloc byte[32];
+
+			Span<byte> combined_pk32 = stackalloc byte[32];
+			Span<GEJ> summed_nonces = stackalloc GEJ[2];
+			summed_nonces[0] = combinedNonce.K1.Q.ToGroupElementJacobian();
+			summed_nonces[1] = combinedNonce.K2.Q.ToGroupElementJacobian();
+
+			combined_pk.WriteToSpan(combined_pk32);
+			/* Add public adaptor to nonce */
+			if (adaptor != null)
+			{
+				summed_nonces[0] = summed_nonces[0].AddVariable(adaptor.Q);
+			}
+			var combined_nonce = secp256k1_musig_process_nonces_internal(
+				this.ctx.EcMultContext,
+				noncehash,
+				summed_nonces,
+				combined_pk32,
+				msg32);
+			session_cache.B = new Scalar(noncehash);
+
+			ECXOnlyPubKey.secp256k1_xonly_ge_serialize(sig_template_data, ref combined_nonce);
+			var rx = combined_nonce.x;
+			/* Negate nonce if Y coordinate is not square */
+			combined_nonce = combined_nonce.NormalizeYVariable();
+			/* Store nonce parity in session cache */
+			session_cache.CombinedNonceParity = combined_nonce.y.IsOdd;
+
+			/* Compute messagehash and store in session cache */
+			ECXOnlyPubKey.secp256k1_musig_compute_messagehash(noncehash, sig_template_data, combined_pk32, msg32);
+			session_cache.E = new Scalar(noncehash);
+
+			/* If there is a tweak then set `msghash` times `tweak` to the `s`-part of the sig template.*/
+			Scalar s = Scalar.Zero;
+			if (is_tweaked)
+			{
+				Scalar e = session_cache.E;
+				if (!ECPrivKey.secp256k1_eckey_privkey_tweak_mul(ref e, scalar_tweak))
+					throw new InvalidOperationException("Impossible to sign (secp256k1_eckey_privkey_tweak_mul is false)");
+				if (pk_parity)
+					e = e.Negate();
+				s = s.Add(e);
+			}
+			SessionCache = session_cache;
+			Template = new SecpSchnorrSignature(rx, s);
+			processed_nonce = true;
+			this.combinedNonce = combinedNonce;
+		}
+
+		internal static GE secp256k1_musig_process_nonces_internal(
+			ECMultContext ecmult_ctx,
+			Span<byte> noncehash,
+			Span<GEJ> summed_noncesj,
+			ReadOnlySpan<byte> combined_pk32,
+			ReadOnlySpan<byte> msg)
+		{
+
+			Scalar b;
+			GEJ combined_noncej;
+			Span<GE> summed_nonces = stackalloc GE[2];
+			summed_nonces[0] = summed_noncesj[0].ToGroupElement();
+			summed_nonces[1] = summed_noncesj[1].ToGroupElement();
+			secp256k1_musig_compute_noncehash(noncehash, summed_nonces, combined_pk32, msg);
+
+			/* combined_nonce = summed_nonces[0] + b*summed_nonces[1] */
+			b = new Scalar(noncehash);
+			combined_noncej = ecmult_ctx.Mult(summed_noncesj[1], b, null);
+			combined_noncej = combined_noncej.Add(summed_nonces[0]);
+			return combined_noncej.ToGroupElement();
+		}
+
+		/* hash(summed_nonces[0], summed_nonces[1], combined_pk, msg) */
+		internal static void secp256k1_musig_compute_noncehash(Span<byte> noncehash, Span<GE> summed_nonces, ReadOnlySpan<byte> combined_pk32, ReadOnlySpan<byte> msg)
+		{
+			Span<byte> buf = stackalloc byte[32];
+			using SHA256 sha = new SHA256();
+			sha.Initialize();
+			int i;
+			for (i = 0; i < 2; i++)
+			{
+				ECXOnlyPubKey.secp256k1_xonly_ge_serialize(buf, ref summed_nonces[i]);
+				sha.Write(buf);
+			}
+			sha.Write(combined_pk32.Slice(0, 32));
+			sha.Write(msg.Slice(0, 32));
+			sha.GetHash(noncehash);
+		}
+
+		public bool Verify(ECXOnlyPubKey pubKey, MusigPubNonce pubNonce, MusigPartialSignature partialSignature)
+		{
+			if (partialSignature == null)
+				throw new ArgumentNullException(nameof(partialSignature));
+			if (pubNonce == null)
+				throw new ArgumentNullException(nameof(pubNonce));
+			if (pubKey == null)
+				throw new ArgumentNullException(nameof(pubKey));
+			if (SessionCache is null)
+				throw new InvalidOperationException("You need to run MusigContext.Process first");
+			GEJ pkj;
+			Span<GE> nonces = stackalloc GE[2];
+			GEJ rj;
+			GEJ tmp;
+			GE pkp;
+			var b = SessionCache.B;
+			var pre_session = this;
+			/* Compute "effective" nonce rj = nonces[0] + b*nonces[1] */
+			/* TODO: use multiexp */
+
+			nonces[0] = pubNonce.K1.Q;
+			nonces[1] = pubNonce.K2.Q;
+
+			rj = nonces[1].ToGroupElementJacobian();
+			rj = this.ctx.EcMultContext.Mult(rj, b, null);
+			rj = rj.AddVariable(nonces[0]);
+
+			pkp = pubKey.Q;
+			/* Multiplying the messagehash by the musig coefficient is equivalent
+			 * to multiplying the signer's public key by the coefficient, except
+			 * much easier to do. */
+			var mu = ECXOnlyPubKey.secp256k1_musig_coefficient(pre_session, pkp.x);
+			var e = SessionCache.E * mu;
+			/* If the MuSig-combined point has an odd Y coordinate, the signers will
+     * sign for the negation of their individual xonly public key such that the
+     * combined signature is valid for the MuSig aggregated xonly key. If the
+     * MuSig-combined point was tweaked then `e` is negated if the combined key
+     * has an odd Y coordinate XOR the internal key has an odd Y coordinate.*/
+			if (pre_session.pk_parity
+					!= (pre_session.is_tweaked
+						&& pre_session.internal_key_parity))
+			{
+				e = e.Negate();
+			}
+
+			var s = partialSignature.E;
+			/* Compute -s*G + e*pkj + rj */
+			s = s.Negate();
+			pkj = pkp.ToGroupElementJacobian();
+			tmp = ctx.EcMultContext.Mult(pkj, e, s);
+			var combined_nonce_parity = SessionCache.CombinedNonceParity;
+			if (combined_nonce_parity)
+			{
+				rj = rj.Negate();
+			}
+			tmp = tmp.AddVariable(rj);
+			return tmp.IsInfinity;
+		}
+
+		public SecpSchnorrSignature Combine(MusigPartialSignature[] partialSignatures)
+		{
+			if (partialSignatures == null)
+				throw new ArgumentNullException(nameof(partialSignatures));
+			if (Template is null)
+				throw new InvalidOperationException("You need to run MusigContext.Process first");
+			var s = this.Template.s;
+			foreach (var sig in partialSignatures)
+			{
+				s = s + sig.E;
+			}
+			return new SecpSchnorrSignature(Template.rx, s);
+		}
+
+		public MusigPartialSignature Sign(ECPrivKey privKey, MusigPrivNonce privNonce)
+		{
+			if (privKey == null)
+				throw new ArgumentNullException(nameof(privKey));
+			if (privNonce == null)
+				throw new ArgumentNullException(nameof(privNonce));
+			if (privNonce.IsUsed)
+				throw new ArgumentNullException(nameof(privNonce), "Nonce already used, a nonce should never be used to sign twice");
+			if (SessionCache is null)
+				throw new InvalidOperationException("You need to run MusigContext.Process first");
+
+			//{
+			//	/* Check in constant time if secnonce has been zeroed. */
+			//	size_t i;
+			//	unsigned char secnonce_acc = 0;
+			//	for (i = 0; i < sizeof(*secnonce) ; i++) {
+			//		secnonce_acc |= secnonce->data[i];
+			//	}
+			//	secp256k1_declassify(ctx, &secnonce_acc, sizeof(secnonce_acc));
+			//	ARG_CHECK(secnonce_acc != 0);
+			//}
+
+			var pre_session = this;
+			var session_cache = SessionCache;
+			Span<Scalar> k = stackalloc Scalar[2];
+			k[0] = privNonce.K1.sec;
+			k[1] = privNonce.K2.sec;
+
+
+			/* Obtain the signer's public key point and determine if the sk is
+			 * negated before signing. That happens if if the signer's pubkey has an odd
+			 * Y coordinate XOR the MuSig-combined pubkey has an odd Y coordinate XOR
+			 * (if tweaked) the internal key has an odd Y coordinate.
+			 *
+			 * This can be seen by looking at the sk key belonging to `combined_pk`.
+			 * Let's define
+			 * P' := mu_0*|P_0| + ... + mu_n*|P_n| where P_i is the i-th public key
+			 * point x_i*G, mu_i is the i-th musig coefficient and |.| is a function
+			 * that normalizes a point to an even Y by negating if necessary similar to
+			 * secp256k1_extrakeys_ge_even_y. Then we have
+			 * P := |P'| + t*G where t is the tweak.
+			 * And the combined xonly public key is
+			 * |P| = x*G
+			 *      where x = sum_i(b_i*mu_i*x_i) + b'*t
+			 *            b' = -1 if P != |P|, 1 otherwise
+			 *            b_i = -1 if (P_i != |P_i| XOR P' != |P'| XOR P != |P|) and 1
+			 *                otherwise.
+			 */
+
+			var sk = privKey.sec;
+			var pk = privKey.CreatePubKey().Q;
+
+			pk = pk.NormalizeYVariable();
+
+			int l = 0;
+			if (pk.y.IsOdd)
+				l++;
+			if (pre_session.pk_parity)
+				l++;
+			if (pre_session.is_tweaked && pre_session.internal_key_parity)
+				l++;
+			if (l % 2 == 1)
+				sk = sk.Negate();
+
+			/* Multiply MuSig coefficient */
+			pk = pk.NormalizeXVariable();
+			var mu = ECXOnlyPubKey.secp256k1_musig_coefficient(pre_session, pk.x);
+			sk = sk * mu;
+			if (session_cache.CombinedNonceParity)
+			{
+				k[0] = k[0].Negate();
+				k[1] = k[1].Negate();
+			}
+
+			var e = session_cache.E * sk;
+			k[1] = session_cache.B * k[1];
+			k[0] = k[0] + k[1];
+			e = e + k[0];
+			Scalar.Clear(ref k[0]);
+			Scalar.Clear(ref k[1]);
+			privNonce.IsUsed = true;
+			return new MusigPartialSignature(e);
+		}
+
+		public SecpSchnorrSignature Adapt(SecpSchnorrSignature signature, ECPrivKey adaptorSecret)
+		{
+			if (adaptorSecret == null)
+				throw new ArgumentNullException(nameof(adaptorSecret));
+			if (signature == null)
+				throw new ArgumentNullException(nameof(signature));
+			if (!processed_nonce || SessionCache is null)
+				throw new InvalidOperationException("You need to run MusigContext.Process first");
+			var s = signature.s;
+			var t = adaptorSecret.sec;
+			if (SessionCache.CombinedNonceParity)
+			{
+				t = t.Negate();
+			}
+			s = s + t;
+			return new SecpSchnorrSignature(signature.rx, s);
+		}
+
+		public ECPrivKey Extract(SecpSchnorrSignature signature, MusigPartialSignature[] partialSignatures)
+		{
+			if (partialSignatures == null)
+				throw new ArgumentNullException(nameof(partialSignatures));
+			if (SessionCache is null)
+				throw new InvalidOperationException("You need to run MusigContext.Process first");
+			var t = signature.s;
+			t = t.Negate();
+			foreach (var sig in partialSignatures)
+			{
+				t = t + sig.E;
+			}
+			if (!SessionCache.CombinedNonceParity)
+			{
+				t = t.Negate();
+			}
+			return new ECPrivKey(t, this.ctx, true);
+		}
+
+		/// <summary>
+		/// This function derives a random secret nonce that will be required for signing and
+		/// creates a private nonce whose public part intended to be sent to other signers.
+		/// </summary>
+		/// <returns>A private nonce whose public part intended to be sent to other signers</returns>
+		public MusigPrivNonce GenerateNonce()
+		{
+			return GenerateNonce(Array.Empty<byte>());
+		}
+		/// <summary>
+		/// This function derives a secret nonce that will be required for signing and
+		/// creates a private nonce whose public part intended to be sent to other signers.
+		/// </summary>
+		/// <param name="sessionId32">A unique session_id32. It is a "number used once". If empty, it will be randomly generated.</param>
+		/// <returns>A private nonce whose public part intended to be sent to other signers</returns>
+		public MusigPrivNonce GenerateNonce(ReadOnlySpan<byte> sessionId32)
+		{
+			return GenerateNonce(sessionId32, null, Array.Empty<byte>());
+		}
+
+		/// <summary>
+		/// This function derives a secret nonce that will be required for signing and
+		/// creates a private nonce whose public part intended to be sent to other signers.
+		/// </summary>
+		/// <param name="counter">A unique counter. Never reuse the same value twice for the same msg32/pubkeys.</param>
+		/// <param name="signingKey">Provide the message to be signed to increase misuse-resistance. If you do provide a signingKey, sessionId32 can instead be a counter (that must never repeat!). However, it is recommended to always choose session_id32 uniformly at random. Can be null.</param>
+		/// <returns>A private nonce whose public part intended to be sent to other signers</returns>
+		public MusigPrivNonce GenerateNonce(ulong counter, ECPrivKey signingKey)
+		{
+			if (signingKey == null)
+				throw new ArgumentNullException(nameof(signingKey));
+
+			Span<byte> sessionId = stackalloc byte[32];
+			for (int i = 0; i < 8; i++)
+				sessionId[i] = (byte)(counter >> (8*i));
+			return GenerateNonce(sessionId, signingKey, Array.Empty<byte>());
+		}
+
+		/// <summary>
+		/// This function derives a secret nonce that will be required for signing and
+		/// creates a private nonce whose public part intended to be sent to other signers.
+		/// </summary>
+		/// <param name="sessionId32">A unique session_id32. It is a "number used once". If empty, it will be randomly generated.</param>
+		/// <param name="signingKey">Provide the message to be signed to increase misuse-resistance. If you do provide a signingKey, sessionId32 can instead be a counter (that must never repeat!). However, it is recommended to always choose session_id32 uniformly at random. Can be null.</param>
+		/// <returns>A private nonce whose public part intended to be sent to other signers</returns>
+		public MusigPrivNonce GenerateNonce(ReadOnlySpan<byte> sessionId32, ECPrivKey? signingKey)
+		{
+			return GenerateNonce(sessionId32, signingKey, Array.Empty<byte>());
+		}
+		/// <summary>
+		/// This function derives a secret nonce that will be required for signing and
+		/// creates a private nonce whose public part intended to be sent to other signers.
+		/// </summary>
+		/// <param name="sessionId32">A unique session_id32. It is a "number used once". If empty, it will be randomly generated.</param>
+		/// <param name="signingKey">Provide the message to be signed to increase misuse-resistance. If you do provide a signingKey, sessionId32 can instead be a counter (that must never repeat!). However, it is recommended to always choose session_id32 uniformly at random. Can be null.</param>
+		/// <param name="extraInput32">Provide the message to be signed to increase misuse-resistance. The extra_input32 argument can be used to provide additional data that does not repeat in normal scenarios, such as the current time. Can be empty.</param>
+		/// <returns>A private nonce whose public part intended to be sent to other signers</returns>
+		public MusigPrivNonce GenerateNonce(ReadOnlySpan<byte> sessionId32, ECPrivKey? signingKey, ReadOnlySpan<byte> extraInput32)
+		{
+			return MusigPrivNonce.GenerateMusigNonce(ctx, sessionId32, signingKey, this.msg32, this.combinedPubKey, extraInput32);
+		}
+	}
+}
+#endif

--- a/NBitcoin/Secp256k1/Musig/MusigPartialSignature.cs
+++ b/NBitcoin/Secp256k1/Musig/MusigPartialSignature.cs
@@ -1,0 +1,49 @@
+﻿#if HAS_SPAN
+#nullable enable
+using NBitcoin.Secp256k1.Musig;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace NBitcoin.Secp256k1
+{
+#if SECP256K1_LIB
+	public
+#endif
+	class MusigPartialSignature
+	{
+#if SECP256K1_LIB
+		public
+#else
+		internal
+#endif
+		readonly Scalar E;
+
+		public MusigPartialSignature(Scalar e)
+		{
+			this.E = e;
+		}
+
+		public MusigPartialSignature(ReadOnlySpan<byte> in32)
+		{
+			this.E = new Scalar(in32, out var overflow);
+			if (overflow != 0)
+				throw new ArgumentOutOfRangeException(nameof(in32), "in32 is overflowing");
+		}
+
+		public void WriteToSpan(Span<byte> in32)
+		{
+			E.WriteToSpan(in32);
+		}
+		public byte[] ToBytes()
+		{
+			byte[] b = new byte[32];
+			WriteToSpan(b);
+			return b;
+		}		
+	}
+}
+#endif

--- a/NBitcoin/Secp256k1/Musig/MusigPrivNonce.cs
+++ b/NBitcoin/Secp256k1/Musig/MusigPrivNonce.cs
@@ -1,0 +1,195 @@
+﻿#if HAS_SPAN
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NBitcoin.Secp256k1.Musig
+{
+
+#if SECP256K1_LIB
+	public
+#endif
+	class MusigPrivNonce : IDisposable
+	{
+		readonly static RandomNumberGenerator rand = new RNGCryptoServiceProvider();
+
+
+		/// <summary>
+		/// This function derives a secret nonce that will be required for signing and
+		/// creates a private nonce whose public part intended to be sent to other signers.
+		/// </summary>
+		/// <param name="context">The context</param>
+		/// <param name="sessionId32">A unique session_id32. It is a "number used once". If empty, it will be randomly generated.</param>
+		/// <param name="signingKey">Provide the message to be signed to increase misuse-resistance. If you do provide a signingKey, sessionId32 can instead be a counter (that must never repeat!). However, it is recommended to always choose session_id32 uniformly at random. Can be null.</param>
+		/// <param name="msg32">Provide the message to be signed to increase misuse-resistance. Can be empty.</param>
+		/// <param name="combinedKey">Provide the message to be signed to increase misuse-resistance. Can be null.</param>
+		/// <param name="extraInput32">Provide the message to be signed to increase misuse-resistance. The extra_input32 argument can be used to provide additional data that does not repeat in normal scenarios, such as the current time. Can be empty.</param>
+		/// <returns>A private nonce whose public part intended to be sent to other signers</returns>
+		public static MusigPrivNonce GenerateMusigNonce(
+						   Context? context,
+						   ReadOnlySpan<byte> sessionId32,
+						   ECPrivKey? signingKey,
+						   ReadOnlySpan<byte> msg32,
+						   ECXOnlyPubKey? combinedKey,
+						   ReadOnlySpan<byte> extraInput32)
+		{
+			if (!(sessionId32.Length is 32) && !(sessionId32.Length is 0))
+				throw new ArgumentException(nameof(sessionId32), "sessionId32 must be 32 bytes or 0 bytes");
+			if (sessionId32.Length is 0)
+			{
+				var bytes = new byte[32];
+				sessionId32 = bytes.AsSpan();
+				rand.GetBytes(bytes);
+			}
+			if (!(msg32.Length is 32) && !(msg32.Length is 0))
+				throw new ArgumentException(nameof(msg32), "msg32 must be 32 bytes or 0 bytes");
+			if (!(extraInput32.Length is 32) && !(extraInput32.Length is 0))
+				throw new ArgumentException(nameof(extraInput32), "extraInput32 must be 32 bytes or 0 bytes");
+
+			Span<byte> key32 = stackalloc byte[32];
+			if (signingKey is null)
+			{
+				key32 = key32.Slice(0, 0);
+			}
+			else
+			{
+				signingKey.WriteToSpan(key32);
+			}
+
+			Span<byte> combined_pk = stackalloc byte[32];
+			if (combinedKey is null)
+			{
+				combined_pk = combined_pk.Slice(0, 0);
+			}
+			else
+			{
+				combinedKey.WriteToSpan(combined_pk);
+			}
+
+			var k = new Scalar[2];
+			secp256k1_nonce_function_musig(k, sessionId32, key32, msg32, combined_pk, extraInput32);
+			return new MusigPrivNonce(new ECPrivKey(k[0], context, true), new ECPrivKey(k[1], context, true));
+		}
+
+
+
+		static void secp256k1_nonce_function_musig(Span<Scalar> k, ReadOnlySpan<byte> session_id, ReadOnlySpan<byte> key32, ReadOnlySpan<byte> msg32, ReadOnlySpan<byte> combined_pk, ReadOnlySpan<byte> extra_input32)
+		{
+			using SHA256 sha = new SHA256();
+			Span<byte> seed = stackalloc byte[32];
+			Span<byte> i = stackalloc byte[1];
+
+			/* TODO: this doesn't have the same sidechannel resistance as the BIP340
+			 * nonce function because the seckey feeds directly into SHA. */
+			sha.InitializeTagged("MuSig/nonce");
+			sha.Write(session_id.Slice(0, 32));
+
+
+
+
+			Span<byte> marker = stackalloc byte[1];
+
+			if (key32.Length is 32)
+			{
+				marker[0] = 1;
+				sha.Write(marker);
+				sha.Write(key32);
+			}
+			else
+			{
+				marker[0] = 0;
+				sha.Write(marker);
+			}
+
+			if (combined_pk.Length is 32)
+			{
+				marker[0] = 1;
+				sha.Write(marker);
+				sha.Write(combined_pk);
+			}
+			else
+			{
+				marker[0] = 0;
+				sha.Write(marker);
+			}
+
+			if (msg32.Length is 32)
+			{
+				marker[0] = 1;
+				sha.Write(marker);
+				sha.Write(msg32);
+			}
+			else
+			{
+				marker[0] = 0;
+				sha.Write(marker);
+			}
+
+			if (extra_input32.Length is 32)
+			{
+				marker[0] = 1;
+				sha.Write(marker);
+				sha.Write(extra_input32);
+			}
+			else
+			{
+				marker[0] = 0;
+				sha.Write(marker);
+			}
+
+			sha.GetHash(seed);
+
+			Span<byte> buf = stackalloc byte[32];
+
+			for (i[0] = 0; i[0] < 2; i[0]++)
+			{
+				sha.Initialize();
+				sha.Write(seed);
+				sha.Write(i);
+				sha.GetHash(buf);
+				k[i[0]] = new Scalar(buf);
+			}
+		}
+
+		private readonly ECPrivKey k1;
+		private readonly ECPrivKey k2;
+
+		public ECPrivKey K1 => k1;
+		public ECPrivKey K2 => k2;
+
+		bool _IsUsed;
+		public bool IsUsed
+		{
+			get
+			{
+				return _IsUsed;
+			}
+			internal set
+			{
+				_IsUsed = value;
+			}
+		}
+
+		MusigPrivNonce(ECPrivKey k1, ECPrivKey k2)
+		{
+			this.k1 = k1;
+			this.k2 = k2;
+		}
+
+		public void Dispose()
+		{
+			k1.Dispose();
+			k2.Dispose();
+		}
+
+		public MusigPubNonce CreatePubNonce()
+		{
+			return new MusigPubNonce(k1.CreatePubKey(), k2.CreatePubKey());
+		}
+	}
+}
+#endif

--- a/NBitcoin/Secp256k1/Musig/MusigPubNonce.cs
+++ b/NBitcoin/Secp256k1/Musig/MusigPubNonce.cs
@@ -1,0 +1,97 @@
+﻿#if HAS_SPAN
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NBitcoin.Secp256k1.Musig
+{
+#if SECP256K1_LIB
+	public
+#else
+	internal
+#endif
+	class MusigPubNonce
+	{
+		private ECPubKey k1;
+		private ECPubKey k2;
+
+#if SECP256K1_LIB
+		public
+#else
+	    internal
+#endif
+		ECPubKey K1 => k1;
+#if SECP256K1_LIB
+		public
+#else
+	    internal
+#endif
+		ECPubKey K2 => k2;
+
+		internal Context context;
+		internal MusigPubNonce(ECPubKey k1, ECPubKey k2)
+		{
+			this.k1 = k1;
+			this.k2 = k2;
+			this.context = k1.ctx;
+		}
+
+		public static MusigPubNonce Combine(MusigPubNonce[] nonces)
+		{
+			if (nonces == null)
+				throw new ArgumentNullException(nameof(nonces));
+			if (nonces.Length is 0)
+				throw new ArgumentException(nameof(nonces), "nonces should have at least one element");
+			Span<GEJ> summed_nonces = stackalloc GEJ[2];
+			secp256k1_musig_sum_nonces(summed_nonces, nonces);
+			for (int i = 0; i < 2; i++)
+			{
+				if (summed_nonces[i].IsInfinity)
+					throw new InvalidOperationException("Impossible to combine the given nonces");
+			}
+			var ctx = nonces[0].context;
+			return new MusigPubNonce(new ECPubKey(summed_nonces[0].ToGroupElement(), ctx),
+									 new ECPubKey(summed_nonces[1].ToGroupElement(), ctx));
+		}
+
+		internal static void secp256k1_musig_sum_nonces(Span<GEJ> summed_nonces, MusigPubNonce[] pubnonces)
+		{
+			int i;
+			summed_nonces[0] = GEJ.Infinity;
+			summed_nonces[1] = GEJ.Infinity;
+
+			for (i = 0; i < pubnonces.Length; i++)
+			{
+				summed_nonces[0] = summed_nonces[0].AddVariable(pubnonces[i].k1.Q);
+				summed_nonces[1] = summed_nonces[1].AddVariable(pubnonces[i].k2.Q);
+			}
+		}
+
+		public MusigPubNonce(Context? context, ReadOnlySpan<byte> in66)
+		{
+			if (!ECPubKey.TryCreate(in66.Slice(0, 33), context, out _, out var k1) ||
+				!ECPubKey.TryCreate(in66.Slice(33, 33), context, out _, out var k2))
+				throw new FormatException("Invalid musig pubnonce");
+			this.context = context ?? Context.Instance;
+			this.k1 = k1;
+			this.k2 = k2;
+		}
+
+		public void WriteToSpan(Span<byte> out66)
+		{
+			k1.WriteToSpan(true, out66.Slice(0, 33), out _);
+			k2.WriteToSpan(true, out66.Slice(33, 33), out _);
+		}
+
+		public byte[] ToBytes()
+		{
+			byte[] b = new byte[66];
+			WriteToSpan(b);
+			return b;
+		}
+	}
+}
+#endif

--- a/NBitcoin/Secp256k1/Schnorr/SecpSchnorrSignature.cs
+++ b/NBitcoin/Secp256k1/Schnorr/SecpSchnorrSignature.cs
@@ -51,6 +51,12 @@ namespace NBitcoin.Secp256k1
 			rx.WriteToSpan(out64.Slice(0, 32));
 			s.WriteToSpan(out64.Slice(32, 32));
 		}
+		public byte[] ToBytes()
+		{
+			var b = new byte[64];
+			WriteToSpan(b);
+			return b;
+		}
 	}
 }
 #endif


### PR DESCRIPTION
Typical usage:

```csharp
var msg32 = random_scalar_order().ToBytes();
var tweak = random_scalar_order().ToBytes();
var adaptor = ctx.CreateECPrivKey(random_scalar_order());
var peers = 3;
var privKeys = new ECPrivKey[peers];
var privNonces = new MusigPrivNonce[peers];
var pubNonces = new MusigPubNonce[peers];
var musig = new MusigContext[peers];
var sigs = new MusigPartialSignature[peers];
var pubKeys = new ECXOnlyPubKey[peers];

for (int i = 0; i < peers; i++)
{
	privKeys[i] = ctx.CreateECPrivKey(random_scalar_order());
	pubKeys[i] = privKeys[i].CreateXOnlyPubKey();
}

for (int i = 0; i < peers; i++)
{
	musig[i] = new MusigContext(pubKeys, msg32);
	privNonces[i] = musig[i].GenerateNonce((uint)i, privKeys[i]);
	pubNonces[i] = privNonces[i].CreatePubNonce();
}

for (int i = 0; i < peers; i++)
{
	if (useTweak)
	{
		musig[i].Tweak(tweak);
	}
	if (useAdaptor)
	{
		musig[i].UseAdaptor(adaptor.CreatePubKey());
	}

	musig[i].ProcessNonces(pubNonces);
	sigs[i] = musig[i].Sign(privKeys[i], privNonces[i]);
}


// Verify all the partial sigs
for (int i = 0; i < peers; i++)
{
	Assert.True(musig[i].Verify(pubKeys[i], pubNonces[i], sigs[i]));
}

// Combine
var schnorrSig = musig[0].Combine(sigs);

if (useAdaptor)
	schnorrSig = musig[0].Adapt(schnorrSig, adaptor);
// Verify resulting signature
// SigningPubKey is the tweaked key if tweaked, or the combined key if not
Assert.True(musig[0].SigningPubKey.SigVerifyBIP340(schnorrSig, msg32));
```