### PR TITLE
Cancellable RPC methods

### DIFF
--- a/NBitcoin.Tests/RPCClientTests.cs
+++ b/NBitcoin.Tests/RPCClientTests.cs
@@ -1171,7 +1171,7 @@ namespace NBitcoin.Tests
 				var rpc = nodeA.CreateRPCClient();
 				var batch = rpc.PrepareBatch();
 				var generating = batch.GenerateAsync(10);
-				var garbaging = batch.SendCommandAsync(new RPCRequest("ofwifwu", new object[0]));
+				var garbaging = batch.SendCommandAsync("ofwifwu");
 				await batch.SendBatchAsync();
 				await generating;
 				var err = await Assert.ThrowsAsync<RPCException>(async () => await garbaging);

--- a/NBitcoin.Tests/RPCClientTests.cs
+++ b/NBitcoin.Tests/RPCClientTests.cs
@@ -1171,7 +1171,7 @@ namespace NBitcoin.Tests
 				var rpc = nodeA.CreateRPCClient();
 				var batch = rpc.PrepareBatch();
 				var generating = batch.GenerateAsync(10);
-				var garbaging = batch.SendCommandAsync("ofwifwu");
+				var garbaging = batch.SendCommandAsync(new RPCRequest("ofwifwu", new object[0]));
 				await batch.SendBatchAsync();
 				await generating;
 				var err = await Assert.ThrowsAsync<RPCException>(async () => await garbaging);

--- a/NBitcoin/IBlockRepository.cs
+++ b/NBitcoin/IBlockRepository.cs
@@ -1,9 +1,10 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 
 namespace NBitcoin
 {
 	public interface IBlockRepository
 	{
-		Task<Block> GetBlockAsync(uint256 blockId);
+		Task<Block> GetBlockAsync(uint256 blockId, CancellationToken cancellationToken);
 	}
 }

--- a/NBitcoin/RPC/RPCClient.Wallet.cs
+++ b/NBitcoin/RPC/RPCClient.Wallet.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Net;
 using System.Runtime.ExceptionServices;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace NBitcoin.RPC
@@ -201,10 +202,10 @@ namespace NBitcoin.RPC
 		{
 			return LoadWallet(null, loadOnStartup);
 		}
-		public async Task<RPCClient> LoadWalletAsync(string? walletName, bool? loadOnStartup = null)
+		public async Task<RPCClient> LoadWalletAsync(string? walletName, bool? loadOnStartup = null, CancellationToken cancellationToken = default)
 		{
 			var req = GetLoadUnloadWalletRequest("loadwallet", walletName, loadOnStartup);
-			var response = await SendCommandAsync(req).ConfigureAwait(false);
+			var response = await SendCommandAsync(req, cancellationToken: cancellationToken).ConfigureAwait(false);
 			return GetWallet(response.Result.Value<string>("name"));
 		}
 
@@ -267,10 +268,10 @@ namespace NBitcoin.RPC
 		{
 			return UnloadWalletAsync(null, loadOnStartup);
 		}
-		public Task UnloadWalletAsync(string? walletName, bool? loadOnStartup = null)
+		public Task UnloadWalletAsync(string? walletName, bool? loadOnStartup = null, CancellationToken cancellationToken = default)
 		{
 			var req = GetLoadUnloadWalletRequest("unloadwallet", walletName, loadOnStartup);
-			return SendCommandAsync(req);
+			return SendCommandAsync(req, cancellationToken: cancellationToken);
 		}
 
 

--- a/NBitcoin/RPC/RPCClient.Wallet.cs
+++ b/NBitcoin/RPC/RPCClient.Wallet.cs
@@ -357,11 +357,11 @@ namespace NBitcoin.RPC
 			if (options != null)
 			{
 				var jOptions = FundRawTransactionOptionsToJson(options);
-				response = await InternalSendCommandAsync("fundrawtransaction", new object[] { ToHex(transaction), jOptions }, cancellationToken).ConfigureAwait(false);
+				response = await SendCommandAsync("fundrawtransaction", cancellationToken, ToHex(transaction), jOptions).ConfigureAwait(false);
 			}
 			else
 			{
-				response = await InternalSendCommandAsync("fundrawtransaction", new object[] { ToHex(transaction) }, cancellationToken).ConfigureAwait(false);
+				response = await SendCommandAsync("fundrawtransaction", cancellationToken, ToHex(transaction)).ConfigureAwait(false);
 			}
 			var r = (JObject)response.Result;
 			return new FundRawTransactionResponse()
