### PR TITLE
Enhance PayToTaprootTemplate

### DIFF
--- a/NBitcoin.Tests/script_tests.cs
+++ b/NBitcoin.Tests/script_tests.cs
@@ -239,6 +239,61 @@ namespace NBitcoin.Tests
 
 		[Fact]
 		[Trait("UnitTest", "UnitTest")]
+		public void CanParseAndGeneratePayToTaprootScripts()
+		{
+			var pubkey = new TaprootPubKey(Encoders.Hex.DecodeData("53a1f6e454df1aa2776a2814a721372d6258050de330b3c6d10ee8f4e0dda343"));
+			var scriptPubKey = new Script("1 53a1f6e454df1aa2776a2814a721372d6258050de330b3c6d10ee8f4e0dda343");
+			Assert.Equal(scriptPubKey, PayToTaprootTemplate.Instance.GenerateScriptPubKey(pubkey));
+			Assert.Equal(pubkey, PayToTaprootTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey));
+
+			// signature has wrong length
+			scriptPubKey = new Script("1 53a1f6e454df1aa2776a2814a721372d6258050de330b3c6d10ee8f4e0dda34300");
+			Assert.Null(PayToTaprootTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey));
+
+			// segwit version is missing
+			scriptPubKey = new Script("53a1f6e454df1aa2776a2814a721372d6258050de330b3c6d10ee8f4e0dda343");
+			Assert.Null(PayToTaprootTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey));
+
+			// too many witnesses
+			scriptPubKey = new Script("1 53a1f6e454df1aa2776a2814a721372d6258050de330b3c6d10ee8f4e0dda343 00");
+			Assert.Null(PayToTaprootTemplate.Instance.ExtractScriptPubKeyParameters(scriptPubKey));
+
+			var sig = TaprootSignature.Parse(Encoders.Hex.DecodeData("e907831f80848d1069a5371b402410364bdf1c5f8307b0084c55f1ce2dca821525f66a4a85ea8b71e482a74f382d2ce5ebeee8fdb2172f477df4900d310536c0"));
+			var witScript = new WitScript("e907831f80848d1069a5371b402410364bdf1c5f8307b0084c55f1ce2dca821525f66a4a85ea8b71e482a74f382d2ce5ebeee8fdb2172f477df4900d310536c0");
+			Assert.Equal(witScript, PayToTaprootTemplate.Instance.GenerateWitScript(sig));
+
+			var annex = new byte[] { 0x50 };
+			witScript = new WitScript("e907831f80848d1069a5371b402410364bdf1c5f8307b0084c55f1ce2dca821525f66a4a85ea8b71e482a74f382d2ce5ebeee8fdb2172f477df4900d310536c0 50");
+			Assert.Equal(witScript, PayToTaprootTemplate.Instance.GenerateWitScript(sig, annex));
+
+			// first byte of annex is not 0x50
+			annex = new byte[] { 0x00 };
+			Assert.Throws<ArgumentException>(() => PayToTaprootTemplate.Instance.GenerateWitScript(sig, annex));
+
+			// annex is empty
+			annex = new byte[] { };
+			Assert.Throws<ArgumentException>(() => PayToTaprootTemplate.Instance.GenerateWitScript(sig, annex));
+
+			witScript = new WitScript("e907831f80848d1069a5371b402410364bdf1c5f8307b0084c55f1ce2dca821525f66a4a85ea8b71e482a74f382d2ce5ebeee8fdb2172f477df4900d310536c0");
+			Assert.Equal(sig.ToBytes(), PayToTaprootTemplate.Instance.ExtractWitScriptParameters(witScript).TransactionSignature.ToBytes());
+			Assert.Null(PayToTaprootTemplate.Instance.ExtractWitScriptParameters(witScript).Annex);
+
+			witScript = new WitScript("e907831f80848d1069a5371b402410364bdf1c5f8307b0084c55f1ce2dca821525f66a4a85ea8b71e482a74f382d2ce5ebeee8fdb2172f477df4900d310536c0 50");
+			annex = new byte[] { 0x50 };
+			Assert.Equal(sig.ToBytes(), PayToTaprootTemplate.Instance.ExtractWitScriptParameters(witScript).TransactionSignature.ToBytes());
+			Assert.Equal(annex, PayToTaprootTemplate.Instance.ExtractWitScriptParameters(witScript).Annex);
+
+			// first byte of annex is not 0x50
+			witScript = new WitScript("e907831f80848d1069a5371b402410364bdf1c5f8307b0084c55f1ce2dca821525f66a4a85ea8b71e482a74f382d2ce5ebeee8fdb2172f477df4900d310536c0 10");
+			Assert.Null(PayToTaprootTemplate.Instance.ExtractWitScriptParameters(witScript));
+
+			// annex is empty
+			witScript = new WitScript("e907831f80848d1069a5371b402410364bdf1c5f8307b0084c55f1ce2dca821525f66a4a85ea8b71e482a74f382d2ce5ebeee8fdb2172f477df4900d310536c0");
+			Assert.Null(PayToTaprootTemplate.Instance.ExtractWitScriptParameters(witScript).Annex);
+		}
+
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
 		public void PayToMultiSigTemplateShouldAcceptNonKeyParameters()
 		{
 			var tx = Transaction.Parse("0100000002f9cbafc519425637ba4227f8d0a0b7160b4e65168193d5af39747891de98b5b5000000006b4830450221008dd619c563e527c47d9bd53534a770b102e40faa87f61433580e04e271ef2f960220029886434e18122b53d5decd25f1f4acb2480659fea20aabd856987ba3c3907e0121022b78b756e2258af13779c1a1f37ea6800259716ca4b7f0b87610e0bf3ab52a01ffffffff42e7988254800876b69f24676b3e0205b77be476512ca4d970707dd5c60598ab00000000fd260100483045022015bd0139bcccf990a6af6ec5c1c52ed8222e03a0d51c334df139968525d2fcd20221009f9efe325476eb64c3958e4713e9eefe49bf1d820ed58d2112721b134e2a1a53034930460221008431bdfa72bc67f9d41fe72e94c88fb8f359ffa30b33c72c121c5a877d922e1002210089ef5fc22dd8bfc6bf9ffdb01a9862d27687d424d1fefbab9e9c7176844a187a014c9052483045022015bd0139bcccf990a6af6ec5c1c52ed8222e03a0d51c334df139968525d2fcd20221009f9efe325476eb64c3958e4713e9eefe49bf1d820ed58d2112721b134e2a1a5303210378d430274f8c5ec1321338151e9f27f4c676a008bdf8638d07c0b6be9ab35c71210378d430274f8c5ec1321338151e9f27f4c676a008bdf8638d07c0b6be9ab35c7153aeffffffff01a08601000000000017a914d8dacdadb7462ae15cd906f1878706d0da8660e68700000000", Network.Main);
@@ -1463,7 +1518,7 @@ namespace NBitcoin.Tests
 				}
 			}
 		}
