### PR TITLE
Fix bounds for ContextStack.Top() and ContextStack.Swap()

### DIFF
--- a/NBitcoin/ScriptEvaluationContext.cs
+++ b/NBitcoin/ScriptEvaluationContext.cs
@@ -2132,7 +2132,7 @@ namespace NBitcoin
 		/// <exception cref="System.IndexOutOfRangeException">topIndex</exception>
 		public T Top(int i)
 		{
-			if (i > 0 || -i > Count)
+			if (i >= 0 || -i > Count)
 				throw new IndexOutOfRangeException("topIndex");
 			return _array[Count + i];
 		}
@@ -2147,9 +2147,9 @@ namespace NBitcoin
 		/// </exception>
 		public void Swap(int i, int j)
 		{
-			if (i > 0 || -i > Count)
+			if (i >= 0 || -i > Count)
 				throw new IndexOutOfRangeException("i");
-			if (i > 0 || -j > Count)
+			if (i >= 0 || -j > Count)
 				throw new IndexOutOfRangeException("j");
 
 			var t = _array[Count + i];

--- a/NBitcoin/ScriptEvaluationContext.cs
+++ b/NBitcoin/ScriptEvaluationContext.cs
@@ -2149,7 +2149,7 @@ namespace NBitcoin
 		{
 			if (i >= 0 || -i > Count)
 				throw new IndexOutOfRangeException("i");
-			if (i >= 0 || -j > Count)
+			if (j >= 0 || -j > Count)
 				throw new IndexOutOfRangeException("j");
 
 			var t = _array[Count + i];


### PR DESCRIPTION
Furthermore, the comments such as `Returns the i-th element from the top of the stack.` are quite misleading since `i` is negative. 