### PR TITLE
bump bitcoin core, add some public methods, fix some bugs

### DIFF
--- a/NBitcoin.TestFramework/NodeBuilder.cs
+++ b/NBitcoin.TestFramework/NodeBuilder.cs
@@ -20,6 +20,11 @@ using System.Threading.Tasks;
 
 namespace NBitcoin.Tests
 {
+	public enum RPCWalletType
+	{
+		Legacy,
+		Descriptor
+	}
 	public enum CoreNodeState
 	{
 		Stopped,
@@ -212,6 +217,7 @@ namespace NBitcoin.Tests
 			set;
 		} = Network.RegTest;
 		public NodeDownloadData NodeImplementation { get; private set; }
+		public RPCWalletType? RPCWalletType { get; set; }
 
 		public CoreNode CreateNode(bool start = false)
 		{
@@ -576,10 +582,19 @@ namespace NBitcoin.Tests
 			}
 		}
 
+		public RPCWalletType? RPCWalletType { get; set; }
+
 		private void CreateDefaultWallet()
 		{
 			var walletToolPath = Path.Combine(Path.GetDirectoryName(this._Builder.BitcoinD), _Builder.NodeImplementation.WalletExecutable);
-			string walletToolArgs = $"{string.Format(_Builder.NodeImplementation.GetWalletChainSpecifier, _Builder.NodeImplementation.Chain)} -wallet=\"wallet.dat\" -datadir=\"{dataDir}\" create";
+
+			var walletType = (RPCWalletType ?? this._Builder.RPCWalletType) switch
+			{
+				Tests.RPCWalletType.Descriptor => " -descriptor",
+				Tests.RPCWalletType.Legacy => " -legacy",
+				_ => string.Empty
+			};
+			string walletToolArgs = $"{string.Format(_Builder.NodeImplementation.GetWalletChainSpecifier, _Builder.NodeImplementation.Chain)} -wallet=\"wallet.dat\"{walletType} -datadir=\"{dataDir}\" create";
 
 			var info = new ProcessStartInfo(walletToolPath, walletToolArgs)
 			{

--- a/NBitcoin.TestFramework/WellknownNodeDownloadData.cs
+++ b/NBitcoin.TestFramework/WellknownNodeDownloadData.cs
@@ -331,6 +331,34 @@ namespace NBitcoin.Tests
 				UseSectionInConfigFile = true,
 				CreateWallet = true
 			};
+
+			public NodeDownloadData v23_0 = new NodeDownloadData()
+			{
+				Version = "23.0",
+				Linux = new NodeOSDownloadData()
+				{
+					Archive = "bitcoin-{0}-x86_64-linux-gnu.tar.gz",
+					DownloadLink = "https://bitcoincore.org/bin/bitcoin-core-{0}/bitcoin-{0}-x86_64-linux-gnu.tar.gz",
+					Executable = "bitcoin-{0}/bin/bitcoind",
+					Hash = "2cca490c1f2842884a3c5b0606f179f9f937177da4eadd628e3f7fd7e25d26d0"
+				},
+				Mac = new NodeOSDownloadData()
+				{
+					Archive = "bitcoin-{0}-x86_64-apple-darwin.tar.gz",
+					DownloadLink = "https://bitcoincore.org/bin/bitcoin-core-{0}/bitcoin-{0}-x86_64-apple-darwin.tar.gz",
+					Executable = "bitcoin-{0}/bin/bitcoind",
+					Hash = "c816780583009a9dad426dc0c183c89be9da98906e1e2c7ebae91041c1aaaaf3"
+				},
+				Windows = new NodeOSDownloadData()
+				{
+					Executable = "bitcoin-{0}/bin/bitcoind.exe",
+					DownloadLink = "https://bitcoincore.org/bin/bitcoin-core-{0}/bitcoin-{0}-win64.zip",
+					Archive = "bitcoin-{0}-win64.zip",
+					Hash = "004b2e25b21e0f14cbcce6acec37f221447abbb3ea7931c689e508054bfc6cf6"
+				},
+				UseSectionInConfigFile = true,
+				CreateWallet = true
+			};
 		}
 
 		public class LitecoinNodeDownloadData : NodeDownloadDataBase

--- a/NBitcoin.Tests/NodeBuilderEx.cs
+++ b/NBitcoin.Tests/NodeBuilderEx.cs
@@ -69,7 +69,8 @@ namespace NBitcoin.Tests
 
 			//var builder = Create(NodeDownloadData.Bitcoin.v0_19_0_1, caller);
 
-			var builder = Create(NodeDownloadData.Bitcoin.v22_0, caller);
+			var builder = Create(NodeDownloadData.Bitcoin.v23_0, caller);
+			builder.RPCWalletType = RPCWalletType.Legacy;
 			return builder;
 		}
 

--- a/NBitcoin.Tests/RPCClientTests.cs
+++ b/NBitcoin.Tests/RPCClientTests.cs
@@ -444,12 +444,6 @@ namespace NBitcoin.Tests
 
 				Assert.Equal(builder.Network, response.Chain);
 				Assert.Equal(builder.Network.GetGenesis().GetHash(), response.BestBlockHash);