@@ -604,7 +604,7 @@ namespace NBitcoin.RPC
 			var oRescan = JObject.FromObject(new { rescan = rescan });
 			parameters.Add(oRescan);
 
-			var response = await InternalSendCommandAsync("importmulti", parameters.ToArray(), cancellationToken).ConfigureAwait(false);
+			var response = await SendCommandAsync("importmulti", cancellationToken, parameters.ToArray()).ConfigureAwait(false);
 			response.ThrowIfError();
 
 			//Somehow, this one has error embedded
@@ -804,13 +804,12 @@ namespace NBitcoin.RPC
 		/// MaximumCount - Maximum number of UTXOs
 		/// MinimumSumAmount - Minimum sum value of all UTXOs
 		/// </param>
-		[Obsolete("Use ListUnspentAsync(ListUnspentOptions, BitcoinAddress[], CancellationToken) instead.")]
 		public async Task<UnspentCoin[]> ListUnspentAsync(ListUnspentOptions options, params BitcoinAddress[] addresses)
 		{
-			return await ListUnspentAsync(options, addresses, CancellationToken.None);
+			return await ListUnspentAsync(options, CancellationToken.None, addresses);
 		}
 
-		public async Task<UnspentCoin[]> ListUnspentAsync(ListUnspentOptions options, BitcoinAddress[] addresses, CancellationToken cancellationToken = default)
+		public async Task<UnspentCoin[]> ListUnspentAsync(ListUnspentOptions options, CancellationToken cancellationToken, params BitcoinAddress[] addresses)
 		{
 			var queryOptions = new Dictionary<string, object>();
 			var queryObjects = new JObject();
@@ -1190,15 +1189,14 @@ namespace NBitcoin.RPC
 			{
 				jOptions = (JObject)"";
 			}
-			RPCResponse response = await InternalSendCommandAsync(
+			RPCResponse response = await SendCommandAsync(
 				"walletcreatefundedpsbt",
-				new object[]{
-					rpcInputs,
-					outputToSend,
-					locktime.Value,
-					jOptions,
-					bip32derivs},
-				cancellationToken).ConfigureAwait(false);
+				cancellationToken,
+				rpcInputs,
+				outputToSend,
+				locktime.Value,
+				jOptions,
+				bip32derivs).ConfigureAwait(false);
 			var result = (JObject)response.Result;
 			var psbt = PSBT.Parse(result.Property("psbt").Value.Value<string>(), Network.Main);
 			var fee = Money.Coins(result.Property("fee").Value.Value<decimal>());

--- a/NBitcoin/RPC/RPCClient.Wallet.cs
+++ b/NBitcoin/RPC/RPCClient.Wallet.cs
@@ -162,7 +162,7 @@ namespace NBitcoin.RPC
 			};
 		}
 
-		public async Task<RPCClient> CreateWalletAsync(string walletNameOrPath, CreateWalletOptions? options = null)
+		public async Task<RPCClient> CreateWalletAsync(string walletNameOrPath, CreateWalletOptions? options = null, CancellationToken cancellationToken = default)
 		{
 			if (string.IsNullOrEmpty(walletNameOrPath)) throw new ArgumentNullException(nameof(walletNameOrPath));
 
@@ -183,7 +183,7 @@ namespace NBitcoin.RPC
 				if (options.LoadOnStartup is bool loadOnStartup)
 					parameters.Add("load_on_startup", loadOnStartup.ToString());
 			}
-			var result = await SendCommandWithNamedArgsAsync(RPCOperations.createwallet.ToString(), parameters).ConfigureAwait(false);
+			var result = await SendCommandWithNamedArgsAsync(RPCOperations.createwallet.ToString(), parameters, cancellationToken).ConfigureAwait(false);
 			return GetWallet(result.Result.Value<string>("name"));
 		}
 
@@ -804,7 +804,13 @@ namespace NBitcoin.RPC
 		/// MaximumCount - Maximum number of UTXOs
 		/// MinimumSumAmount - Minimum sum value of all UTXOs
 		/// </param>
+		[Obsolete("Use ListUnspentAsync(ListUnspentOptions, BitcoinAddress[], CancellationToken) instead.")]
 		public async Task<UnspentCoin[]> ListUnspentAsync(ListUnspentOptions options, params BitcoinAddress[] addresses)
