### PR TITLE
GitHubActions: don't restrict CI to master branch

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,15 +1,7 @@
 name: CI
 
-# Controls when the action will run. 
-on:
-  # Triggers the workflow on push or pull request events but only for the master branch
-  push:
-    branches: [ master ]
-  pull_request:
-    branches:
-      - master
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+on: [push, pull_request, workflow_dispatch]
+
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel


### PR DESCRIPTION
There's no point about restricting CI to master branch; doing this will prevent contributors to know the CI status (e.g. the result from running unit tests after their proposed contributions) before they propose a PullRequest; because normally people create branches when they want to start to work on something (instead of having to use the master branch of their fork).