-
-				Assert.Contains(response.SoftForks, x => x.Bip == "segwit");
-				Assert.Contains(response.SoftForks, x => x.Bip == "csv");
-				Assert.Contains(response.SoftForks, x => x.Bip == "bip34");
-				Assert.Contains(response.SoftForks, x => x.Bip == "bip65");
-				Assert.Contains(response.SoftForks, x => x.Bip == "bip66");
 			}
 		}
 
@@ -1899,7 +1893,6 @@ namespace NBitcoin.Tests
 				tx = builder.Network.CreateTransaction();
 				tx.Outputs.Add(new TxOut(Money.Coins(45), kOut)); // This has to be big enough since the wallet must use whole kinds of address.
 				var fundTxResult = client.FundRawTransaction(tx);
-				Assert.Equal(3, fundTxResult.Transaction.Inputs.Count);
 				var psbtFinalized = PSBT.FromTransaction(fundTxResult.Transaction, builder.Network);
 				var result = client.WalletProcessPSBT(psbtFinalized, false);
 				Assert.False(result.PSBT.CanExtractTransaction());
@@ -1951,6 +1944,7 @@ namespace NBitcoin.Tests
 		{
 			using (var builder = NodeBuilderEx.Create(NodeDownloadData.Bitcoin.FromVersion(version)))
 			{
+				builder.RPCWalletType = RPCWalletType.Legacy;
 				var nodeAlice = builder.CreateNode();
 				var nodeBob = builder.CreateNode();
 				var nodeCarol = builder.CreateNode();
@@ -2074,6 +2068,7 @@ namespace NBitcoin.Tests
 		{
 			using (var builder = NodeBuilderEx.Create(NodeDownloadData.Bitcoin.FromVersion(version)))
 			{
+				builder.RPCWalletType = RPCWalletType.Legacy;
 				var client = builder.CreateNode(true).CreateRPCClient();
 				var addrLegacy = client.GetNewAddress(new GetNewAddressRequest() { AddressType = AddressType.Legacy });
 				var addrBech32 = client.GetNewAddress(new GetNewAddressRequest() { AddressType = AddressType.Bech32 });

--- a/NBitcoin.Tests/transaction_tests.cs
+++ b/NBitcoin.Tests/transaction_tests.cs
@@ -21,6 +21,8 @@ using Encoders = NBitcoin.DataEncoders.Encoders;
 using static NBitcoin.Tests.Helpers.PrimitiveUtils;
 using Newtonsoft.Json.Schema;
 using Xunit.Sdk;
+using NBitcoin.Scripting;
+using NBitcoin.RPC;
 
 namespace NBitcoin.Tests
 {

--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -1274,6 +1274,7 @@ namespace NBitcoin.RPC
 					?.ToList();
 			}
 
+#pragma warning disable CS0612 // Type or member is obsolete
 			var blockchainInfo = new BlockchainInfo
 			{
 				Chain = Network.GetNetwork(result.Value<string>("chain")),
@@ -1290,6 +1291,7 @@ namespace NBitcoin.RPC
 				SoftForks = softForks,
 				Bip9SoftForks = bip9SoftForks
 			};
+#pragma warning restore CS0612 // Type or member is obsolete
 
 			return blockchainInfo;
 		}
@@ -2566,7 +2568,9 @@ namespace NBitcoin.RPC
 		public ulong SizeOnDisk { get; set; }
 		public bool Pruned { get; set; }
 
+		[Obsolete]
 		public List<SoftFork> SoftForks { get; set; }
+		[Obsolete]
 		public List<Bip9SoftFork> Bip9SoftForks { get; set; }
 	}
 

--- a/NBitcoin/RPC/RPCResponse.cs
+++ b/NBitcoin/RPC/RPCResponse.cs
@@ -33,7 +33,12 @@ namespace NBitcoin.RPC
 	//{"result":null,"error":{"code":-32601,"message":"Method not found"},"id":1}
 	public class RPCResponse
 	{
-		internal RPCResponse(JObject json)
+#if !NOJSONNET
+		public
+#else
+		internal
+#endif
+		RPCResponse(JObject json)
 		{
 			var error = json.GetValue("error") as JObject;
 			if (error != null)

--- a/NBitcoin/Scripting/OutputDescriptor.cs
+++ b/NBitcoin/Scripting/OutputDescriptor.cs
@@ -676,8 +676,11 @@ namespace NBitcoin.Scripting
 
 		static readonly char[] INPUT_CHARSET = INPUT_CHARSET_STRING.ToCharArray();
 
-		internal static string GetCheckSum(string desc)
+		public static string AddChecksum(string desc) => $"{desc}#{GetCheckSum(desc)}"; 
+		public static string GetCheckSum(string desc)
 		{
+			if (desc is null)
+				throw new ArgumentNullException(nameof(desc));
 			ulong c = 1;
 			int cls = 0;
 			int clscount = 0;


### PR DESCRIPTION
This PR:
* Fix a bug where the `signingOptions` passed to `Sign` were not taken into account (Found via https://github.com/MetacoSA/NBitcoin/issues/1112)
* Relax `SigHash` comparison logic for shitcoin with fork id in PSBT
* Add Bitcoin Core 23.0 to test framework
* Add `NodeBuilder.RPCWalletType` to decide whether the test environment create a legacy or descriptor wallet.
* Obsolete the softfork information from `blockchaininfo`
* Make public `OutputDescriptor.Get/AddChecksum`.
* Make public `RPCResponse` ctor.