+		{
+			return await ListUnspentAsync(options, addresses, CancellationToken.None);
+		}
+
+		public async Task<UnspentCoin[]> ListUnspentAsync(ListUnspentOptions options, BitcoinAddress[] addresses, CancellationToken cancellationToken = default)
 		{
 			var queryOptions = new Dictionary<string, object>();
 			var queryObjects = new JObject();
@@ -831,7 +837,7 @@ namespace NBitcoin.RPC
 			var addr = (from a in addresses select a.ToString()).ToArray();
 			queryOptions.Add("addresses", addr);
 
-			var response = await SendCommandWithNamedArgsAsync(RPCOperations.listunspent.ToString(), queryOptions).ConfigureAwait(false);
+			var response = await SendCommandWithNamedArgsAsync(RPCOperations.listunspent.ToString(), queryOptions, cancellationToken).ConfigureAwait(false);
 			return response.Result.Select(i => new UnspentCoin((JObject)i, Network)).ToArray();
 		}
 
@@ -998,7 +1004,7 @@ namespace NBitcoin.RPC
 		/// </summary>
 		/// <param name="request">The transaction to be signed</param>
 		/// <returns>The signed transaction</returns>
-		public async Task<SignRawTransactionResponse> SignRawTransactionWithKeyAsync(SignRawTransactionWithKeyRequest request)
+		public async Task<SignRawTransactionResponse> SignRawTransactionWithKeyAsync(SignRawTransactionWithKeyRequest request, CancellationToken cancellationToken = default)
 		{
 			Dictionary<string, object> values = new Dictionary<string, object>();
 			values.Add("hexstring", request.Transaction.ToHex());
@@ -1031,7 +1037,7 @@ namespace NBitcoin.RPC
 				}
 			}
 
-			var result = await SendCommandWithNamedArgsAsync("signrawtransactionwithkey", values).ConfigureAwait(false);
+			var result = await SendCommandWithNamedArgsAsync("signrawtransactionwithkey", values, cancellationToken).ConfigureAwait(false);
 			var response = new SignRawTransactionResponse();
 			response.SignedTransaction = ParseTxHex(result.Result["hex"].Value<string>());
 			response.Complete = result.Result["complete"].Value<bool>();
@@ -1070,7 +1076,7 @@ namespace NBitcoin.RPC
 		/// </summary>
 		/// <param name="request">The transaction to be signed</param>
 		/// <returns>The signed transaction</returns>
-		public async Task<SignRawTransactionResponse> SignRawTransactionWithWalletAsync(SignRawTransactionRequest request)
+		public async Task<SignRawTransactionResponse> SignRawTransactionWithWalletAsync(SignRawTransactionRequest request, CancellationToken cancellationToken = default)
 		{
 			Dictionary<string, object> values = new Dictionary<string, object>();
 			values.Add("hexstring", request.Transaction.ToHex());
@@ -1097,7 +1103,7 @@ namespace NBitcoin.RPC
 				}
 			}
 
-			var result = await SendCommandWithNamedArgsAsync("signrawtransactionwithwallet", values).ConfigureAwait(false);
+			var result = await SendCommandWithNamedArgsAsync("signrawtransactionwithwallet", values, cancellationToken).ConfigureAwait(false);
 			var response = new SignRawTransactionResponse();
 			response.SignedTransaction = ParseTxHex(result.Result["hex"].Value<string>());
 			response.Complete = result.Result["complete"].Value<bool>();

--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -578,7 +578,7 @@ namespace NBitcoin.RPC
 			return SendCommandAsync(commandName, CancellationToken.None, parameters);
 		}
 
-		private Task<RPCResponse> SendCommandAsync(RPCOperations commandName, CancellationToken cancellationToken, params object[] parameters)
+		public Task<RPCResponse> SendCommandAsync(RPCOperations commandName, CancellationToken cancellationToken, params object[] parameters)
 		{
 			return SendCommandAsync(commandName.ToString(), cancellationToken, parameters);
 		}
@@ -610,7 +610,7 @@ namespace NBitcoin.RPC
 			return SendCommandAsync(commandName, CancellationToken.None, parameters);
 		}
 
