### PR TITLE
Use `ReadAsync` in .NET 6 (take 2)

### DIFF
--- a/NBitcoin/Utils.cs
+++ b/NBitcoin/Utils.cs
@@ -326,6 +326,9 @@ namespace NBitcoin
 				//Only take the slow path if cancellation is possible.
 				if (stream is NetworkStream && cancellation.CanBeCanceled)
 				{
+#if !NO_SOCKETASYNC
+					currentReadCount = stream.ReadAsync(buffer, offset + totalReadCount, count - totalReadCount, cancellation).GetAwaiter().GetResult();
+#else
 					var ar = stream.BeginRead(buffer, offset + totalReadCount, count - totalReadCount, null, null);
 					if (!ar.CompletedSynchronously)
 					{
@@ -338,6 +341,7 @@ namespace NBitcoin
 					cancellation.ThrowIfCancellationRequested();
 
 					currentReadCount = stream.EndRead(ar);
+#endif
 				}
 				else
 				{


### PR DESCRIPTION
Successor of #1088

I was thinking about https://github.com/MetacoSA/NBitcoin/pull/1088#issuecomment-1128314543 and it seems to me that it can be fixed by just narrowing the scope of the change to the `NetworkStream` as that's the main thing I wanted to improve in the first place.

@NicolasDorier Does it make sense to you now? If not I'll abandon this idea as I don't have other ideas.