### PR TITLE
Extract structural coin field to simpler interface

### DIFF
--- a/NBitcoin/Coin.cs
+++ b/NBitcoin/Coin.cs
@@ -16,17 +16,20 @@ namespace NBitcoin
 			get;
 		}
 	}
-	public interface ICoin
+	public interface ICoinable
 	{
-		IMoney Amount
-		{
-			get;
-		}
 		OutPoint Outpoint
 		{
 			get;
 		}
 		TxOut TxOut
+		{
+			get;
+		}
+	}
+	public interface ICoin : ICoinable
+	{
+		IMoney Amount
 		{
 			get;
 		}
@@ -163,7 +166,7 @@ namespace NBitcoin
 			}
 		}
 
-		OutPoint ICoin.Outpoint
+		OutPoint ICoinable.Outpoint
 		{
 			get
 			{
@@ -171,7 +174,7 @@ namespace NBitcoin
 			}
 		}
 
-		TxOut ICoin.TxOut
+		TxOut ICoinable.TxOut
 		{
 			get
 			{
@@ -340,7 +343,7 @@ namespace NBitcoin
 			}
 		}
 
-		OutPoint ICoin.Outpoint
+		OutPoint ICoinable.Outpoint
 		{
 			get
 			{
@@ -348,7 +351,7 @@ namespace NBitcoin
 			}
 		}
 
-		TxOut ICoin.TxOut
+		TxOut ICoinable.TxOut
 		{
 			get
 			{
@@ -565,7 +568,7 @@ namespace NBitcoin
 			}
 		}
 
-		OutPoint ICoin.Outpoint
+		OutPoint ICoinable.Outpoint
 		{
 			get
 			{
@@ -573,7 +576,7 @@ namespace NBitcoin
 			}
 		}
 
-		TxOut ICoin.TxOut
+		TxOut ICoinable.TxOut
 		{
 			get
 			{


### PR DESCRIPTION
This PR creates a simpler `ICoinable` interface that contains only the structural elements that define a coin (prev_out, txout).

The reason behind this is that we are facing more and more need to abstract the concept of Coin but `ICoin` is not good enough for us because to implement it we need to implement things that makes no sense in our context. 

Notice that across NBitcoin this new `ICoinable` is a better fit that `ICoin` in most of the places. I didn't do that change because, even when it wouldn't break backward compatibility, the idea here is to do the smallest possible change that help us to move forward. (anyway, let me know if you want me to do the change)