-		private Task<RPCResponse> SendCommandAsync(string commandName, CancellationToken cancellationToken, params object[] parameters)
+		public Task<RPCResponse> SendCommandAsync(string commandName, CancellationToken cancellationToken, params object[] parameters)
 		{
 			return SendCommandAsync(new RPCRequest(commandName, parameters), cancellationToken: cancellationToken);
 		}

--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -540,7 +540,7 @@ namespace NBitcoin.RPC
 			return BitcoinAddress.Create(result.Result.ToString(), Network);
 		}
 
-		public async Task<BitcoinAddress> GetNewAddressAsync(GetNewAddressRequest request)
+		public async Task<BitcoinAddress> GetNewAddressAsync(GetNewAddressRequest request, CancellationToken cancellationToken = default)
 		{
 			var p = new Dictionary<string, object>();
 			if (request != null)
@@ -558,7 +558,8 @@ namespace NBitcoin.RPC
 										  );
 				}
 			}
-			return BitcoinAddress.Create((await SendCommandWithNamedArgsAsync(RPCOperations.getnewaddress.ToString(), p).ConfigureAwait(false)).Result.ToString(), Network);
+			var getAddressResponse = await SendCommandWithNamedArgsAsync(RPCOperations.getnewaddress.ToString(), p, cancellationToken).ConfigureAwait(false);
+			return BitcoinAddress.Create(getAddressResponse.Result.ToString(), Network);
 		}
 
 		public BitcoinAddress GetRawChangeAddress()

--- a/NBitcoin/RPC/RestClient.cs
+++ b/NBitcoin/RPC/RestClient.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using NBitcoin.Protocol;
 using NBitcoin.Protocol.Payloads;
@@ -76,7 +77,7 @@ namespace NBitcoin.RPC
 		/// <param name="blockId">The block identifier.</param>
 		/// <returns>Given a block hash (id) returns the requested block object.</returns>
 		/// <exception cref="System.ArgumentNullException">blockId cannot be null.</exception>
-		public async Task<Block> GetBlockAsync(uint256 blockId)
+		public async Task<Block> GetBlockAsync(uint256 blockId, CancellationToken cancellationToken = default)
 		{
 			if (blockId == null)
 				throw new ArgumentNullException(nameof(blockId));

--- a/NBitcoin/Utils.cs
+++ b/NBitcoin/Utils.cs
@@ -161,7 +161,7 @@ namespace NBitcoin
 
 		public static Block GetBlock(this IBlockRepository repository, uint256 blockId)
 		{
-			return repository.GetBlockAsync(blockId).GetAwaiter().GetResult();
+			return repository.GetBlockAsync(blockId, CancellationToken.None).GetAwaiter().GetResult();
 		}
 
 		public static T ToNetwork<T>(this T obj, ChainName chainName) where T : IBitcoinString
@@ -365,7 +365,7 @@ namespace NBitcoin
 			if(offset > buffer.Length - count) throw new ArgumentOutOfRangeException("count");
 
 			//IO interruption not supported on these platforms.
-			
+
 			int totalReadCount = 0;
 #if !NOSOCKET
 			var interruptable = stream is NetworkStream && cancellation.CanBeCanceled;


### PR DESCRIPTION
## Content

This PR adds a cancellation token to most async methods and pass it to the `HttpClient.SendAsync` method. Depending on the framework's version there are other methods that could also receive the cancellation token but that is out of the scope of this PR, however, the work done here can make that future work easier.

## Background

In Wasabi many times we propagate a cancellation token all the way down to all async methods and some times the last call in that chain is an async call to the `RPCClient` that do not accept a cancellation token.

I assume having an uniform pattern where most methods accept a cancellation token and can cancel a IO task is desirable (not always possible).

## A tiny huge problem 

For reasons of usability the `RPCClient::SendCommandAsync` methods receive optional parameters with `params object[]` what makes these methods really easy to use but that comes with the problem that it is not possible to add a `CancellationToken`  parameter at the end of the list (what is the recommended place to put it) because `params` must be the latest one.

There is no good solution to that problem and for that reason it is not easy to add `CancellationToken` to the methods without breaking compatibility so, I decided to DO NOT break it (except for that can be seen in one test). I had to create a new (private) method called `InternalSendCommandAsync` that is used internally instead of the already published `SendCommandAsync`.
The name `InternalSendCommandAsync` doesn't sound great, I know.

**Update:**

This work is needed for https://github.com/zkSNACKs/WalletWasabi/issues/5991