### PR TITLE
change qtum protocol version to 70020

### DIFF
--- a/NBitcoin.Altcoins/Qtum.cs
+++ b/NBitcoin.Altcoins/Qtum.cs
@@ -179,7 +179,7 @@ namespace NBitcoin.Altcoins
 			.SetMagic(0xd3a6cff1)
 			.SetPort(3888)
 			.SetRPCPort(3889)
-			.SetMaxP2PVersion(70019)
+			.SetMaxP2PVersion(70020)
 			.SetName("qtum-main")
 			.AddAlias("qtum-mainnet")
 			.AddDNSSeeds(new[]{
@@ -219,7 +219,7 @@ namespace NBitcoin.Altcoins
 			.SetMagic(0x0615220d)
 			.SetPort(13888)
 			.SetRPCPort(13889)
-			.SetMaxP2PVersion(70019)
+			.SetMaxP2PVersion(70020)
 			.SetName("qtum-test")
 			.AddAlias("qtum-testnet")
 			.AddDNSSeeds(new[]{
@@ -260,7 +260,7 @@ namespace NBitcoin.Altcoins
 			.SetMagic(0xe1c6ddfd)
 			.SetPort(23888)
 			.SetRPCPort(13889)
-			.SetMaxP2PVersion(70019)
+			.SetMaxP2PVersion(70020)
 			.SetName("qtum-reg")
 			.AddAlias("qtum-regtest")
 			.AddSeeds(new NetworkAddress[0])


### PR DESCRIPTION
With the hard fork of Qtum v22.0, Protocol Version was changed from 70019 to 70020. even NBitcoin cannot connect to Qtum Core unless Protocol Version is changed to 70020.

https://github.com/qtumproject/qtum/commit/783392932caa9cb4815b647cdf8403426e517ce3#diff-c1748716c75862af55db8eed0aab60c391416ba3b08802ae01ede4abb2a05aeeR12