### PR TITLE
Do not send output's value below dust to fee. Instead, just send it back to change

### DIFF
--- a/NBitcoin.Tests/transaction_tests.cs
+++ b/NBitcoin.Tests/transaction_tests.cs
@@ -803,7 +803,7 @@ namespace NBitcoin.Tests
 			var k = new Key();
 			var scriptCoin = RandomCoin(Money.Coins(0.0001m), k.PubKey.ScriptPubKey, true);
 			var builder = Network.CreateTransactionBuilder();
-			Assert.Throws<NotEnoughFundsException>(() => builder
+			Assert.Throws<OutputTooSmallException>(() => builder
 			.AddCoins(scriptCoin)
 			.Send(new Key(), scriptCoin.Amount)
 			.SubtractFees()
@@ -2644,9 +2644,7 @@ namespace NBitcoin.Tests
 			builder.DustPrevention = false;
 
 			TransactionPolicyError[] errors;
-			Assert.False(builder.Verify(signed, Money.Coins(0.0001m), out errors));
-			var ex = (NotEnoughFundsPolicyError)errors.Single();
-			Assert.True((Money)ex.Missing == Money.Parse("-0.00000500"));
+			Assert.True(builder.Verify(signed, Money.Coins(0.0001m), out errors));
 
 			builder = Network.CreateTransactionBuilder();
 			builder.MergeOutputs = false;

--- a/NBitcoin/NBitcoin.csproj
+++ b/NBitcoin/NBitcoin.csproj
@@ -12,7 +12,7 @@
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>
 	<PropertyGroup>
-		<Version Condition=" '$(Version)' == '' ">7.0.18</Version>
+		<Version Condition=" '$(Version)' == '' ">7.0.19</Version>
 		<LangVersion>9.0</LangVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/NBitcoin/TransactionBuilder.cs
+++ b/NBitcoin/TransactionBuilder.cs
@@ -810,6 +810,11 @@ namespace NBitcoin
 				get;
 				set;
 			}
+			/// <summary>
+			/// Money which has been recovered from outputs that are too small to be included
+			/// we should be able to pay fees with that
+			/// </summary>
+			public Money SurrendedValue { get; set; } = Money.Zero;
 		}
 
 		List<BuilderGroup> _BuilderGroups = new List<BuilderGroup>();
@@ -1151,7 +1156,7 @@ namespace NBitcoin
 			_LastSendBuilder = null; //If the amount is dust, we don't want the fee to be paid by the previous Send
 			if (DustPrevention && amount < GetDust(scriptPubKey) && !_OpReturnTemplate.CheckScriptPubKey(scriptPubKey))
 			{
-				SendFees(amount);
+				CurrentGroup.SurrendedValue += amount;
 				return this;
 			}
 
@@ -1872,10 +1877,11 @@ namespace NBitcoin
 		{
 			var gctx = ctx.CurrentGroupContext;
 			IMoney zero = ctx.Zero;
+			IMoney surrendedMoney = zero is Money ? group.SurrendedValue : zero;
 			foreach (var builder in builders)
 				builder(ctx);
 
-			IMoney selectionTarget = (gctx.SentOutput + gctx.Fee - gctx.LeftOverChange).GetAmount(zero);
+			IMoney selectionTarget = (gctx.SentOutput + gctx.Fee - gctx.LeftOverChange + surrendedMoney).GetAmount(zero);
 
 			var unconsumed = coins.Where(c => !ctx.ConsumedOutpoints.Contains(c.Outpoint)).ToArray();
 
@@ -1893,7 +1899,7 @@ namespace NBitcoin
 						selectionTarget.Sub(unconsumed.Select(u => u.Amount).Sum(zero)));
 
 			var totalInput = selection.Select(s => s.Amount).Sum(zero);
-			var change = totalInput.Sub(selectionTarget);
+			var change = totalInput.Sub(selectionTarget).Add(surrendedMoney);
 			if (change.CompareTo(zero) == -1)
 				throw new NotEnoughFundsException(notEnoughFundsMessage,
 					group.Name,
@@ -2269,8 +2275,6 @@ namespace NBitcoin
 				if (fees != null)
 				{
 					Money margin = Money.Zero;
-					if (DustPrevention)
-						margin = GetDust() * 2;
 					if (!fees.Almost(expectedFees, margin))
 						exceptions.Add(new NotEnoughFundsPolicyError("Fees different than expected", expectedFees - fees));
 				}


### PR DESCRIPTION
When an output was too low, its value was sent to fee. (on top of the fee paid for the size of the transaction)
Now we instead send back the output's value to the change.