-		
+
 		private static async IAsyncEnumerable<ScriptTest3Vector> GetScriptsTest3Vectors()
 		{
 			var testDataDir = Path.Combine("TestData", "script_tests");

--- a/NBitcoin/StandardScriptTemplate.cs
+++ b/NBitcoin/StandardScriptTemplate.cs
@@ -194,7 +194,7 @@ namespace NBitcoin
 			if (signature == null)
 				throw new ArgumentNullException(nameof(signature));
 			if (annex == null)
-				throw new ArgumentNullException(nameof(annex));
+				return GenerateWitScript(signature);
 			if (!CheckAnnex(annex))
 				throw new ArgumentException("The first byte of annex must be 0x50", "annex");
 

--- a/NBitcoin/StandardScriptTemplate.cs
+++ b/NBitcoin/StandardScriptTemplate.cs
@@ -148,7 +148,7 @@ namespace NBitcoin
 			throw new NotSupportedException();
 		}
 
-		[Obsolete("Use GenerateWitScript instead")]
+		[Obsolete("Use GenerateWitScript(TaprootSignature signature) instead")]
 		public Script GenerateScriptSig(TaprootSignature signature)
 		{
 			if (signature == null)
@@ -158,6 +158,9 @@ namespace NBitcoin
 
 		public PayToTaprootScriptSigParameters ExtractWitScriptParameters(WitScript witScript)
 		{
+			if (witScript == null)
+				throw new ArgumentNullException(nameof(witScript));
+
 			if (witScript.PushCount != 1 && witScript.PushCount != 2)
 				return null;
 			var hasAnex = false;
@@ -191,7 +194,7 @@ namespace NBitcoin
 			if (signature == null)
 				throw new ArgumentNullException(nameof(signature));
 			if (annex == null)
-				throw new ArgumentNullException(nameof(signature));
+				throw new ArgumentNullException(nameof(annex));
 			if (!CheckAnnex(annex))
 				throw new ArgumentException("The first byte of annex must be 0x50", "annex");
 

--- a/NBitcoin/StandardScriptTemplate.cs
+++ b/NBitcoin/StandardScriptTemplate.cs
@@ -151,9 +151,7 @@ namespace NBitcoin
 		[Obsolete("Use GenerateWitScript(TaprootSignature signature) instead")]
 		public Script GenerateScriptSig(TaprootSignature signature)
 		{
-			if (signature == null)
-				throw new ArgumentNullException(nameof(signature));
-			return new Script(Op.GetPushOp(signature.ToBytes()));
+			return GenerateWitScript(signature);
 		}
 
 		public PayToTaprootScriptSigParameters ExtractWitScriptParameters(WitScript witScript)
@@ -186,7 +184,9 @@ namespace NBitcoin
 
 		public WitScript GenerateWitScript(TaprootSignature signature)
 		{
-			return GenerateScriptSig(signature);
+			if (signature == null)
+				throw new ArgumentNullException(nameof(signature));
+			return new Script(Op.GetPushOp(signature.ToBytes()));
 		}
 
 		public WitScript GenerateWitScript(TaprootSignature signature, byte[] annex)

--- a/NBitcoin/StandardScriptTemplate.cs
+++ b/NBitcoin/StandardScriptTemplate.cs
@@ -148,11 +148,54 @@ namespace NBitcoin
 			throw new NotSupportedException();
 		}
 
+		[Obsolete("Use GenerateWitScript instead")]
 		public Script GenerateScriptSig(TaprootSignature signature)
 		{
 			if (signature == null)
 				throw new ArgumentNullException(nameof(signature));
 			return new Script(Op.GetPushOp(signature.ToBytes()));
+		}
+
+		public PayToTaprootScriptSigParameters ExtractWitScriptParameters(WitScript witScript)
+		{
+			if (witScript.PushCount != 1 && witScript.PushCount != 2)
+				return null;
+			var hasAnex = false;
+			if (witScript.PushCount == 2)
+			{
+				if (!CheckAnnex(witScript[1]))
+					return null;
+				hasAnex = true;
+			}
+			if (!TaprootSignature.TryParse(witScript[0], out var sig))
+				return null;
+			return new PayToTaprootScriptSigParameters()
+			{
+				TransactionSignature = sig,
+				Annex = hasAnex ? witScript[1] : null,
+			};
+		}
+
+		private bool CheckAnnex(byte[] annex)
+		{
+			return annex.Length > 0 && annex[0] == 0x50;
+		}
+
+		public WitScript GenerateWitScript(TaprootSignature signature)
+		{
+			return GenerateScriptSig(signature);
+		}
+
+		public WitScript GenerateWitScript(TaprootSignature signature, byte[] annex)
+		{
+			if (signature == null)
+				throw new ArgumentNullException(nameof(signature));
+			if (annex == null)
+				throw new ArgumentNullException(nameof(signature));
+			if (!CheckAnnex(annex))
+				throw new ArgumentException("The first byte of annex must be 0x50", "annex");
+
+			return new Script(Op.GetPushOp(signature.ToBytes()), Op.GetPushOp(annex));
 		}
 	}
 	public class PayToMultiSigTemplate : ScriptTemplate
@@ -593,6 +636,19 @@ namespace NBitcoin
 
 	}
 
+	public class PayToTaprootScriptSigParameters
+	{
+		public TaprootSignature TransactionSignature
+		{
+			get;
+			set;
+		}
+		public byte[] Annex
+		{
+			get;
+			set;
+		}
+	}
 	public class PayToWitPubkeyHashScriptSigParameters : PayToPubkeyHashScriptSigParameters
 	{
 		public override IAddressableDestination Hash


### PR DESCRIPTION
This PR makes some enhancement in `PayToTaprootTemplate`:
  * It deprecates ~~`GenerateScriptPubKey`~~`GenerateScriptSig` in favour of `GenerateWitScript`. Rationale: A taproot output is a version one segwit output (see [BIP-341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#script-validation-rules)). That means its `scriptSig` is empty and its redeem script (Schnorr signature) is placed in `witness`. The function `GenerateScriptPubKey` remains present in the code to ensure backward compatibility. 
  * It implements support of annex (see [BIP-341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#cite_ref-5-0)).
  * It implements `ExtractWitScriptParameters`.
  * It introduces tests of `PayToTaprootTemplate`.