### PR TITLE
Update Network GetDefaultDataFolder to fallback to OS Temp folder when HOME and APPDATA not available

### DIFF
--- a/NBitcoin/Network.cs
+++ b/NBitcoin/Network.cs
@@ -2073,7 +2073,7 @@ namespace NBitcoin
 		public static string? GetDefaultDataFolder(string folderName)
 		{
 			var home = Environment.GetEnvironmentVariable("HOME");
-			var localAppData = Environment.GetEnvironmentVariable("APPDATA");
+			var localAppData = Environment.GetEnvironmentVariable("APPDATA") ?? Path.GetTempPath();
 			if (string.IsNullOrEmpty(home) && string.IsNullOrEmpty(localAppData))
 				return null;
 			if (!string.IsNullOrEmpty(home) && string.IsNullOrEmpty(localAppData))


### PR DESCRIPTION
Fallback to the operating system's TEMP folder when both `HOME` and `APPDATA` are not available, as a workaround.

A better approach for a future improvement would be to remove any filesystem dependencies when accessing networks.

---

Repro steps: https://github.com/augustoproiete-repros/nbitcoin-issue-1050-ubuntu-exception

`Network.GetDefaultDataFolder` expects either `HOME` or `APPDATA` environment variables to be available, which might not be the case in some scenarios as described in https://github.com/MetacoSA/NBitcoin/issues/1050 [in which case it returns `null`](https://github.com/MetacoSA/NBitcoin/blob/v6.0.9/NBitcoin/Network.cs#L2077-L2078).

`CreateSignet` [relies](https://github.com/MetacoSA/NBitcoin/blob/v6.0.9/NBitcoin/Bitcoin.cs#L64-L65) on `Network.GetDefaultDataFolder` to set the path of the signet cookie and currently [throws an exception when the value is `null`](https://github.com/augustoproiete-repros/nbitcoin-issue-1050-ubuntu-exception/runs/3715694401?check_suite_focus=true#step:6:22).

[![image](https://user-images.githubusercontent.com/177608/134836970-5178dc1d-5212-4d4c-892c-b5ae61e77dcf.png)](https://github.com/augustoproiete-repros/nbitcoin-issue-1050-ubuntu-exception/runs/3715694401?check_suite_focus=true#step:6:22)

---

Closes https://github.com/MetacoSA/NBitcoin/issues/1050


