### PR TITLE
Implement TaprootBuilder and TaprootSpendInfo

### DIFF
--- a/NBitcoin.Tests/Generators/CryptoGenerator.cs
+++ b/NBitcoin.Tests/Generators/CryptoGenerator.cs
@@ -26,10 +26,12 @@ namespace NBitcoin.Tests.Generators
 		public static Arbitrary<ECDSASignature> ECDSASignatureArb() =>
 			Arb.From(ECDSA());
 
+#if HAS_SPAN
 		public static Arbitrary<TaprootInternalPubKey> TaprootInternalPubKeyArb() =>
 			Arb.From(TaprootInternalPubKey());
 		public static Arbitrary<TaprootFullPubKey> TaprootFullPubKeyArb() =>
 			Arb.From(TaprootFullPubKey());
+#endif
 
 		public static Arbitrary<uint256> UInt256Arb() =>
 			Arb.From(Hash256());

--- a/NBitcoin.Tests/Generators/CryptoGenerator.cs
+++ b/NBitcoin.Tests/Generators/CryptoGenerator.cs
@@ -4,6 +4,7 @@ using FsCheck;
 using System.Collections.Generic;
 using Microsoft.FSharp.Collections;
 using System.Linq;
+using Microsoft.FSharp.Core;
 using NBitcoin.Crypto;
 
 namespace NBitcoin.Tests.Generators
@@ -24,6 +25,14 @@ namespace NBitcoin.Tests.Generators
 			Arb.From(KeyPath());
 		public static Arbitrary<ECDSASignature> ECDSASignatureArb() =>
 			Arb.From(ECDSA());
+
+		public static Arbitrary<TaprootInternalPubKey> TaprootInternalPubKeyArb() =>
+			Arb.From(TaprootInternalPubKey());
+		public static Arbitrary<TaprootFullPubKey> TaprootFullPubKeyArb() =>
+			Arb.From(TaprootFullPubKey());
+
+		public static Arbitrary<uint256> UInt256Arb() =>
+			Arb.From(Hash256());
 		public static Gen<Key> PrivateKey() => Gen.Fresh(() => new Key());
 
 		public static Gen<List<Key>> PrivateKeys(int n) =>
@@ -43,6 +52,16 @@ namespace NBitcoin.Tests.Generators
 		public static Gen<List<PubKey>> PublicKeys(int n) =>
 			from pks in Gen.ListOf(n, PublicKey())
 			select pks.ToList();
+
+#if HAS_SPAN
+		public static Gen<TaprootInternalPubKey> TaprootInternalPubKey() =>
+			from pk in PublicKey()
+			select pk.TaprootInternalKey;
+
+		public static Gen<TaprootFullPubKey> TaprootFullPubKey() =>
+			from pk in PublicKey()
+			select pk.GetTaprootFullPubKey();
+#endif
 
 		#region hash
 		public static Gen<uint256> Hash256() =>

--- a/NBitcoin.Tests/NBitcoin.Tests.csproj
+++ b/NBitcoin.Tests/NBitcoin.Tests.csproj
@@ -189,6 +189,9 @@
     <None Update="data\musig\*.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="data\bip-0341\*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/NBitcoin.Tests/PropertyTest/Taproot.cs
+++ b/NBitcoin.Tests/PropertyTest/Taproot.cs
@@ -1,0 +1,30 @@
+using System.Linq;
+using FsCheck;
+using FsCheck.Xunit;
+using NBitcoin.Crypto;
+using NBitcoin.Tests.Generators;
+using Xunit;
+
+namespace NBitcoin.Tests.PropertyTest
+{
+#if NET6_0_OR_GREATER
+	public class TaprootTests
+	{
+	public TaprootTests()
+		{
+			Arb.Register<CryptoGenerator>();
+		}
+
+		[Property(MaxTest = 100)]
+		[Trait("UnitTest", "UnitTest")]
+		public void SerializeDeserializeControlBlock(ControlBlock ctrl)
+		{
+			if ((ctrl.LeafVersion & 1) == 1)
+				return;
+			if (ctrl.LeafVersion == 0x50) // annex
+				return;
+			Assert.Equal(ctrl, ControlBlock.FromSlice(ctrl.ToBytes()));
+		}
+	}
+#endif
+}

--- a/NBitcoin.Tests/PropertyTest/Taproot.cs
+++ b/NBitcoin.Tests/PropertyTest/Taproot.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace NBitcoin.Tests.PropertyTest
 {
-#if NET6_0_OR_GREATER
+#if HAS_SPAN
 	public class TaprootTests
 	{
 	public TaprootTests()

--- a/NBitcoin.Tests/PropertyTest/Taproot.cs
+++ b/NBitcoin.Tests/PropertyTest/Taproot.cs
@@ -21,7 +21,7 @@ namespace NBitcoin.Tests.PropertyTest
 		{
 			if ((ctrl.LeafVersion & 1) == 1)
 				return;
-			if (ctrl.LeafVersion == 0x50) // annex
+			if (ctrl.LeafVersion == TaprootConstants.TAPROOT_LEAF_ANNEX)
 				return;
 			Assert.Equal(ctrl, ControlBlock.FromSlice(ctrl.ToBytes()));
 		}

--- a/NBitcoin.Tests/TaprootBuilderTests.cs
+++ b/NBitcoin.Tests/TaprootBuilderTests.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.VisualBasic;
+using NBitcoin.DataEncoders;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NBitcoin.Tests
+{
+	public class TaprootBuilderTests
+	{
+		private readonly ITestOutputHelper _testOutputHelper;
+		public TaprootBuilderTests(ITestOutputHelper testOutputHelper)
+		{
+			_testOutputHelper = testOutputHelper;
+		}
+#if NET6_0_OR_GREATER
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void TestVectorsCore()
+		{
+			var internalKey = TaprootInternalPubKey.Parse("93c7378d96518a75448821c4f7c8f4bae7ce60f804d03d1f0628dd5dd0f5de51");
+
+			var scriptWeights = new[]
+			{
+				(10u, Script.FromHex("51")),
+				(20u, Script.FromHex("52")),
+				(20u, Script.FromHex("53")),
+				(30u, Script.FromHex("54")),
+				(19u, Script.FromHex("55")),
+			};
+
+			var treeInfo = TaprootSpendInfo.WithHuffmanTree(internalKey, scriptWeights);
+			/* The resulting tree should put the scripts into a tree similar
+			 * to the following:
+			 *
+			 *   1      __/\__
+			 *         /      \
+			 *        /\     / \
+			 *   2   54 52  53 /\
+			 *   3            55 51
+			 */
+			var expected = new[] { ("51", 3), ("52", 2), ("53", 2), ("54", 2), ("55", 3) };
+			foreach (var t in expected)
+			{
+				var (script, expectedLength) = t;
+				Assert.True(
+					treeInfo
+						.ScriptToMerkleProofMap!
+						.TryGetValue((Script.FromHex(script), (byte)TaprootConstants.TAPROOT_LEAF_TAPSCRIPT), out var scriptSet)
+				);
+				var actualLength = scriptSet[0];
+				Assert.Equal(expectedLength, actualLength.Count);
+			}
+
+			var outputKey = treeInfo.OutputPubKey;
+
+			foreach (var (_, script) in scriptWeights)
+			{
+				var ctrlBlock = treeInfo.GetControlBlock(script, (byte)TaprootConstants.TAPROOT_LEAF_TAPSCRIPT);
+				Assert.True(ctrlBlock.VerifyTaprootCommitment(outputKey, script));
+			}
+		}
+
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void TaptreeBuilderTests()
+		{
+			var internalPubKey = TaprootInternalPubKey.Parse("93c7378d96518a75448821c4f7c8f4bae7ce60f804d03d1f0628dd5dd0f5de51");
+			var builder = new TaprootBuilder();
+			// Create a tree as shown below
+			// For example, imagine this tree:
+			// A, B , C are at depth 2 and D,E are at 3
+			//                                       ....
+			//                                     /      \
+			//                                    /\      /\
+			//                                   /  \    /  \
+			//                                  A    B  C  / \
+			//                                            D   E
+			var a = Script.FromHex("51");
+			var b = Script.FromHex("52");
+			var c = Script.FromHex("53");
+			var d = Script.FromHex("54");
+			var e = Script.FromHex("55");
+			builder
+				.AddLeaf(2, a)
+				.AddLeaf(2, b)
+				.AddLeaf(2, c)
+				.AddLeaf(3, d);
+
+			// Trying to finalize an incomplete tree throws Exception(
+			Assert.Throws<InvalidOperationException>(() => builder.Finalize(internalPubKey));
+			builder.AddLeaf(3, e);
+			var treeInfo = builder.Finalize(internalPubKey);
+			var outputKey = treeInfo.OutputPubKey;
+			foreach (var script in new[] { a, b, c, d, e })
+			{
+				var ctrlBlock = treeInfo.GetControlBlock(script, (byte)TaprootConstants.TAPROOT_LEAF_TAPSCRIPT);
+				Assert.True(ctrlBlock.VerifyTaprootCommitment(outputKey, script));
+			}
+		}
+
+		private TaprootBuilder ProcessScriptTrees(JToken v, TaprootBuilder builder, List<(Script, byte)> leaves,
+			uint depth)
+		{
+
+			if (v is null) return builder;
+			if (v is JArray arr)
+			{
+				foreach (var leaf in arr)
+				{
+					builder = ProcessScriptTrees(leaf, builder, leaves, depth + 1);
+				}
+			}
+			else
+			{
+				var script = Script.FromHex(v["script"].ToString());
+				var ver = (byte)(ulong)v["leafVersion"];
+				leaves.Add((script, ver));
+				builder = builder.AddLeaf(depth, script, ver);
+			}
+			return builder;
+		}
+		[Fact]
+		[Trait("Core", "Core")]
+		public void BIP341Tests()
+		{
+			var data = JObject.Parse(File.ReadAllText("data/bip-0341/wallet-test-vectors.json"));
+
+			foreach (var arr in data["scriptPubKey"]!.ToArray())
+			{
+				var internalKey = TaprootInternalPubKey.Parse(arr["given"]!["internalPubkey"]!.ToString());
+				var scriptTree = arr["given"]["scriptTree"];
+				if (!scriptTree.HasValues)
+				{
+					Assert.False(arr["intermediary"]!["merkleRoot"]!.HasValues);
+				}
+				else
+				{
+					var merkleRootHex = arr["intermediary"]!["merkleRoot"]!.ToString();
+					Assert.NotNull(merkleRootHex);
+					_testOutputHelper.WriteLine($"scriptTree: {scriptTree}, merkleRoot {merkleRootHex}");
+					var merkleRoot =
+						new uint256(Encoders.Hex.DecodeData( merkleRootHex));
+					var leafHashes = arr["intermediary"]!["leafHashes"]!.ToArray();
+					var ctrlBlocks = arr["expected"]!["scriptPathControlBlocks"]!.ToArray();
+					var builder = new TaprootBuilder();
+					var leaves = new List<(Script, byte)>();
+					builder = ProcessScriptTrees(scriptTree, builder, leaves, 0);
+					var spendInfo = builder.Finalize(internalKey);
+					foreach (var (i, (script, version)) in leaves.Select((v, i) => (i, v)))
+					{
+						var expectedLeafHash = new uint256(Encoders.Hex.DecodeData(leafHashes[i].ToString()));
+						var expectedControlBlockStr = ctrlBlocks[i].ToString();
+						var expectedControlBlock = ControlBlock.FromHex(expectedControlBlockStr);
+						var leafHash = script.TaprootLeafHash(version);
+						var ctrlBlock = spendInfo.GetControlBlock(script, version);
+						Assert.Equal(expectedLeafHash, leafHash);
+						var ctrlStr = Encoders.Hex.EncodeData(ctrlBlock.ToBytes());
+						_testOutputHelper.WriteLine($"Control block str {ctrlStr}. expected {expectedControlBlockStr}");
+						Assert.Equal(expectedControlBlock, ctrlBlock);
+						Assert.Equal(expectedControlBlockStr, ctrlStr);
+					}
+
+					var expectedOutputKey = TaprootPubKey.Parse(arr["intermediary"]!["tweakedPubkey"]!.ToString());
+					var expectedTweak = arr["intermediary"]!["tweak"]!.ToString();
+					var expectedSpk = Script.FromHex(arr["expected"]!["scriptPubKey"]!.ToString());
+					var expectedAddr = arr["expected"]!["bip350Address"]!.ToString();
+
+					var tweak = new byte [32];
+					TaprootFullPubKey.ComputeTapTweak(internalKey, merkleRoot, tweak);
+					var tweakHex = DataEncoders.Encoders.Hex.EncodeData(tweak);
+					var outputKey = internalKey.GetTaprootFullPubKey(merkleRoot);
+					var addr = new TaprootAddress(outputKey, Network.Main);
+					var spk = addr.ScriptPubKey;
+					Assert.Equal(outputKey, expectedOutputKey);
+					Assert.Equal(tweakHex, expectedTweak);
+					Assert.Equal(addr.ToString(), expectedAddr);
+					Assert.Equal(spk, expectedSpk);
+				}
+			}
+		}
+#endif
+	}
+}

--- a/NBitcoin.Tests/TaprootBuilderTests.cs
+++ b/NBitcoin.Tests/TaprootBuilderTests.cs
@@ -18,7 +18,7 @@ namespace NBitcoin.Tests
 		{
 			_testOutputHelper = testOutputHelper;
 		}
-#if NET6_0_OR_GREATER
+#if HAS_SPAN
 		[Fact]
 		[Trait("UnitTest", "UnitTest")]
 		public void TestVectorsCore()

--- a/NBitcoin.Tests/data/bip-0341/wallet-test-vectors.json
+++ b/NBitcoin.Tests/data/bip-0341/wallet-test-vectors.json
@@ -1,0 +1,452 @@
+{
+    "version": 1,
+    "scriptPubKey": [
+        {
+            "given": {
+                "internalPubkey": "d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d",
+                "scriptTree": null
+            },
+            "intermediary": {
+                "merkleRoot": null,
+                "tweak": "b86e7be8f39bab32a6f2c0443abbc210f0edac0e2c53d501b36b64437d9c6c70",
+                "tweakedPubkey": "53a1f6e454df1aa2776a2814a721372d6258050de330b3c6d10ee8f4e0dda343"
+            },
+            "expected": {
+                "scriptPubKey": "512053a1f6e454df1aa2776a2814a721372d6258050de330b3c6d10ee8f4e0dda343",
+                "bip350Address": "bc1p2wsldez5mud2yam29q22wgfh9439spgduvct83k3pm50fcxa5dps59h4z5"
+            }
+        },
+        {
+            "given": {
+                "internalPubkey": "187791b6f712a8ea41c8ecdd0ee77fab3e85263b37e1ec18a3651926b3a6cf27",
+                "scriptTree": {
+                    "id": 0,
+                    "script": "20d85a959b0290bf19bb89ed43c916be835475d013da4b362117393e25a48229b8ac",
+                    "leafVersion": 192
+                }
+            },
+            "intermediary": {
+                "leafHashes": [
+                    "5b75adecf53548f3ec6ad7d78383bf84cc57b55a3127c72b9a2481752dd88b21"
+                ],
+                "merkleRoot": "5b75adecf53548f3ec6ad7d78383bf84cc57b55a3127c72b9a2481752dd88b21",
+                "tweak": "cbd8679ba636c1110ea247542cfbd964131a6be84f873f7f3b62a777528ed001",
+                "tweakedPubkey": "147c9c57132f6e7ecddba9800bb0c4449251c92a1e60371ee77557b6620f3ea3"
+            },
+            "expected": {
+                "scriptPubKey": "5120147c9c57132f6e7ecddba9800bb0c4449251c92a1e60371ee77557b6620f3ea3",
+                "bip350Address": "bc1pz37fc4cn9ah8anwm4xqqhvxygjf9rjf2resrw8h8w4tmvcs0863sa2e586",
+                "scriptPathControlBlocks": [
+                    "c1187791b6f712a8ea41c8ecdd0ee77fab3e85263b37e1ec18a3651926b3a6cf27"
+                ]
+            }
+        },
+        {
+            "given": {
+                "internalPubkey": "93478e9488f956df2396be2ce6c5cced75f900dfa18e7dabd2428aae78451820",
+                "scriptTree": {
+                    "id": 0,
+                    "script": "20b617298552a72ade070667e86ca63b8f5789a9fe8731ef91202a91c9f3459007ac",
+                    "leafVersion": 192
+                }
+            },
+            "intermediary": {
+                "leafHashes": [
+                    "c525714a7f49c28aedbbba78c005931a81c234b2f6c99a73e4d06082adc8bf2b"
+                ],
+                "merkleRoot": "c525714a7f49c28aedbbba78c005931a81c234b2f6c99a73e4d06082adc8bf2b",
+                "tweak": "6af9e28dbf9d6aaf027696e2598a5b3d056f5fd2355a7fd5a37a0e5008132d30",
+                "tweakedPubkey": "e4d810fd50586274face62b8a807eb9719cef49c04177cc6b76a9a4251d5450e"
+            },
+            "expected": {
+                "scriptPubKey": "5120e4d810fd50586274face62b8a807eb9719cef49c04177cc6b76a9a4251d5450e",
+                "bip350Address": "bc1punvppl2stp38f7kwv2u2spltjuvuaayuqsthe34hd2dyy5w4g58qqfuag5",
+                "scriptPathControlBlocks": [
+                    "c093478e9488f956df2396be2ce6c5cced75f900dfa18e7dabd2428aae78451820"
+                ]
+            }
+        },
+        {
+            "given": {
+                "internalPubkey": "ee4fe085983462a184015d1f782d6a5f8b9c2b60130aff050ce221ecf3786592",
+                "scriptTree": [
+                    {
+                        "id": 0,
+                        "script": "20387671353e273264c495656e27e39ba899ea8fee3bb69fb2a680e22093447d48ac",
+                        "leafVersion": 192
+                    },
+                    {
+                        "id": 1,
+                        "script": "06424950333431",
+                        "leafVersion": 250
+                    }
+                ]
+            },
+            "intermediary": {
+                "leafHashes": [
+                    "8ad69ec7cf41c2a4001fd1f738bf1e505ce2277acdcaa63fe4765192497f47a7",
+                    "f224a923cd0021ab202ab139cc56802ddb92dcfc172b9212261a539df79a112a"
+                ],
+                "merkleRoot": "6c2dc106ab816b73f9d07e3cd1ef2c8c1256f519748e0813e4edd2405d277bef",
+                "tweak": "9e0517edc8259bb3359255400b23ca9507f2a91cd1e4250ba068b4eafceba4a9",
+                "tweakedPubkey": "712447206d7a5238acc7ff53fbe94a3b64539ad291c7cdbc490b7577e4b17df5"
+            },
+            "expected": {
+                "scriptPubKey": "5120712447206d7a5238acc7ff53fbe94a3b64539ad291c7cdbc490b7577e4b17df5",
+                "bip350Address": "bc1pwyjywgrd0ffr3tx8laflh6228dj98xkjj8rum0zfpd6h0e930h6saqxrrm",
+                "scriptPathControlBlocks": [
+                    "c0ee4fe085983462a184015d1f782d6a5f8b9c2b60130aff050ce221ecf3786592f224a923cd0021ab202ab139cc56802ddb92dcfc172b9212261a539df79a112a",
+                    "faee4fe085983462a184015d1f782d6a5f8b9c2b60130aff050ce221ecf37865928ad69ec7cf41c2a4001fd1f738bf1e505ce2277acdcaa63fe4765192497f47a7"
+                ]
+            }
+        },
+        {
+            "given": {
+                "internalPubkey": "f9f400803e683727b14f463836e1e78e1c64417638aa066919291a225f0e8dd8",
+                "scriptTree": [
+                    {
+                        "id": 0,
+                        "script": "2044b178d64c32c4a05cc4f4d1407268f764c940d20ce97abfd44db5c3592b72fdac",
+                        "leafVersion": 192
+                    },
+                    {
+                        "id": 1,
+                        "script": "07546170726f6f74",
+                        "leafVersion": 192
+                    }
+                ]
+            },
+            "intermediary": {
+                "leafHashes": [
+                    "64512fecdb5afa04f98839b50e6f0cb7b1e539bf6f205f67934083cdcc3c8d89",
+                    "2cb2b90daa543b544161530c925f285b06196940d6085ca9474d41dc3822c5cb"
+                ],
+                "merkleRoot": "ab179431c28d3b68fb798957faf5497d69c883c6fb1e1cd9f81483d87bac90cc",
+                "tweak": "639f0281b7ac49e742cd25b7f188657626da1ad169209078e2761cefd91fd65e",
+                "tweakedPubkey": "77e30a5522dd9f894c3f8b8bd4c4b2cf82ca7da8a3ea6a239655c39c050ab220"
+            },
+            "expected": {
+                "scriptPubKey": "512077e30a5522dd9f894c3f8b8bd4c4b2cf82ca7da8a3ea6a239655c39c050ab220",
+                "bip350Address": "bc1pwl3s54fzmk0cjnpl3w9af39je7pv5ldg504x5guk2hpecpg2kgsqaqstjq",
+                "scriptPathControlBlocks": [
+                    "c1f9f400803e683727b14f463836e1e78e1c64417638aa066919291a225f0e8dd82cb2b90daa543b544161530c925f285b06196940d6085ca9474d41dc3822c5cb",
+                    "c1f9f400803e683727b14f463836e1e78e1c64417638aa066919291a225f0e8dd864512fecdb5afa04f98839b50e6f0cb7b1e539bf6f205f67934083cdcc3c8d89"
+                ]
+            }
+        },
+        {
+            "given": {
+                "internalPubkey": "e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6f",
+                "scriptTree": [
+                    {
+                        "id": 0,
+                        "script": "2072ea6adcf1d371dea8fba1035a09f3d24ed5a059799bae114084130ee5898e69ac",
+                        "leafVersion": 192
+                    },
+                    [
+                        {
+                            "id": 1,
+                            "script": "202352d137f2f3ab38d1eaa976758873377fa5ebb817372c71e2c542313d4abda8ac",
+                            "leafVersion": 192
+                        },
+                        {
+                            "id": 2,
+                            "script": "207337c0dd4253cb86f2c43a2351aadd82cccb12a172cd120452b9bb8324f2186aac",
+                            "leafVersion": 192
+                        }
+                    ]
+                ]
+            },
+            "intermediary": {
+                "leafHashes": [
+                    "2645a02e0aac1fe69d69755733a9b7621b694bb5b5cde2bbfc94066ed62b9817",
+                    "ba982a91d4fc552163cb1c0da03676102d5b7a014304c01f0c77b2b8e888de1c",
+                    "9e31407bffa15fefbf5090b149d53959ecdf3f62b1246780238c24501d5ceaf6"
+                ],
+                "merkleRoot": "ccbd66c6f7e8fdab47b3a486f59d28262be857f30d4773f2d5ea47f7761ce0e2",
+                "tweak": "b57bfa183d28eeb6ad688ddaabb265b4a41fbf68e5fed2c72c74de70d5a786f4",
+                "tweakedPubkey": "91b64d5324723a985170e4dc5a0f84c041804f2cd12660fa5dec09fc21783605"
+            },
+            "expected": {
+                "scriptPubKey": "512091b64d5324723a985170e4dc5a0f84c041804f2cd12660fa5dec09fc21783605",
+                "bip350Address": "bc1pjxmy65eywgafs5tsunw95ruycpqcqnev6ynxp7jaasylcgtcxczs6n332e",
+                "scriptPathControlBlocks": [
+                    "c0e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6fffe578e9ea769027e4f5a3de40732f75a88a6353a09d767ddeb66accef85e553",
+                    "c0e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6f9e31407bffa15fefbf5090b149d53959ecdf3f62b1246780238c24501d5ceaf62645a02e0aac1fe69d69755733a9b7621b694bb5b5cde2bbfc94066ed62b9817",
+                    "c0e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6fba982a91d4fc552163cb1c0da03676102d5b7a014304c01f0c77b2b8e888de1c2645a02e0aac1fe69d69755733a9b7621b694bb5b5cde2bbfc94066ed62b9817"
+                ]
+            }
+        },
+        {
+            "given": {
+                "internalPubkey": "55adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312d",
+                "scriptTree": [
+                    {
+                        "id": 0,
+                        "script": "2071981521ad9fc9036687364118fb6ccd2035b96a423c59c5430e98310a11abe2ac",
+                        "leafVersion": 192
+                    },
+                    [
+                        {
+                            "id": 1,
+                            "script": "20d5094d2dbe9b76e2c245a2b89b6006888952e2faa6a149ae318d69e520617748ac",
+                            "leafVersion": 192
+                        },
+                        {
+                            "id": 2,
+                            "script": "20c440b462ad48c7a77f94cd4532d8f2119dcebbd7c9764557e62726419b08ad4cac",
+                            "leafVersion": 192
+                        }
+                    ]
+                ]
+            },
+            "intermediary": {
+                "leafHashes": [
+                    "f154e8e8e17c31d3462d7132589ed29353c6fafdb884c5a6e04ea938834f0d9d",
+                    "737ed1fe30bc42b8022d717b44f0d93516617af64a64753b7a06bf16b26cd711",
+                    "d7485025fceb78b9ed667db36ed8b8dc7b1f0b307ac167fa516fe4352b9f4ef7"
+                ],
+                "merkleRoot": "2f6b2c5397b6d68ca18e09a3f05161668ffe93a988582d55c6f07bd5b3329def",
+                "tweak": "6579138e7976dc13b6a92f7bfd5a2fc7684f5ea42419d43368301470f3b74ed9",
+                "tweakedPubkey": "75169f4001aa68f15bbed28b218df1d0a62cbbcf1188c6665110c293c907b831"
+            },
+            "expected": {
+                "scriptPubKey": "512075169f4001aa68f15bbed28b218df1d0a62cbbcf1188c6665110c293c907b831",
+                "bip350Address": "bc1pw5tf7sqp4f50zka7629jrr036znzew70zxyvvej3zrpf8jg8hqcssyuewe",
+                "scriptPathControlBlocks": [
+                    "c155adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312d3cd369a528b326bc9d2133cbd2ac21451acb31681a410434672c8e34fe757e91",
+                    "c155adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312dd7485025fceb78b9ed667db36ed8b8dc7b1f0b307ac167fa516fe4352b9f4ef7f154e8e8e17c31d3462d7132589ed29353c6fafdb884c5a6e04ea938834f0d9d",
+                    "c155adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312d737ed1fe30bc42b8022d717b44f0d93516617af64a64753b7a06bf16b26cd711f154e8e8e17c31d3462d7132589ed29353c6fafdb884c5a6e04ea938834f0d9d"
+                ]
+            }
+        }
+    ],
+    "keyPathSpending": [
+        {
+            "given": {
+                "rawUnsignedTx": "02000000097de20cbff686da83a54981d2b9bab3586f4ca7e48f57f5b55963115f3b334e9c010000000000000000d7b7cab57b1393ace2d064f4d4a2cb8af6def61273e127517d44759b6dafdd990000000000fffffffff8e1f583384333689228c5d28eac13366be082dc57441760d957275419a418420000000000fffffffff0689180aa63b30cb162a73c6d2a38b7eeda2a83ece74310fda0843ad604853b0100000000feffffffaa5202bdf6d8ccd2ee0f0202afbbb7461d9264a25e5bfd3c5a52ee1239e0ba6c0000000000feffffff956149bdc66faa968eb2be2d2faa29718acbfe3941215893a2a3446d32acd050000000000000000000e664b9773b88c09c32cb70a2a3e4da0ced63b7ba3b22f848531bbb1d5d5f4c94010000000000000000e9aa6b8e6c9de67619e6a3924ae25696bb7b694bb677a632a74ef7eadfd4eabf0000000000ffffffffa778eb6a263dc090464cd125c466b5a99667720b1c110468831d058aa1b82af10100000000ffffffff0200ca9a3b000000001976a91406afd46bcdfd22ef94ac122aa11f241244a37ecc88ac807840cb0000000020ac9a87f5594be208f8532db38cff670c450ed2fea8fcdefcc9a663f78bab962b0065cd1d",
+                "utxosSpent": [
+                    {
+                        "scriptPubKey": "512053a1f6e454df1aa2776a2814a721372d6258050de330b3c6d10ee8f4e0dda343",
+                        "amountSats": 420000000
+                    },
+                    {
+                        "scriptPubKey": "5120147c9c57132f6e7ecddba9800bb0c4449251c92a1e60371ee77557b6620f3ea3",
+                        "amountSats": 462000000
+                    },
+                    {
+                        "scriptPubKey": "76a914751e76e8199196d454941c45d1b3a323f1433bd688ac",
+                        "amountSats": 294000000
+                    },
+                    {
+                        "scriptPubKey": "5120e4d810fd50586274face62b8a807eb9719cef49c04177cc6b76a9a4251d5450e",
+                        "amountSats": 504000000
+                    },
+                    {
+                        "scriptPubKey": "512091b64d5324723a985170e4dc5a0f84c041804f2cd12660fa5dec09fc21783605",
+                        "amountSats": 630000000
+                    },
+                    {
+                        "scriptPubKey": "00147dd65592d0ab2fe0d0257d571abf032cd9db93dc",
+                        "amountSats": 378000000
+                    },
+                    {
+                        "scriptPubKey": "512075169f4001aa68f15bbed28b218df1d0a62cbbcf1188c6665110c293c907b831",
+                        "amountSats": 672000000
+                    },
+                    {
+                        "scriptPubKey": "5120712447206d7a5238acc7ff53fbe94a3b64539ad291c7cdbc490b7577e4b17df5",
+                        "amountSats": 546000000
+                    },
+                    {
+                        "scriptPubKey": "512077e30a5522dd9f894c3f8b8bd4c4b2cf82ca7da8a3ea6a239655c39c050ab220",
+                        "amountSats": 588000000
+                    }
+                ]
+            },
+            "intermediary": {
+                "hashAmounts": "58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde6",
+                "hashOutputs": "a2e6dab7c1f0dcd297c8d61647fd17d821541ea69c3cc37dcbad7f90d4eb4bc5",
+                "hashPrevouts": "e3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f",
+                "hashScriptPubkeys": "23ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e21",
+                "hashSequences": "18959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957e"
+            },
+            "inputSpending": [
+                {
+                    "given": {
+                        "txinIndex": 0,
+                        "internalPrivkey": "6b973d88838f27366ed61c9ad6367663045cb456e28335c109e30717ae0c6baa",
+                        "merkleRoot": null,
+                        "hashType": 3
+                    },
+                    "intermediary": {
+                        "internalPubkey": "d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d",
+                        "tweak": "b86e7be8f39bab32a6f2c0443abbc210f0edac0e2c53d501b36b64437d9c6c70",
+                        "tweakedPrivkey": "2405b971772ad26915c8dcdf10f238753a9b837e5f8e6a86fd7c0cce5b7296d9",
+                        "sigMsg": "0003020000000065cd1de3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde623ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e2118959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957e0000000000d0418f0e9a36245b9a50ec87f8bf5be5bcae434337b87139c3a5b1f56e33cba0",
+                        "precomputedUsed": [
+                            "hashAmounts",
+                            "hashPrevouts",
+                            "hashScriptPubkeys",
+                            "hashSequences"
+                        ],
+                        "sigHash": "2514a6272f85cfa0f45eb907fcb0d121b808ed37c6ea160a5a9046ed5526d555"
+                    },
+                    "expected": {
+                        "witness": [
+                            "ed7c1647cb97379e76892be0cacff57ec4a7102aa24296ca39af7541246d8ff14d38958d4cc1e2e478e4d4a764bbfd835b16d4e314b72937b29833060b87276c03"
+                        ]
+                    }
+                },
+                {
+                    "given": {
+                        "txinIndex": 1,
+                        "internalPrivkey": "1e4da49f6aaf4e5cd175fe08a32bb5cb4863d963921255f33d3bc31e1343907f",
+                        "merkleRoot": "5b75adecf53548f3ec6ad7d78383bf84cc57b55a3127c72b9a2481752dd88b21",
+                        "hashType": 131
+                    },
+                    "intermediary": {
+                        "internalPubkey": "187791b6f712a8ea41c8ecdd0ee77fab3e85263b37e1ec18a3651926b3a6cf27",
+                        "tweak": "cbd8679ba636c1110ea247542cfbd964131a6be84f873f7f3b62a777528ed001",
+                        "tweakedPrivkey": "ea260c3b10e60f6de018455cd0278f2f5b7e454be1999572789e6a9565d26080",
+                        "sigMsg": "0083020000000065cd1d00d7b7cab57b1393ace2d064f4d4a2cb8af6def61273e127517d44759b6dafdd9900000000808f891b00000000225120147c9c57132f6e7ecddba9800bb0c4449251c92a1e60371ee77557b6620f3ea3ffffffffffcef8fb4ca7efc5433f591ecfc57391811ce1e186a3793024def5c884cba51d",
+                        "precomputedUsed": [],
+                        "sigHash": "325a644af47e8a5a2591cda0ab0723978537318f10e6a63d4eed783b96a71a4d"
+                    },
+                    "expected": {
+                        "witness": [
+                            "052aedffc554b41f52b521071793a6b88d6dbca9dba94cf34c83696de0c1ec35ca9c5ed4ab28059bd606a4f3a657eec0bb96661d42921b5f50a95ad33675b54f83"
+                        ]
+                    }
+                },
+                {
+                    "given": {
+                        "txinIndex": 3,
+                        "internalPrivkey": "d3c7af07da2d54f7a7735d3d0fc4f0a73164db638b2f2f7c43f711f6d4aa7e64",
+                        "merkleRoot": "c525714a7f49c28aedbbba78c005931a81c234b2f6c99a73e4d06082adc8bf2b",
+                        "hashType": 1
+                    },
+                    "intermediary": {
+                        "internalPubkey": "93478e9488f956df2396be2ce6c5cced75f900dfa18e7dabd2428aae78451820",
+                        "tweak": "6af9e28dbf9d6aaf027696e2598a5b3d056f5fd2355a7fd5a37a0e5008132d30",
+                        "tweakedPrivkey": "97323385e57015b75b0339a549c56a948eb961555973f0951f555ae6039ef00d",
+                        "sigMsg": "0001020000000065cd1de3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde623ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e2118959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957ea2e6dab7c1f0dcd297c8d61647fd17d821541ea69c3cc37dcbad7f90d4eb4bc50003000000",
+                        "precomputedUsed": [
+                            "hashAmounts",
+                            "hashOutputs",
+                            "hashPrevouts",
+                            "hashScriptPubkeys",
+                            "hashSequences"
+                        ],
+                        "sigHash": "bf013ea93474aa67815b1b6cc441d23b64fa310911d991e713cd34c7f5d46669"
+                    },
+                    "expected": {
+                        "witness": [
+                            "ff45f742a876139946a149ab4d9185574b98dc919d2eb6754f8abaa59d18b025637a3aa043b91817739554f4ed2026cf8022dbd83e351ce1fabc272841d2510a01"
+                        ]
+                    }
+                },
+                {
+                    "given": {
+                        "txinIndex": 4,
+                        "internalPrivkey": "f36bb07a11e469ce941d16b63b11b9b9120a84d9d87cff2c84a8d4affb438f4e",
+                        "merkleRoot": "ccbd66c6f7e8fdab47b3a486f59d28262be857f30d4773f2d5ea47f7761ce0e2",
+                        "hashType": 0
+                    },
+                    "intermediary": {
+                        "internalPubkey": "e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6f",
+                        "tweak": "b57bfa183d28eeb6ad688ddaabb265b4a41fbf68e5fed2c72c74de70d5a786f4",
+                        "tweakedPrivkey": "a8e7aa924f0d58854185a490e6c41f6efb7b675c0f3331b7f14b549400b4d501",
+                        "sigMsg": "0000020000000065cd1de3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde623ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e2118959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957ea2e6dab7c1f0dcd297c8d61647fd17d821541ea69c3cc37dcbad7f90d4eb4bc50004000000",
+                        "precomputedUsed": [
+                            "hashAmounts",
+                            "hashOutputs",
+                            "hashPrevouts",
+                            "hashScriptPubkeys",
+                            "hashSequences"
+                        ],
+                        "sigHash": "4f900a0bae3f1446fd48490c2958b5a023228f01661cda3496a11da502a7f7ef"
+                    },
+                    "expected": {
+                        "witness": [
+                            "b4010dd48a617db09926f729e79c33ae0b4e94b79f04a1ae93ede6315eb3669de185a17d2b0ac9ee09fd4c64b678a0b61a0a86fa888a273c8511be83bfd6810f"
+                        ]
+                    }
+                },
+                {
+                    "given": {
+                        "txinIndex": 6,
+                        "internalPrivkey": "415cfe9c15d9cea27d8104d5517c06e9de48e2f986b695e4f5ffebf230e725d8",
+                        "merkleRoot": "2f6b2c5397b6d68ca18e09a3f05161668ffe93a988582d55c6f07bd5b3329def",
+                        "hashType": 2
+                    },
+                    "intermediary": {
+                        "internalPubkey": "55adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312d",
+                        "tweak": "6579138e7976dc13b6a92f7bfd5a2fc7684f5ea42419d43368301470f3b74ed9",
+                        "tweakedPrivkey": "241c14f2639d0d7139282aa6abde28dd8a067baa9d633e4e7230287ec2d02901",
+                        "sigMsg": "0002020000000065cd1de3b33bb4ef3a52ad1fffb555c0d82828eb22737036eaeb02a235d82b909c4c3f58a6964a4f5f8f0b642ded0a8a553be7622a719da71d1f5befcefcdee8e0fde623ad0f61ad2bca5ba6a7693f50fce988e17c3780bf2b1e720cfbb38fbdd52e2118959c7221ab5ce9e26c3cd67b22c24f8baa54bac281d8e6b05e400e6c3a957e0006000000",
+                        "precomputedUsed": [
+                            "hashAmounts",
+                            "hashPrevouts",
+                            "hashScriptPubkeys",
+                            "hashSequences"
+                        ],
+                        "sigHash": "15f25c298eb5cdc7eb1d638dd2d45c97c4c59dcaec6679cfc16ad84f30876b85"
+                    },
+                    "expected": {
+                        "witness": [
+                            "a3785919a2ce3c4ce26f298c3d51619bc474ae24014bcdd31328cd8cfbab2eff3395fa0a16fe5f486d12f22a9cedded5ae74feb4bbe5351346508c5405bcfee002"
+                        ]
+                    }
+                },
+                {
+                    "given": {
+                        "txinIndex": 7,
+                        "internalPrivkey": "c7b0e81f0a9a0b0499e112279d718cca98e79a12e2f137c72ae5b213aad0d103",
+                        "merkleRoot": "6c2dc106ab816b73f9d07e3cd1ef2c8c1256f519748e0813e4edd2405d277bef",
+                        "hashType": 130
+                    },
+                    "intermediary": {
+                        "internalPubkey": "ee4fe085983462a184015d1f782d6a5f8b9c2b60130aff050ce221ecf3786592",
+                        "tweak": "9e0517edc8259bb3359255400b23ca9507f2a91cd1e4250ba068b4eafceba4a9",
+                        "tweakedPrivkey": "65b6000cd2bfa6b7cf736767a8955760e62b6649058cbc970b7c0871d786346b",
+                        "sigMsg": "0082020000000065cd1d00e9aa6b8e6c9de67619e6a3924ae25696bb7b694bb677a632a74ef7eadfd4eabf00000000804c8b2000000000225120712447206d7a5238acc7ff53fbe94a3b64539ad291c7cdbc490b7577e4b17df5ffffffff",
+                        "precomputedUsed": [],
+                        "sigHash": "cd292de50313804dabe4685e83f923d2969577191a3e1d2882220dca88cbeb10"
+                    },
+                    "expected": {
+                        "witness": [
+                            "ea0c6ba90763c2d3a296ad82ba45881abb4f426b3f87af162dd24d5109edc1cdd11915095ba47c3a9963dc1e6c432939872bc49212fe34c632cd3ab9fed429c482"
+                        ]
+                    }
+                },
+                {
+                    "given": {
+                        "txinIndex": 8,
+                        "internalPrivkey": "77863416be0d0665e517e1c375fd6f75839544eca553675ef7fdf4949518ebaa",
+                        "merkleRoot": "ab179431c28d3b68fb798957faf5497d69c883c6fb1e1cd9f81483d87bac90cc",
+                        "hashType": 129
+                    },
+                    "intermediary": {
+                        "internalPubkey": "f9f400803e683727b14f463836e1e78e1c64417638aa066919291a225f0e8dd8",
+                        "tweak": "639f0281b7ac49e742cd25b7f188657626da1ad169209078e2761cefd91fd65e",
+                        "tweakedPrivkey": "ec18ce6af99f43815db543f47b8af5ff5df3b2cb7315c955aa4a86e8143d2bf5",
+                        "sigMsg": "0081020000000065cd1da2e6dab7c1f0dcd297c8d61647fd17d821541ea69c3cc37dcbad7f90d4eb4bc500a778eb6a263dc090464cd125c466b5a99667720b1c110468831d058aa1b82af101000000002b0c230000000022512077e30a5522dd9f894c3f8b8bd4c4b2cf82ca7da8a3ea6a239655c39c050ab220ffffffff",
+                        "precomputedUsed": [
+                            "hashOutputs"
+                        ],
+                        "sigHash": "cccb739eca6c13a8a89e6e5cd317ffe55669bbda23f2fd37b0f18755e008edd2"
+                    },
+                    "expected": {
+                        "witness": [
+                            "bbc9584a11074e83bc8c6759ec55401f0ae7b03ef290c3139814f545b58a9f8127258000874f44bc46db7646322107d4d86aec8e73b8719a61fff761d75b5dd981"
+                        ]
+                    }
+                }
+            ],
+            "auxiliary": {
+                "fullySignedTx": "020000000001097de20cbff686da83a54981d2b9bab3586f4ca7e48f57f5b55963115f3b334e9c010000000000000000d7b7cab57b1393ace2d064f4d4a2cb8af6def61273e127517d44759b6dafdd990000000000fffffffff8e1f583384333689228c5d28eac13366be082dc57441760d957275419a41842000000006b4830450221008f3b8f8f0537c420654d2283673a761b7ee2ea3c130753103e08ce79201cf32a022079e7ab904a1980ef1c5890b648c8783f4d10103dd62f740d13daa79e298d50c201210279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798fffffffff0689180aa63b30cb162a73c6d2a38b7eeda2a83ece74310fda0843ad604853b0100000000feffffffaa5202bdf6d8ccd2ee0f0202afbbb7461d9264a25e5bfd3c5a52ee1239e0ba6c0000000000feffffff956149bdc66faa968eb2be2d2faa29718acbfe3941215893a2a3446d32acd050000000000000000000e664b9773b88c09c32cb70a2a3e4da0ced63b7ba3b22f848531bbb1d5d5f4c94010000000000000000e9aa6b8e6c9de67619e6a3924ae25696bb7b694bb677a632a74ef7eadfd4eabf0000000000ffffffffa778eb6a263dc090464cd125c466b5a99667720b1c110468831d058aa1b82af10100000000ffffffff0200ca9a3b000000001976a91406afd46bcdfd22ef94ac122aa11f241244a37ecc88ac807840cb0000000020ac9a87f5594be208f8532db38cff670c450ed2fea8fcdefcc9a663f78bab962b0141ed7c1647cb97379e76892be0cacff57ec4a7102aa24296ca39af7541246d8ff14d38958d4cc1e2e478e4d4a764bbfd835b16d4e314b72937b29833060b87276c030141052aedffc554b41f52b521071793a6b88d6dbca9dba94cf34c83696de0c1ec35ca9c5ed4ab28059bd606a4f3a657eec0bb96661d42921b5f50a95ad33675b54f83000141ff45f742a876139946a149ab4d9185574b98dc919d2eb6754f8abaa59d18b025637a3aa043b91817739554f4ed2026cf8022dbd83e351ce1fabc272841d2510a010140b4010dd48a617db09926f729e79c33ae0b4e94b79f04a1ae93ede6315eb3669de185a17d2b0ac9ee09fd4c64b678a0b61a0a86fa888a273c8511be83bfd6810f0247304402202b795e4de72646d76eab3f0ab27dfa30b810e856ff3a46c9a702df53bb0d8cc302203ccc4d822edab5f35caddb10af1be93583526ccfbade4b4ead350781e2f8adcd012102f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f90141a3785919a2ce3c4ce26f298c3d51619bc474ae24014bcdd31328cd8cfbab2eff3395fa0a16fe5f486d12f22a9cedded5ae74feb4bbe5351346508c5405bcfee0020141ea0c6ba90763c2d3a296ad82ba45881abb4f426b3f87af162dd24d5109edc1cdd11915095ba47c3a9963dc1e6c432939872bc49212fe34c632cd3ab9fed429c4820141bbc9584a11074e83bc8c6759ec55401f0ae7b03ef290c3139814f545b58a9f8127258000874f44bc46db7646322107d4d86aec8e73b8719a61fff761d75b5dd9810065cd1d"
+            }
+        }
+    ]
+}

--- a/NBitcoin/PriorityQueue.cs
+++ b/NBitcoin/PriorityQueue.cs
@@ -61,7 +61,7 @@ namespace NBitcoin
     /// </remarks>
     [DebuggerDisplay("Count = {Count}")]
     [DebuggerTypeProxy(typeof(PriorityQueueDebugView<,>))]
-    public class PriorityQueue<TElement, TPriority>
+    internal class PriorityQueue<TElement, TPriority>
     {
 	    private static int ArrayMaxLength = 0X7FFFFFC7;
         /// <summary>

--- a/NBitcoin/PriorityQueue.cs
+++ b/NBitcoin/PriorityQueue.cs
@@ -1,0 +1,1022 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Runtime.CompilerServices;
+namespace NBitcoin
+{
+#if !NET6_0_OR_GREATER
+	static class SR
+	{
+		internal static string ArgumentOutOfRange_NeedNonNegNum => nameof(ArgumentOutOfRange_NeedNonNegNum);
+		internal static string InvalidOperation_EmptyQueue => nameof(InvalidOperation_EmptyQueue);
+		internal static string Arg_RankMultiDimNotSupported => nameof(Arg_RankMultiDimNotSupported);
+		internal static string  Arg_NonZeroLowerBound=> nameof(Arg_NonZeroLowerBound);
+		internal static string ArgumentOutOfRange_IndexMustBeLessOrEqual => nameof(ArgumentOutOfRange_IndexMustBeLessOrEqual);
+		internal static string Argument_InvalidOffLen => nameof(Argument_InvalidOffLen);
+		internal static string Argument_InvalidArrayType => nameof(Argument_InvalidArrayType);
+		internal static string InvalidOperation_EnumFailedVersion => nameof(InvalidOperation_EnumFailedVersion);
+	}
+	sealed class PriorityQueueDebugView<TElement, TPriority>
+	{
+		private readonly PriorityQueue<TElement, TPriority> _queue;
+		private readonly bool _sort;
+
+		public PriorityQueueDebugView(PriorityQueue<TElement, TPriority> queue)
+		{
+
+			_queue = queue ?? throw new ArgumentNullException(nameof(queue));
+			_sort = true;
+		}
+
+		public PriorityQueueDebugView(PriorityQueue<TElement, TPriority>.UnorderedItemsCollection collection)
+		{
+			_queue = collection?._queue ?? throw new ArgumentNullException(nameof(collection));
+		}
+
+		[DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+		public (TElement Element, TPriority Priority)[] Items
+		{
+			get
+			{
+				var list = new List<(TElement Element, TPriority Priority)>(_queue.UnorderedItems);
+				if (_sort)
+				{
+					list.Sort((i1, i2) => _queue.Comparer.Compare(i1.Priority, i2.Priority));
+				}
+				return list.ToArray();
+			}
+		}
+	}
+    /// <summary>
+    ///  Represents a min priority queue.
+    /// </summary>
+    /// <typeparam name="TElement">Specifies the type of elements in the queue.</typeparam>
+    /// <typeparam name="TPriority">Specifies the type of priority associated with enqueued elements.</typeparam>
+    /// <remarks>
+    ///  Implements an array-backed quaternary min-heap. Each element is enqueued with an associated priority
+    ///  that determines the dequeue order: elements with the lowest priority get dequeued first.
+    /// </remarks>
+    [DebuggerDisplay("Count = {Count}")]
+    [DebuggerTypeProxy(typeof(PriorityQueueDebugView<,>))]
+    public class PriorityQueue<TElement, TPriority>
+    {
+	    private static int ArrayMaxLength = 0X7FFFFFC7;
+        /// <summary>
+        /// Represents an implicit heap-ordered complete d-ary tree, stored as an array.
+        /// </summary>
+        private (TElement Element, TPriority Priority)[] _nodes;
+
+        /// <summary>
+        /// Custom comparer used to order the heap.
+        /// </summary>
+        private readonly IComparer<TPriority>? _comparer;
+
+        /// <summary>
+        /// Lazily-initialized collection used to expose the contents of the queue.
+        /// </summary>
+        private UnorderedItemsCollection? _unorderedItems;
+
+        /// <summary>
+        /// The number of nodes in the heap.
+        /// </summary>
+        private int _size;
+
+        /// <summary>
+        /// Version updated on mutation to help validate enumerators operate on a consistent state.
+        /// </summary>
+        private int _version;
+
+        /// <summary>
+        /// Specifies the arity of the d-ary heap, which here is quaternary.
+        /// It is assumed that this value is a power of 2.
+        /// </summary>
+        private const int Arity = 4;
+
+        /// <summary>
+        /// The binary logarithm of <see cref="Arity" />.
+        /// </summary>
+        private const int Log2Arity = 2;
+
+#if DEBUG
+        static PriorityQueue()
+        {
+            Debug.Assert(Log2Arity > 0 && Math.Pow(2, Log2Arity) == Arity);
+        }
+#endif
+
+        /// <summary>
+        ///  Initializes a new instance of the <see cref="PriorityQueue{TElement, TPriority}"/> class.
+        /// </summary>
+        public PriorityQueue()
+        {
+            _nodes = Array.Empty<(TElement, TPriority)>();
+            _comparer = InitializeComparer(null);
+        }
+
+        /// <summary>
+        ///  Initializes a new instance of the <see cref="PriorityQueue{TElement, TPriority}"/> class
+        ///  with the specified initial capacity.
+        /// </summary>
+        /// <param name="initialCapacity">Initial capacity to allocate in the underlying heap array.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///  The specified <paramref name="initialCapacity"/> was negative.
+        /// </exception>
+        public PriorityQueue(int initialCapacity)
+            : this(initialCapacity, comparer: null)
+        {
+        }
+
+        /// <summary>
+        ///  Initializes a new instance of the <see cref="PriorityQueue{TElement, TPriority}"/> class
+        ///  with the specified custom priority comparer.
+        /// </summary>
+        /// <param name="comparer">
+        ///  Custom comparer dictating the ordering of elements.
+        ///  Uses <see cref="Comparer{T}.Default" /> if the argument is <see langword="null"/>.
+        /// </param>
+        public PriorityQueue(IComparer<TPriority>? comparer)
+        {
+            _nodes = Array.Empty<(TElement, TPriority)>();
+            _comparer = InitializeComparer(comparer);
+        }
+
+        /// <summary>
+        ///  Initializes a new instance of the <see cref="PriorityQueue{TElement, TPriority}"/> class
+        ///  with the specified initial capacity and custom priority comparer.
+        /// </summary>
+        /// <param name="initialCapacity">Initial capacity to allocate in the underlying heap array.</param>
+        /// <param name="comparer">
+        ///  Custom comparer dictating the ordering of elements.
+        ///  Uses <see cref="Comparer{T}.Default" /> if the argument is <see langword="null"/>.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///  The specified <paramref name="initialCapacity"/> was negative.
+        /// </exception>
+        public PriorityQueue(int initialCapacity, IComparer<TPriority>? comparer)
+        {
+            if (initialCapacity < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(initialCapacity), initialCapacity, SR.ArgumentOutOfRange_NeedNonNegNum);
+            }
+
+            _nodes = new (TElement, TPriority)[initialCapacity];
+            _comparer = InitializeComparer(comparer);
+        }
+
+        /// <summary>
+        ///  Initializes a new instance of the <see cref="PriorityQueue{TElement, TPriority}"/> class
+        ///  that is populated with the specified elements and priorities.
+        /// </summary>
+        /// <param name="items">The pairs of elements and priorities with which to populate the queue.</param>
+        /// <exception cref="ArgumentNullException">
+        ///  The specified <paramref name="items"/> argument was <see langword="null"/>.
+        /// </exception>
+        /// <remarks>
+        ///  Constructs the heap using a heapify operation,
+        ///  which is generally faster than enqueuing individual elements sequentially.
+        /// </remarks>
+        public PriorityQueue(IEnumerable<(TElement Element, TPriority Priority)> items)
+            : this(items, comparer: null)
+        {
+        }
+
+        /// <summary>
+        ///  Initializes a new instance of the <see cref="PriorityQueue{TElement, TPriority}"/> class
+        ///  that is populated with the specified elements and priorities,
+        ///  and with the specified custom priority comparer.
+        /// </summary>
+        /// <param name="items">The pairs of elements and priorities with which to populate the queue.</param>
+        /// <param name="comparer">
+        ///  Custom comparer dictating the ordering of elements.
+        ///  Uses <see cref="Comparer{T}.Default" /> if the argument is <see langword="null"/>.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///  The specified <paramref name="items"/> argument was <see langword="null"/>.
+        /// </exception>
+        /// <remarks>
+        ///  Constructs the heap using a heapify operation,
+        ///  which is generally faster than enqueuing individual elements sequentially.
+        /// </remarks>
+        public PriorityQueue(IEnumerable<(TElement Element, TPriority Priority)> items, IComparer<TPriority>? comparer)
+        {
+	        if (items == null) throw new ArgumentNullException(nameof(items));
+
+	        _nodes = items.ToArray(); // EnumerableHelpers.ToArray(items, out _size);
+	        _size = _nodes.Length;
+            _comparer = InitializeComparer(comparer);
+
+            if (_size > 1)
+            {
+                Heapify();
+            }
+        }
+
+        /// <summary>
+        ///  Gets the number of elements contained in the <see cref="PriorityQueue{TElement, TPriority}"/>.
+        /// </summary>
+        public int Count => _size;
+
+        /// <summary>
+        ///  Gets the priority comparer used by the <see cref="PriorityQueue{TElement, TPriority}"/>.
+        /// </summary>
+        public IComparer<TPriority> Comparer => _comparer ?? Comparer<TPriority>.Default;
+
+        /// <summary>
+        ///  Gets a collection that enumerates the elements of the queue in an unordered manner.
+        /// </summary>
+        /// <remarks>
+        ///  The enumeration does not order items by priority, since that would require N * log(N) time and N space.
+        ///  Items are instead enumerated following the internal array heap layout.
+        /// </remarks>
+        public UnorderedItemsCollection UnorderedItems => _unorderedItems ??= new UnorderedItemsCollection(this);
+
+        /// <summary>
+        ///  Adds the specified element with associated priority to the <see cref="PriorityQueue{TElement, TPriority}"/>.
+        /// </summary>
+        /// <param name="element">The element to add to the <see cref="PriorityQueue{TElement, TPriority}"/>.</param>
+        /// <param name="priority">The priority with which to associate the new element.</param>
+        public void Enqueue(TElement element, TPriority priority)
+        {
+            // Virtually add the node at the end of the underlying array.
+            // Note that the node being enqueued does not need to be physically placed
+            // there at this point, as such an assignment would be redundant.
+
+            int currentSize = _size;
+            _version++;
+
+            if (_nodes.Length == currentSize)
+            {
+                Grow(currentSize + 1);
+            }
+
+            _size = currentSize + 1;
+
+            if (_comparer == null)
+            {
+                MoveUpDefaultComparer((element, priority), currentSize);
+            }
+            else
+            {
+                MoveUpCustomComparer((element, priority), currentSize);
+            }
+        }
+
+        /// <summary>
+        ///  Returns the minimal element from the <see cref="PriorityQueue{TElement, TPriority}"/> without removing it.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">The <see cref="PriorityQueue{TElement, TPriority}"/> is empty.</exception>
+        /// <returns>The minimal element of the <see cref="PriorityQueue{TElement, TPriority}"/>.</returns>
+        public TElement Peek()
+        {
+            if (_size == 0)
+            {
+                throw new InvalidOperationException(SR.InvalidOperation_EmptyQueue);
+            }
+
+            return _nodes[0].Element;
+        }
+
+        /// <summary>
+        ///  Removes and returns the minimal element from the <see cref="PriorityQueue{TElement, TPriority}"/>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">The queue is empty.</exception>
+        /// <returns>The minimal element of the <see cref="PriorityQueue{TElement, TPriority}"/>.</returns>
+        public TElement Dequeue()
+        {
+            if (_size == 0)
+            {
+                throw new InvalidOperationException(SR.InvalidOperation_EmptyQueue);
+            }
+
+            TElement element = _nodes[0].Element;
+            RemoveRootNode();
+            return element;
+        }
+
+        /// <summary>
+        ///  Removes the minimal element and then immediately adds the specified element with associated priority to the <see cref="PriorityQueue{TElement, TPriority}"/>,
+        /// </summary>
+        /// <param name="element">The element to add to the <see cref="PriorityQueue{TElement, TPriority}"/>.</param>
+        /// <param name="priority">The priority with which to associate the new element.</param>
+        /// <exception cref="InvalidOperationException">The queue is empty.</exception>
+        /// <returns>The minimal element removed before performing the enqueue operation.</returns>
+        /// <remarks>
+        ///  Implements an extract-then-insert heap operation that is generally more efficient
+        ///  than sequencing Dequeue and Enqueue operations: in the worst case scenario only one
+        ///  shift-down operation is required.
+        /// </remarks>
+        public TElement DequeueEnqueue(TElement element, TPriority priority)
+        {
+            if (_size == 0)
+            {
+                throw new InvalidOperationException(SR.InvalidOperation_EmptyQueue);
+            }
+
+            (TElement Element, TPriority Priority) root = _nodes[0];
+
+            if (_comparer == null)
+            {
+                if (Comparer<TPriority>.Default.Compare(priority, root.Priority) > 0)
+                {
+                    MoveDownDefaultComparer((element, priority), 0);
+                }
+                else
+                {
+                    _nodes[0] = (element, priority);
+                }
+            }
+            else
+            {
+                if (_comparer.Compare(priority, root.Priority) > 0)
+                {
+                    MoveDownCustomComparer((element, priority), 0);
+                }
+                else
+                {
+                    _nodes[0] = (element, priority);
+                }
+            }
+
+            _version++;
+            return root.Element;
+        }
+
+        /// <summary>
+        ///  Removes the minimal element from the <see cref="PriorityQueue{TElement, TPriority}"/>,
+        ///  and copies it to the <paramref name="element"/> parameter,
+        ///  and its associated priority to the <paramref name="priority"/> parameter.
+        /// </summary>
+        /// <param name="element">The removed element.</param>
+        /// <param name="priority">The priority associated with the removed element.</param>
+        /// <returns>
+        ///  <see langword="true"/> if the element is successfully removed;
+        ///  <see langword="false"/> if the <see cref="PriorityQueue{TElement, TPriority}"/> is empty.
+        /// </returns>
+        public bool TryDequeue([MaybeNullWhen(false)] out TElement element, [MaybeNullWhen(false)] out TPriority priority)
+        {
+            if (_size != 0)
+            {
+                (element, priority) = _nodes[0];
+                RemoveRootNode();
+                return true;
+            }
+
+            element = default;
+            priority = default;
+            return false;
+        }
+
+        /// <summary>
+        ///  Returns a value that indicates whether there is a minimal element in the <see cref="PriorityQueue{TElement, TPriority}"/>,
+        ///  and if one is present, copies it to the <paramref name="element"/> parameter,
+        ///  and its associated priority to the <paramref name="priority"/> parameter.
+        ///  The element is not removed from the <see cref="PriorityQueue{TElement, TPriority}"/>.
+        /// </summary>
+        /// <param name="element">The minimal element in the queue.</param>
+        /// <param name="priority">The priority associated with the minimal element.</param>
+        /// <returns>
+        ///  <see langword="true"/> if there is a minimal element;
+        ///  <see langword="false"/> if the <see cref="PriorityQueue{TElement, TPriority}"/> is empty.
+        /// </returns>
+        public bool TryPeek([MaybeNullWhen(false)] out TElement element, [MaybeNullWhen(false)] out TPriority priority)
+        {
+            if (_size != 0)
+            {
+                (element, priority) = _nodes[0];
+                return true;
+            }
+
+            element = default;
+            priority = default;
+            return false;
+        }
+
+        /// <summary>
+        ///  Adds the specified element with associated priority to the <see cref="PriorityQueue{TElement, TPriority}"/>,
+        ///  and immediately removes the minimal element, returning the result.
+        /// </summary>
+        /// <param name="element">The element to add to the <see cref="PriorityQueue{TElement, TPriority}"/>.</param>
+        /// <param name="priority">The priority with which to associate the new element.</param>
+        /// <returns>The minimal element removed after the enqueue operation.</returns>
+        /// <remarks>
+        ///  Implements an insert-then-extract heap operation that is generally more efficient
+        ///  than sequencing Enqueue and Dequeue operations: in the worst case scenario only one
+        ///  shift-down operation is required.
+        /// </remarks>
+        public TElement EnqueueDequeue(TElement element, TPriority priority)
+        {
+            if (_size != 0)
+            {
+                (TElement Element, TPriority Priority) root = _nodes[0];
+
+                if (_comparer == null)
+                {
+                    if (Comparer<TPriority>.Default.Compare(priority, root.Priority) > 0)
+                    {
+                        MoveDownDefaultComparer((element, priority), 0);
+                        _version++;
+                        return root.Element;
+                    }
+                }
+                else
+                {
+                    if (_comparer.Compare(priority, root.Priority) > 0)
+                    {
+                        MoveDownCustomComparer((element, priority), 0);
+                        _version++;
+                        return root.Element;
+                    }
+                }
+            }
+
+            return element;
+        }
+
+        /// <summary>
+        ///  Enqueues a sequence of element/priority pairs to the <see cref="PriorityQueue{TElement, TPriority}"/>.
+        /// </summary>
+        /// <param name="items">The pairs of elements and priorities to add to the queue.</param>
+        /// <exception cref="ArgumentNullException">
+        ///  The specified <paramref name="items"/> argument was <see langword="null"/>.
+        /// </exception>
+        public void EnqueueRange(IEnumerable<(TElement Element, TPriority Priority)> items)
+        {
+	        if (items == null) throw new ArgumentNullException(nameof(items));
+
+	        int count = 0;
+            var collection = items as ICollection<(TElement Element, TPriority Priority)>;
+            if (collection is not null && (count = collection.Count) > _nodes.Length - _size)
+            {
+                Grow(checked(_size + count));
+            }
+
+            if (_size == 0)
+            {
+                // build using Heapify() if the queue is empty.
+
+                if (collection is not null)
+                {
+                    collection.CopyTo(_nodes, 0);
+                    _size = count;
+                }
+                else
+                {
+                    int i = 0;
+                    (TElement, TPriority)[] nodes = _nodes;
+                    foreach ((TElement element, TPriority priority) in items)
+                    {
+                        if (nodes.Length == i)
+                        {
+                            Grow(i + 1);
+                            nodes = _nodes;
+                        }
+
+                        nodes[i++] = (element, priority);
+                    }
+
+                    _size = i;
+                }
+
+                _version++;
+
+                if (_size > 1)
+                {
+                    Heapify();
+                }
+            }
+            else
+            {
+                foreach ((TElement element, TPriority priority) in items)
+                {
+                    Enqueue(element, priority);
+                }
+            }
+        }
+
+        /// <summary>
+        ///  Enqueues a sequence of elements pairs to the <see cref="PriorityQueue{TElement, TPriority}"/>,
+        ///  all associated with the specified priority.
+        /// </summary>
+        /// <param name="elements">The elements to add to the queue.</param>
+        /// <param name="priority">The priority to associate with the new elements.</param>
+        /// <exception cref="ArgumentNullException">
+        ///  The specified <paramref name="elements"/> argument was <see langword="null"/>.
+        /// </exception>
+        public void EnqueueRange(IEnumerable<TElement> elements, TPriority priority)
+        {
+	        if (elements == null) throw new ArgumentNullException(nameof(elements));
+
+	        int count;
+            if (elements is ICollection<TElement> collection &&
+                (count = collection.Count) > _nodes.Length - _size)
+            {
+                Grow(checked(_size + count));
+            }
+
+            if (_size == 0)
+            {
+                // build using Heapify() if the queue is empty.
+
+                int i = 0;
+                (TElement, TPriority)[] nodes = _nodes;
+                foreach (TElement element in elements)
+                {
+                    if (nodes.Length == i)
+                    {
+                        Grow(i + 1);
+                        nodes = _nodes;
+                    }
+
+                    nodes[i++] = (element, priority);
+                }
+
+                _size = i;
+                _version++;
+
+                if (i > 1)
+                {
+                    Heapify();
+                }
+            }
+            else
+            {
+                foreach (TElement element in elements)
+                {
+                    Enqueue(element, priority);
+                }
+            }
+        }
+
+        /// <summary>
+        ///  Removes all items from the <see cref="PriorityQueue{TElement, TPriority}"/>.
+        /// </summary>
+        public void Clear()
+        {
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<(TElement, TPriority)>())
+            {
+                // Clear the elements so that the gc can reclaim the references
+                Array.Clear(_nodes, 0, _size);
+            }
+            _size = 0;
+            _version++;
+        }
+
+        /// <summary>
+        ///  Ensures that the <see cref="PriorityQueue{TElement, TPriority}"/> can hold up to
+        ///  <paramref name="capacity"/> items without further expansion of its backing storage.
+        /// </summary>
+        /// <param name="capacity">The minimum capacity to be used.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///  The specified <paramref name="capacity"/> is negative.
+        /// </exception>
+        /// <returns>The current capacity of the <see cref="PriorityQueue{TElement, TPriority}"/>.</returns>
+        public int EnsureCapacity(int capacity)
+        {
+            if (capacity < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(capacity), capacity, SR.ArgumentOutOfRange_NeedNonNegNum);
+            }
+
+            if (_nodes.Length < capacity)
+            {
+                Grow(capacity);
+                _version++;
+            }
+
+            return _nodes.Length;
+        }
+
+        /// <summary>
+        ///  Sets the capacity to the actual number of items in the <see cref="PriorityQueue{TElement, TPriority}"/>,
+        ///  if that is less than 90 percent of current capacity.
+        /// </summary>
+        /// <remarks>
+        ///  This method can be used to minimize a collection's memory overhead
+        ///  if no new elements will be added to the collection.
+        /// </remarks>
+        public void TrimExcess()
+        {
+            int threshold = (int)(_nodes.Length * 0.9);
+            if (_size < threshold)
+            {
+                Array.Resize(ref _nodes, _size);
+                _version++;
+            }
+        }
+
+        /// <summary>
+        /// Grows the priority queue to match the specified min capacity.
+        /// </summary>
+        private void Grow(int minCapacity)
+        {
+            Debug.Assert(_nodes.Length < minCapacity);
+
+            const int GrowFactor = 2;
+            const int MinimumGrow = 4;
+
+            int newcapacity = GrowFactor * _nodes.Length;
+
+            // Allow the queue to grow to maximum possible capacity (~2G elements) before encountering overflow.
+            // Note that this check works even when _nodes.Length overflowed thanks to the (uint) cast
+            if ((uint)newcapacity > ArrayMaxLength) newcapacity = ArrayMaxLength;
+
+            // Ensure minimum growth is respected.
+            newcapacity = Math.Max(newcapacity, _nodes.Length + MinimumGrow);
+
+            // If the computed capacity is still less than specified, set to the original argument.
+            // Capacities exceeding ArrayMaxLength will be surfaced as OutOfMemoryException by Array.Resize.
+            if (newcapacity < minCapacity) newcapacity = minCapacity;
+
+            Array.Resize(ref _nodes, newcapacity);
+        }
+
+        /// <summary>
+        /// Removes the node from the root of the heap
+        /// </summary>
+        private void RemoveRootNode()
+        {
+            int lastNodeIndex = --_size;
+            _version++;
+
+            if (lastNodeIndex > 0)
+            {
+                (TElement Element, TPriority Priority) lastNode = _nodes[lastNodeIndex];
+                if (_comparer == null)
+                {
+                    MoveDownDefaultComparer(lastNode, 0);
+                }
+                else
+                {
+                    MoveDownCustomComparer(lastNode, 0);
+                }
+            }
+
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<(TElement, TPriority)>())
+            {
+                _nodes[lastNodeIndex] = default;
+            }
+        }
+
+        /// <summary>
+        /// Gets the index of an element's parent.
+        /// </summary>
+        private static int GetParentIndex(int index) => (index - 1) >> Log2Arity;
+
+        /// <summary>
+        /// Gets the index of the first child of an element.
+        /// </summary>
+        private static int GetFirstChildIndex(int index) => (index << Log2Arity) + 1;
+
+        /// <summary>
+        /// Converts an unordered list into a heap.
+        /// </summary>
+        private void Heapify()
+        {
+            // Leaves of the tree are in fact 1-element heaps, for which there
+            // is no need to correct them. The heap property needs to be restored
+            // only for higher nodes, starting from the first node that has children.
+            // It is the parent of the very last element in the array.
+
+            (TElement Element, TPriority Priority)[] nodes = _nodes;
+            int lastParentWithChildren = GetParentIndex(_size - 1);
+
+            if (_comparer == null)
+            {
+                for (int index = lastParentWithChildren; index >= 0; --index)
+                {
+                    MoveDownDefaultComparer(nodes[index], index);
+                }
+            }
+            else
+            {
+                for (int index = lastParentWithChildren; index >= 0; --index)
+                {
+                    MoveDownCustomComparer(nodes[index], index);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Moves a node up in the tree to restore heap order.
+        /// </summary>
+        private void MoveUpDefaultComparer((TElement Element, TPriority Priority) node, int nodeIndex)
+        {
+            // Instead of swapping items all the way to the root, we will perform
+            // a similar optimization as in the insertion sort.
+
+            Debug.Assert(_comparer is null);
+            Debug.Assert(0 <= nodeIndex && nodeIndex < _size);
+
+            (TElement Element, TPriority Priority)[] nodes = _nodes;
+
+            while (nodeIndex > 0)
+            {
+                int parentIndex = GetParentIndex(nodeIndex);
+                (TElement Element, TPriority Priority) parent = nodes[parentIndex];
+
+                if (Comparer<TPriority>.Default.Compare(node.Priority, parent.Priority) < 0)
+                {
+                    nodes[nodeIndex] = parent;
+                    nodeIndex = parentIndex;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            nodes[nodeIndex] = node;
+        }
+
+        /// <summary>
+        /// Moves a node up in the tree to restore heap order.
+        /// </summary>
+        private void MoveUpCustomComparer((TElement Element, TPriority Priority) node, int nodeIndex)
+        {
+            // Instead of swapping items all the way to the root, we will perform
+            // a similar optimization as in the insertion sort.
+
+            Debug.Assert(_comparer is not null);
+            Debug.Assert(0 <= nodeIndex && nodeIndex < _size);
+
+            IComparer<TPriority> comparer = _comparer;
+            (TElement Element, TPriority Priority)[] nodes = _nodes;
+
+            while (nodeIndex > 0)
+            {
+                int parentIndex = GetParentIndex(nodeIndex);
+                (TElement Element, TPriority Priority) parent = nodes[parentIndex];
+
+                if (comparer.Compare(node.Priority, parent.Priority) < 0)
+                {
+                    nodes[nodeIndex] = parent;
+                    nodeIndex = parentIndex;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            nodes[nodeIndex] = node;
+        }
+
+        /// <summary>
+        /// Moves a node down in the tree to restore heap order.
+        /// </summary>
+        private void MoveDownDefaultComparer((TElement Element, TPriority Priority) node, int nodeIndex)
+        {
+            // The node to move down will not actually be swapped every time.
+            // Rather, values on the affected path will be moved up, thus leaving a free spot
+            // for this value to drop in. Similar optimization as in the insertion sort.
+
+            Debug.Assert(_comparer is null);
+            Debug.Assert(0 <= nodeIndex && nodeIndex < _size);
+
+            (TElement Element, TPriority Priority)[] nodes = _nodes;
+            int size = _size;
+
+            int i;
+            while ((i = GetFirstChildIndex(nodeIndex)) < size)
+            {
+                // Find the child node with the minimal priority
+                (TElement Element, TPriority Priority) minChild = nodes[i];
+                int minChildIndex = i;
+
+                int childIndexUpperBound = Math.Min(i + Arity, size);
+                while (++i < childIndexUpperBound)
+                {
+                    (TElement Element, TPriority Priority) nextChild = nodes[i];
+                    if (Comparer<TPriority>.Default.Compare(nextChild.Priority, minChild.Priority) < 0)
+                    {
+                        minChild = nextChild;
+                        minChildIndex = i;
+                    }
+                }
+
+                // Heap property is satisfied; insert node in this location.
+                if (Comparer<TPriority>.Default.Compare(node.Priority, minChild.Priority) <= 0)
+                {
+                    break;
+                }
+
+                // Move the minimal child up by one node and
+                // continue recursively from its location.
+                nodes[nodeIndex] = minChild;
+                nodeIndex = minChildIndex;
+            }
+
+            nodes[nodeIndex] = node;
+        }
+
+        /// <summary>
+        /// Moves a node down in the tree to restore heap order.
+        /// </summary>
+        private void MoveDownCustomComparer((TElement Element, TPriority Priority) node, int nodeIndex)
+        {
+            // The node to move down will not actually be swapped every time.
+            // Rather, values on the affected path will be moved up, thus leaving a free spot
+            // for this value to drop in. Similar optimization as in the insertion sort.
+
+            Debug.Assert(_comparer is not null);
+            Debug.Assert(0 <= nodeIndex && nodeIndex < _size);
+
+            IComparer<TPriority> comparer = _comparer;
+            (TElement Element, TPriority Priority)[] nodes = _nodes;
+            int size = _size;
+
+            int i;
+            while ((i = GetFirstChildIndex(nodeIndex)) < size)
+            {
+                // Find the child node with the minimal priority
+                (TElement Element, TPriority Priority) minChild = nodes[i];
+                int minChildIndex = i;
+
+                int childIndexUpperBound = Math.Min(i + Arity, size);
+                while (++i < childIndexUpperBound)
+                {
+                    (TElement Element, TPriority Priority) nextChild = nodes[i];
+                    if (comparer.Compare(nextChild.Priority, minChild.Priority) < 0)
+                    {
+                        minChild = nextChild;
+                        minChildIndex = i;
+                    }
+                }
+
+                // Heap property is satisfied; insert node in this location.
+                if (comparer.Compare(node.Priority, minChild.Priority) <= 0)
+                {
+                    break;
+                }
+
+                // Move the minimal child up by one node and continue recursively from its location.
+                nodes[nodeIndex] = minChild;
+                nodeIndex = minChildIndex;
+            }
+
+            nodes[nodeIndex] = node;
+        }
+
+        /// <summary>
+        /// Initializes the custom comparer to be used internally by the heap.
+        /// </summary>
+        private static IComparer<TPriority>? InitializeComparer(IComparer<TPriority>? comparer)
+        {
+            if (typeof(TPriority).IsValueType)
+            {
+                if (comparer == Comparer<TPriority>.Default)
+                {
+                    // if the user manually specifies the default comparer,
+                    // revert to using the optimized path.
+                    return null;
+                }
+
+                return comparer;
+            }
+            else
+            {
+                // Currently the JIT doesn't optimize direct Comparer<T>.Default.Compare
+                // calls for reference types, so we want to cache the comparer instance instead.
+                // TODO https://github.com/dotnet/runtime/issues/10050: Update if this changes in the future.
+                return comparer ?? Comparer<TPriority>.Default;
+            }
+        }
+
+        /// <summary>
+        ///  Enumerates the contents of a <see cref="PriorityQueue{TElement, TPriority}"/>, without any ordering guarantees.
+        /// </summary>
+        [DebuggerDisplay("Count = {Count}")]
+        [DebuggerTypeProxy(typeof(PriorityQueueDebugView<,>))]
+        public sealed class UnorderedItemsCollection : IReadOnlyCollection<(TElement Element, TPriority Priority)>, ICollection
+        {
+            internal readonly PriorityQueue<TElement, TPriority> _queue;
+
+            internal UnorderedItemsCollection(PriorityQueue<TElement, TPriority> queue) => _queue = queue;
+
+            public int Count => _queue._size;
+            object ICollection.SyncRoot => this;
+            bool ICollection.IsSynchronized => false;
+
+            void ICollection.CopyTo(Array array, int index)
+            {
+	            if (array == null) throw new ArgumentNullException(nameof(array));
+
+	            if (array.Rank != 1)
+                {
+                    throw new ArgumentException(SR.Arg_RankMultiDimNotSupported, nameof(array));
+                }
+
+                if (array.GetLowerBound(0) != 0)
+                {
+                    throw new ArgumentException(SR.Arg_NonZeroLowerBound, nameof(array));
+                }
+
+                if (index < 0 || index > array.Length)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_IndexMustBeLessOrEqual);
+                }
+
+                if (array.Length - index < _queue._size)
+                {
+                    throw new ArgumentException(SR.Argument_InvalidOffLen);
+                }
+
+                try
+                {
+                    Array.Copy(_queue._nodes, 0, array, index, _queue._size);
+                }
+                catch (ArrayTypeMismatchException)
+                {
+                    throw new ArgumentException(SR.Argument_InvalidArrayType, nameof(array));
+                }
+            }
+
+            /// <summary>
+            ///  Enumerates the element and priority pairs of a <see cref="PriorityQueue{TElement, TPriority}"/>,
+            ///  without any ordering guarantees.
+            /// </summary>
+            public struct Enumerator : IEnumerator<(TElement Element, TPriority Priority)>
+            {
+                private readonly PriorityQueue<TElement, TPriority> _queue;
+                private readonly int _version;
+                private int _index;
+                private (TElement, TPriority) _current;
+
+                internal Enumerator(PriorityQueue<TElement, TPriority> queue)
+                {
+                    _queue = queue;
+                    _index = 0;
+                    _version = queue._version;
+                    _current = default;
+                }
+
+                /// <summary>
+                /// Releases all resources used by the <see cref="Enumerator"/>.
+                /// </summary>
+                public void Dispose() { }
+
+                /// <summary>
+                /// Advances the enumerator to the next element of the <see cref="UnorderedItems"/>.
+                /// </summary>
+                /// <returns><see langword="true"/> if the enumerator was successfully advanced to the next element; <see langword="false"/> if the enumerator has passed the end of the collection.</returns>
+                public bool MoveNext()
+                {
+                    PriorityQueue<TElement, TPriority> localQueue = _queue;
+
+                    if (_version == localQueue._version && ((uint)_index < (uint)localQueue._size))
+                    {
+                        _current = localQueue._nodes[_index];
+                        _index++;
+                        return true;
+                    }
+
+                    return MoveNextRare();
+                }
+
+                private bool MoveNextRare()
+                {
+                    if (_version != _queue._version)
+                    {
+                        throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
+                    }
+
+                    _index = _queue._size + 1;
+                    _current = default;
+                    return false;
+                }
+
+                /// <summary>
+                /// Gets the element at the current position of the enumerator.
+                /// </summary>
+                public (TElement Element, TPriority Priority) Current => _current;
+                object IEnumerator.Current => _current;
+
+                void IEnumerator.Reset()
+                {
+                    if (_version != _queue._version)
+                    {
+                        throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
+                    }
+
+                    _index = 0;
+                    _current = default;
+                }
+            }
+
+            /// <summary>
+            /// Returns an enumerator that iterates through the <see cref="UnorderedItems"/>.
+            /// </summary>
+            /// <returns>An <see cref="Enumerator"/> for the <see cref="UnorderedItems"/>.</returns>
+            public Enumerator GetEnumerator() => new Enumerator(_queue);
+
+            IEnumerator<(TElement Element, TPriority Priority)> IEnumerable<(TElement Element, TPriority Priority)>.GetEnumerator() => GetEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+    }
+#endif
+}

--- a/NBitcoin/PriorityQueue.cs
+++ b/NBitcoin/PriorityQueue.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 namespace NBitcoin
 {
 #if !NET6_0_OR_GREATER
+#nullable enable
 	static class SR
 	{
 		internal static string ArgumentOutOfRange_NeedNonNegNum => nameof(ArgumentOutOfRange_NeedNonNegNum);

--- a/NBitcoin/PriorityQueue.cs
+++ b/NBitcoin/PriorityQueue.cs
@@ -552,20 +552,6 @@ namespace NBitcoin
         }
 
         /// <summary>
-        ///  Removes all items from the <see cref="PriorityQueue{TElement, TPriority}"/>.
-        /// </summary>
-        public void Clear()
-        {
-            if (RuntimeHelpers.IsReferenceOrContainsReferences<(TElement, TPriority)>())
-            {
-                // Clear the elements so that the gc can reclaim the references
-                Array.Clear(_nodes, 0, _size);
-            }
-            _size = 0;
-            _version++;
-        }
-
-        /// <summary>
         ///  Ensures that the <see cref="PriorityQueue{TElement, TPriority}"/> can hold up to
         ///  <paramref name="capacity"/> items without further expansion of its backing storage.
         /// </summary>
@@ -655,7 +641,7 @@ namespace NBitcoin
                 }
             }
 
-            if (RuntimeHelpers.IsReferenceOrContainsReferences<(TElement, TPriority)>())
+            if (!typeof(TElement).IsValueType || !typeof(TPriority).IsValueType)
             {
                 _nodes[lastNodeIndex] = default;
             }

--- a/NBitcoin/Script.cs
+++ b/NBitcoin/Script.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using NBitcoin.Crypto;
 
 namespace NBitcoin
 {
@@ -512,6 +513,29 @@ namespace NBitcoin
 			}
 		}
 
+#if HAS_SPAN
+		private uint256? _leafHash;
+		public uint256 TaprootV1LeafHash
+		{
+			get
+			{
+				if (_leafHash is not null)
+					return _leafHash;
+				_leafHash = TaprootLeafHash((byte)TaprootConstants.TAPROOT_LEAF_TAPSCRIPT);
+				return _leafHash;
+			}
+		}
+
+		internal uint256 TaprootLeafHash(byte version)
+		{
+				var hash = new HashStream { SingleSHA256 = true };
+				hash.InitializeTagged("TapLeaf");
+				hash.WriteByte(version);
+				var bs = new BitcoinStream(hash, true);
+				bs.ReadWrite(this);
+				return hash.GetHash();
+		}
+#endif
 		/// <summary>
 		/// Extract the ScriptCode delimited by the codeSeparatorIndex th OP_CODESEPARATOR.
 		/// </summary>

--- a/NBitcoin/Script.cs
+++ b/NBitcoin/Script.cs
@@ -514,7 +514,7 @@ namespace NBitcoin
 		}
 
 #if HAS_SPAN
-		private uint256? _leafHash;
+		private uint256 _leafHash;
 		public uint256 TaprootV1LeafHash
 		{
 			get

--- a/NBitcoin/ScriptEvaluationContext.cs
+++ b/NBitcoin/ScriptEvaluationContext.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using static NBitcoin.TaprootConstants;
 
 namespace NBitcoin
 {
@@ -623,15 +624,6 @@ namespace NBitcoin
 		}
 		const byte ANNEX_TAG = 0x50;
 		// How much weight budget is added to the witness size (Tapscript only, see BIP 342).
-#if HAS_SPAN
-		static long VALIDATION_WEIGHT_OFFSET = 50;
-		const int TAPROOT_CONTROL_BASE_SIZE = 33;
-		const int TAPROOT_CONTROL_NODE_SIZE = 32;
-		const int TAPROOT_CONTROL_MAX_NODE_COUNT = 128;
-		const int TAPROOT_CONTROL_MAX_SIZE = TAPROOT_CONTROL_BASE_SIZE + TAPROOT_CONTROL_NODE_SIZE * TAPROOT_CONTROL_MAX_NODE_COUNT;
-		const uint TAPROOT_LEAF_MASK = 0xfe;
-		const uint TAPROOT_LEAF_TAPSCRIPT = 0xc0;
-#endif
 		private bool VerifyWitnessProgram(WitScript witness, WitProgramParameters wit, TransactionChecker checker, bool isP2SH)
 		{
 			ContextStack<byte[]> stack = new ContextStack<byte[]>(witness.Pushes);
@@ -753,7 +745,7 @@ namespace NBitcoin
 			return q.CheckTapTweak(p, merkle_root, (control[0] & 1) != 0);
 		}
 
-		private uint256 ComputeTaprootMerkleRoot(ReadOnlySpan<byte> control, uint256 tapleafHash)
+		internal static uint256 ComputeTaprootMerkleRoot(ReadOnlySpan<byte> control, uint256 tapleafHash)
 		{
 			int path_len = (control.Length - TAPROOT_CONTROL_BASE_SIZE) / TAPROOT_CONTROL_NODE_SIZE;
 			uint256 k = tapleafHash;

--- a/NBitcoin/TaprootConstants.cs
+++ b/NBitcoin/TaprootConstants.cs
@@ -1,0 +1,20 @@
+using System;
+using NBitcoin.Secp256k1;
+
+namespace NBitcoin
+{
+#if HAS_SPAN
+	public static class TaprootConstants
+	{
+		internal static long VALIDATION_WEIGHT_OFFSET = 50;
+		internal const int TAPROOT_CONTROL_BASE_SIZE = 33;
+		internal const int TAPROOT_CONTROL_NODE_SIZE = 32;
+		internal const int TAPROOT_CONTROL_MAX_NODE_COUNT = 128;
+		internal const int TAPROOT_CONTROL_MAX_SIZE = TAPROOT_CONTROL_BASE_SIZE + TAPROOT_CONTROL_NODE_SIZE * TAPROOT_CONTROL_MAX_NODE_COUNT;
+		internal const uint TAPROOT_LEAF_MASK = 0xfe;
+		internal const uint TAPROOT_LEAF_ANNEX = 0x50;
+		public const uint TAPROOT_LEAF_TAPSCRIPT = 0xc0;
+
+	}
+#endif
+}

--- a/NBitcoin/TaprootConstants.cs
+++ b/NBitcoin/TaprootConstants.cs
@@ -1,11 +1,13 @@
 using System;
+#if HAS_SPAN
 using NBitcoin.Secp256k1;
+#endif
 
 namespace NBitcoin
 {
-#if HAS_SPAN
 	public static class TaprootConstants
 	{
+#if HAS_SPAN
 		internal static long VALIDATION_WEIGHT_OFFSET = 50;
 		internal const int TAPROOT_CONTROL_BASE_SIZE = 33;
 		internal const int TAPROOT_CONTROL_NODE_SIZE = 32;
@@ -14,7 +16,6 @@ namespace NBitcoin
 		internal const uint TAPROOT_LEAF_MASK = 0xfe;
 		internal const uint TAPROOT_LEAF_ANNEX = 0x50;
 		public const uint TAPROOT_LEAF_TAPSCRIPT = 0xc0;
-
-	}
 #endif
+	}
 }

--- a/NBitcoin/TaprootFullPubKey.cs
+++ b/NBitcoin/TaprootFullPubKey.cs
@@ -7,9 +7,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using NBitcoin.DataEncoders;
-#if HAS_SPAN
-using NBitcoin.Secp256k1;
-#endif
 
 namespace NBitcoin
 {

--- a/NBitcoin/TaprootFullPubKey.cs
+++ b/NBitcoin/TaprootFullPubKey.cs
@@ -6,6 +6,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using NBitcoin.DataEncoders;
+#if HAS_SPAN
+using NBitcoin.Secp256k1;
+#endif
 
 namespace NBitcoin
 {
@@ -20,6 +24,7 @@ namespace NBitcoin
 			var outputKey = internalKey.pubkey.AddTweak(tweak32).ToXOnlyPubKey(out var parity);
 			return new TaprootFullPubKey(outputKey, parity, internalKey, merkleRoot);
 		}
+
 		private TaprootFullPubKey(ECXOnlyPubKey outputKey, bool outputParity, TaprootInternalPubKey internalKey, uint256? merkleRoot) : base(outputKey)
 		{
 			OutputKey = new TaprootPubKey(outputKey);

--- a/NBitcoin/TaprootInternalPubKey.cs
+++ b/NBitcoin/TaprootInternalPubKey.cs
@@ -13,7 +13,7 @@ using System.Threading.Tasks;
 
 namespace NBitcoin
 {
-	public class TaprootInternalPubKey
+	public class TaprootInternalPubKey : IEquatable<TaprootInternalPubKey>
 	{
 #if HAS_SPAN
 		internal readonly ECXOnlyPubKey pubkey;
@@ -25,6 +25,17 @@ namespace NBitcoin
 		private byte[] pubkey = new byte[32];
 #endif
 
+
+#if HAS_SPAN
+		public static TaprootInternalPubKey Parse(string hex)
+		{
+			if (!TryParse(hex, out var result))
+				throw new FormatException($"Failed to parse TaprootInternalKey {hex}");
+			return result;
+		}
+		public static bool TryParse(string hex, [MaybeNullWhen(false)] out TaprootInternalPubKey result)
+			=> TryCreate(Encoders.Hex.DecodeData(hex), out result);
+#endif
 		public static bool TryCreate(byte[] pubkey, [MaybeNullWhen(false)] out TaprootInternalPubKey result)
 		{
 #if HAS_SPAN
@@ -67,6 +78,7 @@ namespace NBitcoin
 		{
 			return TaprootFullPubKey.Create(this, merkleRoot);
 		}
+
 #endif
 		public TaprootInternalPubKey(byte[] pubkey)
 		{
@@ -102,10 +114,18 @@ namespace NBitcoin
 #if HAS_SPAN
 		public override bool Equals(object? obj)
 		{
-			if (!(obj is TaprootInternalPubKey a))
-				return false;
-			return a.pubkey.Q.x == this.pubkey.Q.x;
+			if (ReferenceEquals(null, obj)) return false;
+			if (ReferenceEquals(this, obj)) return true;
+			if (obj.GetType() != this.GetType()) return false;
+			return Equals((TaprootInternalPubKey)obj);
 		}
+
+		public bool Equals(TaprootInternalPubKey? other)
+		{
+			if (ReferenceEquals(null, other)) return false;
+			return Utils.ArrayEqual(other.pubkey.ToBytes(), pubkey.ToBytes());
+		}
+
 		public static bool operator ==(TaprootInternalPubKey a, TaprootInternalPubKey b)
 		{
 			if (a is TaprootInternalPubKey && b is TaprootInternalPubKey)

--- a/NBitcoin/TaprootInternalPubKey.cs
+++ b/NBitcoin/TaprootInternalPubKey.cs
@@ -111,7 +111,7 @@ namespace NBitcoin
 			pubkey.WriteToSpan(out32);
 		}
 #endif
-#if HAS_SPAN
+
 		public override bool Equals(object? obj)
 		{
 			if (ReferenceEquals(null, obj)) return false;
@@ -119,12 +119,18 @@ namespace NBitcoin
 			if (obj.GetType() != this.GetType()) return false;
 			return Equals((TaprootInternalPubKey)obj);
 		}
-
 		public bool Equals(TaprootInternalPubKey? other)
 		{
 			if (ReferenceEquals(null, other)) return false;
+#if HAS_SPAN
 			return Utils.ArrayEqual(other.pubkey.ToBytes(), pubkey.ToBytes());
+#else
+		return Utils.ArrayEqual(other.pubkey, pubkey);
+#endif
 		}
+
+#if HAS_SPAN
+
 
 		public static bool operator ==(TaprootInternalPubKey a, TaprootInternalPubKey b)
 		{
@@ -143,12 +149,7 @@ namespace NBitcoin
 			return pubkey.GetHashCode();
 		}
 #else
-		public override bool Equals(object obj)
-		{
-			if (!(obj is TaprootInternalPubKey a))
-				return false;
-			return Utils.ArrayEqual(pubkey, a.pubkey);
-		}
+
 		public static bool operator ==(TaprootInternalPubKey a, TaprootInternalPubKey b)
 		{
 			if (a is TaprootInternalPubKey && b is TaprootInternalPubKey)

--- a/NBitcoin/TaprootPubKey.cs
+++ b/NBitcoin/TaprootPubKey.cs
@@ -59,6 +59,13 @@ namespace NBitcoin
 				throw new ArgumentException("Invalid taproot pubkey");
 			this.pubkey = k;
 		}
+
+		public static TaprootPubKey Parse(string hex)
+		{
+			if (!TryCreate(Encoders.Hex.DecodeData(hex), out var result))
+				throw new FormatException($"Invalid x-only pubkey {hex}");
+			return result;
+		}
 #endif
 			public TaprootPubKey(byte[] pubkey)
 		{

--- a/NBitcoin/TaprootSpendInfo.cs
+++ b/NBitcoin/TaprootSpendInfo.cs
@@ -14,7 +14,7 @@ using LeafVersion = System.Byte;
 
 namespace NBitcoin
 {
-#if NET6_0_OR_GREATER
+#if HAS_SPAN
 #nullable enable
 
 	internal class ScriptLeaf

--- a/NBitcoin/TaprootSpendInfo.cs
+++ b/NBitcoin/TaprootSpendInfo.cs
@@ -1,0 +1,458 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Text;
+using NBitcoin.DataEncoders;
+using NBitcoin.Secp256k1;
+using TaprootMerkleBranch = System.Collections.Generic.List<NBitcoin.uint256>;
+using static NBitcoin.TaprootConstants;
+using LeafVersion = System.Byte;
+
+namespace NBitcoin
+{
+#if NET6_0_OR_GREATER
+#nullable enable
+
+	internal class ScriptLeaf
+	{
+		internal Script Script { get; init; }
+		internal LeafVersion Version { get; init;  }
+		internal TaprootMerkleBranch MerkleBranch { get; } = new ();
+
+		public uint Depth => (uint)this.MerkleBranch.Count;
+		public uint256 LeafHash => Script.TaprootLeafHash(Version);
+	}
+
+	/// <summary>
+	/// Represents from
+	/// </summary>
+	public class NodeInfo
+	{
+		internal uint256 Hash { get; private init; }
+		internal List<ScriptLeaf> Leaves { get; private init; }
+		internal bool HasHiddenNodes { get; private init; }
+
+		public static NodeInfo NewLeafWithVersion(Script sc, LeafVersion leafVersion)
+		{
+			var leaf = new ScriptLeaf
+			{
+				Script = sc,
+				Version = leafVersion
+			};
+			return
+				new NodeInfo
+				{
+					Hash = leaf.LeafHash,
+					Leaves = new List<ScriptLeaf> { leaf },
+					HasHiddenNodes = false
+				};
+		}
+
+		public static NodeInfo NewHiddenNode(uint256 hash) =>
+			new NodeInfo
+			{
+				Hash = hash,
+				Leaves = new List<ScriptLeaf>(),
+				HasHiddenNodes = true,
+			};
+
+		/// <summary>
+		/// Combines two `NodeInfo` to create a new parent.
+		/// </summary>
+		/// <param name="a"></param>
+		/// <param name="b"></param>
+		/// <returns></returns>
+		public static NodeInfo operator +(NodeInfo a, NodeInfo b)
+		{
+			var allLeaves = new List<ScriptLeaf>(a.Leaves.Count + b.Leaves.Count);
+			foreach (var aLeaf in a.Leaves)
+			{
+				aLeaf.MerkleBranch.Add(b.Hash); // add hashing parameter.
+				allLeaves.Add(aLeaf);
+			}
+			foreach (var bLeaf in b.Leaves)
+			{
+				bLeaf.MerkleBranch.Add(a.Hash);
+				allLeaves.Add(bLeaf);
+			}
+
+			using SHA256 sha = new SHA256();
+			sha.InitializeTagged("TapBranch");
+			if (CompareLexicographic(a.Hash, b.Hash))
+			{
+				sha.Write(a.Hash.ToBytes());
+				sha.Write(b.Hash.ToBytes());
+			}
+			else
+			{
+				sha.Write(b.Hash.ToBytes());
+				sha.Write(a.Hash.ToBytes());
+			}
+			return new NodeInfo
+			{
+				Hash = new uint256(sha.GetHash()),
+				Leaves = allLeaves,
+				HasHiddenNodes = a.HasHiddenNodes || b.HasHiddenNodes
+			};
+		}
+		static bool CompareLexicographic(uint256 a, uint256 b)
+		{
+			Span<byte> ab = stackalloc byte[32];
+			Span<byte> bb = stackalloc byte[32];
+			a.ToBytes(ab);
+			b.ToBytes(bb);
+			for (int i = 0; i < ab.Length && i < bb.Length; i++)
+			{
+				if (ab[i] < bb[i])
+					return true;
+				if (bb[i] < ab[i])
+					return false;
+			}
+			return true;
+		}
+	}
+
+	public class ControlBlock : IEquatable<ControlBlock>
+	{
+		public byte LeafVersion { get; internal init; }
+		public bool OutputParityIsOdd { get; internal init; }
+		public TaprootInternalPubKey InternalPubKey { get; internal init; }
+		public TaprootMerkleBranch MerkleBranch { get; internal init; }
+
+		private static HexEncoder _hex = new HexEncoder();
+
+		public static ControlBlock FromHex(string hex)
+			=> FromSlice(_hex.DecodeData(hex));
+		public static ControlBlock FromSlice(ReadOnlySpan<byte> buffer)
+		{
+			if (buffer.Length < TAPROOT_CONTROL_BASE_SIZE ||
+			    (buffer.Length - TAPROOT_CONTROL_BASE_SIZE) % TAPROOT_CONTROL_NODE_SIZE != 0)
+				throw new FormatException($"Invalid control block size {buffer.Length}");
+
+			var outputKeyParity = (buffer[0] & 1) == 1;
+			var leafVersion = buffer[0] & (byte)TAPROOT_LEAF_MASK;
+			if (((byte)leafVersion & 0b_0000_0001) == 1)
+				throw new FormatException($"Invalid LeafBytes: Odd leaf version {leafVersion}");
+			if (leafVersion == 0x50)
+				throw new FormatException($"Invalid LeafBytes: annex {leafVersion}");
+			if (!TaprootInternalPubKey.TryCreate(buffer[1..TAPROOT_CONTROL_BASE_SIZE], out var internalPubKey))
+				throw new FormatException($"Failed to parse Internal pubkey for control block");
+
+			var merkleBranch = new TaprootMerkleBranch();
+			int index = TAPROOT_CONTROL_BASE_SIZE;
+			while (index <= buffer.Length - TAPROOT_CONTROL_NODE_SIZE)
+			{
+				var hash = new uint256(buffer.Slice(index, TAPROOT_CONTROL_NODE_SIZE));
+				merkleBranch.Add(hash);
+				index += TAPROOT_CONTROL_NODE_SIZE;
+			}
+			return new ControlBlock
+			{
+				OutputParityIsOdd = outputKeyParity,
+				LeafVersion = (byte)leafVersion,
+				InternalPubKey = internalPubKey,
+				MerkleBranch = merkleBranch,
+			};
+		}
+
+		public byte[] ToBytes()
+		{
+			var buf = new byte[TAPROOT_CONTROL_BASE_SIZE + (TAPROOT_CONTROL_NODE_SIZE * MerkleBranch.Count)];
+			buf[0] = (byte)((byte)(OutputParityIsOdd ? 1 : 0) | LeafVersion);
+			InternalPubKey.ToBytes().CopyTo(buf, 1);
+			foreach (var (hash, i) in MerkleBranch.Select((v, i) => (v, i)))
+			{
+				var index = (i * TAPROOT_CONTROL_NODE_SIZE);
+				hash.ToBytes().CopyTo(buf, TAPROOT_CONTROL_BASE_SIZE + index);
+			}
+			return buf;
+		}
+
+		/// <summary>
+		/// Verifies that a control block is correct proof for a given output key and script.
+		///
+		/// Only checks that script is contained inside the taptree described by output key.
+		/// Full verification must also execute the script with witness data.
+		/// </summary>
+		/// <returns></returns>
+		public bool VerifyTaprootCommitment(TaprootFullPubKey outputKey, Script script)
+		{
+			var merkleRoot = ScriptEvaluationContext.ComputeTaprootMerkleRoot(this.ToBytes(), script.TaprootV1LeafHash);
+			return outputKey.CheckTapTweak(InternalPubKey, merkleRoot, OutputParityIsOdd);
+		}
+
+		public bool Equals(ControlBlock? other)
+		{
+			if (ReferenceEquals(null, other)) return false;
+			if (ReferenceEquals(this, other)) return true;
+			return LeafVersion == other.LeafVersion && OutputParityIsOdd == other.OutputParityIsOdd && InternalPubKey.Equals(other.InternalPubKey) && MerkleBranch.SequenceEqual(other.MerkleBranch);
+		}
+
+		public override bool Equals(object? obj)
+		{
+			if (ReferenceEquals(null, obj)) return false;
+			if (ReferenceEquals(this, obj)) return true;
+			if (obj.GetType() != this.GetType()) return false;
+			return Equals((ControlBlock)obj);
+		}
+
+		public override int GetHashCode()
+		{
+			return HashCode.Combine(LeafVersion, OutputParityIsOdd, InternalPubKey, MerkleBranch);
+		}
+	}
+
+
+	/// <summary>
+	/// Mostly taken from [rust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin/blob/1d0b0e6ed8e80767fef9b00a38c9e5fefc34baa0/bitcoin/src/util/taproot.rs#L184)
+	/// </summary>
+	public class TaprootSpendInfo
+	{
+		public TaprootInternalPubKey InternalPubKey { get; private init; }
+		public TaprootFullPubKey OutputPubKey { get; private init; }
+
+		/// <summary>
+		/// map from script to -> its merkle proof
+		/// More than one control block for a given script is only possible if it appears in multiple branches of the tree.
+		/// In all cases, keeping one should be enough for spending funds, but we keep all of the paths
+		/// so that a full tree can be constructed again from spending data if required.
+		/// </summary>
+		public ConcurrentDictionary<(Script, LeafVersion), List<TaprootMerkleBranch>>? ScriptToMerkleProofMap { get;
+			private init;
+		}
+		public uint256? MerkleRoot { get; internal init; }
+
+		public TaprootSpendInfo(
+			TaprootInternalPubKey internalPubKey,
+			TaprootFullPubKey outputPubKey,
+			Dictionary<(Script, LeafVersion), List<TaprootMerkleBranch>> scriptToMerkleProofMap
+			)
+		{
+			var map = new ConcurrentDictionary<(Script, LeafVersion), List<TaprootMerkleBranch>>();
+			foreach (var kv in scriptToMerkleProofMap)
+			{
+				map.AddOrReplace(kv.Key, kv.Value);
+			}
+			InternalPubKey = internalPubKey ?? throw new ArgumentNullException(nameof(internalPubKey));
+			OutputPubKey = outputPubKey;
+			ScriptToMerkleProofMap = map;
+
+		}
+
+		public static TaprootSpendInfo CreateKeySpend(TaprootInternalPubKey internalPubKey, uint256? merkleRoot = null)
+		{
+			var outputKey = internalPubKey.GetTaprootFullPubKey(merkleRoot);
+			return new TaprootSpendInfo(internalPubKey, outputKey, new Dictionary<(Script, LeafVersion), List<TaprootMerkleBranch>>())
+			{
+				MerkleRoot = merkleRoot
+			};
+		}
+
+
+		public static TaprootSpendInfo FromNodeInfo(TaprootInternalPubKey internalPubKey, NodeInfo node)
+		{
+			var rootHash = node.Hash;
+			var info = TaprootSpendInfo.CreateKeySpend(internalPubKey, rootHash);
+			foreach (var leaves in node.Leaves)
+			{
+				var k = (leaves.Script, leaves.Version);
+				var v = leaves.MerkleBranch;
+				if (info.ScriptToMerkleProofMap.TryGetValue(k, out var set))
+					set.Add(v);
+				var hashSet = new List<List<uint256>> { v };
+				info.ScriptToMerkleProofMap.TryAdd(k, hashSet);
+			}
+			return info;
+		}
+
+		public static TaprootSpendInfo WithHuffmanTree(TaprootInternalPubKey internalPubKey, params (UInt32, Script)[] scriptWeights) =>
+			TaprootBuilder.WithHuffmanTree(scriptWeights).Finalize(internalPubKey);
+
+		/// <summary>
+		/// Constructs a ControlBlock for particular script with the given version.
+		/// </summary>
+		/// <returns>
+		/// If there are multiple control blocks possible, gets the shortest one.
+		/// If the script is not contained in the `TaprootSpendInfo` false.
+		/// </returns>
+		public bool TryGetControlBlock(Script script, LeafVersion version, [MaybeNullWhen(false)] out ControlBlock controlBlock)
+		{
+			controlBlock = null;
+			if (!this.ScriptToMerkleProofMap.TryGetValue((script, version), out var merkleBranchSet))
+				return false;
+
+			// choose the smallest merkle proof.
+			var smallest = merkleBranchSet.MinBy(x => x.Count);
+			controlBlock = new ControlBlock
+			{
+				OutputParityIsOdd =
+					this.OutputPubKey.OutputKeyParity,
+				InternalPubKey = InternalPubKey,
+				LeafVersion = version,
+				MerkleBranch = smallest!,
+			};
+			return true;
+		}
+
+		public ControlBlock GetControlBlock(Script script, LeafVersion version)
+		{
+			if (!TryGetControlBlock(script, version, out var ctrl))
+				throw new InvalidDataException($"Failed to get control block for script: {script}, version: {version}");
+			return ctrl;
+		}
+
+	}
+
+	/// <summary>
+	/// Builder for building taproot iteratively.
+	/// Mostly taken from TaprootBuilder in r[ust-bitcoin](https://github.com/rust-bitcoin/rust-bitcoin/blob/1d0b0e6ed8e80767fef9b00a38c9e5fefc34baa0/bitcoin/src/util/taproot.rs#L343)
+	/// And in [bitcoin](https://github.com/bitcoin/bitcoin/blob/7ef730ca84bd71a06f986ae7070e7b2ac8e47582/src/script/standard.h#L226)
+	/// Currently it is only usable in netx.0 (x >=6), because we want to use PriorityQueue in .NET 6
+	/// </summary>
+	public class TaprootBuilder
+	{
+
+		internal List<NodeInfo?> Branch
+		{
+			get;
+		} = new();
+
+		/// <summary>
+		/// Creates a new `TaprootBuilder` from a list of scripts (with default script version) and weights of
+		/// satisfaction for that script.
+		///
+		/// The weights represent the probability of each branch being taken. If probability/weights
+		/// for each condition are known, constructing the tree as a Huffman Tree is the optimal way to
+		/// minimize average case satisfaction cost. This function takes as input an iterator of
+		/// `(uint32, Script)` where `uint32` represents the satisfaction weights of the branch. For
+		/// example, [(3, S1), (2, S2), (5, S3)] would construct a TapTree that has optimal satisfaction
+		/// weight when probability for S1 is 30%, S2 is 20%, and S3 is 50%.
+		///
+		/// # Errors:
+		///
+		/// - When the optimal Huffman Tree has a depth more than 128.
+		/// - If the provided list of script weights is empty.
+		///
+		/// # Edge Cases:
+		///
+		/// If the script weight calculations overflow, a sub-optimal tree may be generated. This should
+		/// not happen unless you are dealing with billions of branches with weights close to 2^32.
+		/// </summary>
+		/// <returns></returns>
+		public static TaprootBuilder WithHuffmanTree(params (UInt32, Script)[] scriptWeights)
+		{
+			if (scriptWeights == null) throw new ArgumentNullException(nameof(scriptWeights));
+			if (scriptWeights.Length == 0) throw new ArgumentException("Scripts has 0 length.", nameof(scriptWeights));
+			var nodeWeights = new PriorityQueue<(UInt32, NodeInfo), UInt32>(initialCapacity:scriptWeights.Length);
+
+			foreach (var (p, leaf) in scriptWeights)
+			{
+				var nodeInfo = NodeInfo.NewLeafWithVersion(leaf, (byte)TAPROOT_LEAF_TAPSCRIPT);
+				nodeWeights.Enqueue((p, nodeInfo), p);
+			}
+
+			while (nodeWeights.Count > 1)
+			{
+				// combine the last two elements and insert a new node
+
+				var (p1, s1) = nodeWeights.Dequeue();
+				var (p2, s2) = nodeWeights.Dequeue();
+
+				// Insert the sum of first two in the tree as a new node
+				var p = p1 + p2;
+				nodeWeights.Enqueue((p, s1 + s2), p);
+			}
+
+			// Every iteration of the loop reduces the nodeWeights.Count by exactly 1,
+			// therefore, the loop will eventually terminate with exactly 1 element.
+			Debug.Assert(nodeWeights.Count == 1);
+			var node = nodeWeights.Dequeue().Item2;
+			var builder = new TaprootBuilder();
+			builder.Branch.Add(node);
+			return builder;
+		}
+
+
+		/// <summary>
+		/// Adds a leaf script at `depth` to the builder
+		/// </summary>
+		/// <param name="depth"></param>
+		/// <param name="script"></param>
+		/// <param name="version"></param>
+		/// <returns></returns>
+		public TaprootBuilder AddLeaf(uint depth, Script script, LeafVersion version) =>
+			Insert(NodeInfo.NewLeafWithVersion(script, version), depth);
+
+		public TaprootBuilder AddLeaf(uint depth, Script script) =>
+			AddLeaf(depth, script, (byte)TAPROOT_LEAF_TAPSCRIPT);
+		/// <summary>
+		/// Adds a hidden/omitted node at `depth` to the builder. Errors if the leaves are not provided in DFS walk order.
+		/// The depth of the root node is 0.
+		/// <param name="depth"></param>
+		/// <param name="hash"></param>
+		/// <returns></returns>
+		public TaprootBuilder AddHiddenNode(uint depth, uint256 hash) =>
+			Insert(NodeInfo.NewHiddenNode(hash), depth);
+
+		public bool IsFinalizable => Branch.Count == 0 || (Branch.Count == 1 && Branch[0] is not null);
+
+		public bool HasHiddenNodes => Branch.Any(node => node is not null && node.HasHiddenNodes);
+
+		/// <summary>
+		/// Finalize the builder and returns resulted TaprootSpendInfo.
+		/// You might want to check `IsFinalizable` before calling this method.
+		/// </summary>
+		/// <param name="internalPubKey"></param>
+		/// <returns></returns>
+		/// <exception cref="InvalidOperationException"></exception>
+		public TaprootSpendInfo Finalize(TaprootInternalPubKey internalPubKey) =>
+			(Branch.Count == 0)
+				? TaprootSpendInfo.CreateKeySpend(internalPubKey, null)
+				: (Branch.Count == 1)
+					? TaprootSpendInfo.FromNodeInfo(internalPubKey, Branch.Last()!)
+					: throw new InvalidOperationException($"Failed to finalize, maybe you forgot to add some scripts? Branch.Count: {Branch.Count}");
+
+		private TaprootBuilder Insert(NodeInfo node, uint depth)
+		{
+			if (depth > TAPROOT_CONTROL_MAX_NODE_COUNT)
+				throw new InvalidDataException($"Invalid Merkle Tree Depth {depth}");
+
+			// We cannot insert a leaf at a lower depth while a deeper branch is unfinished. Doing
+			// so would mean the AddLeaf/AddHidden invocations do not correspond to a DFS traversal
+			// of a binary tree
+			if (depth + 1u < Branch.Count)
+				throw new InvalidDataException();
+
+			while (Branch.Count == depth + 1)
+			{
+				var child = Branch.Last();
+				if (child is null)
+					break;
+				Branch.RemoveAt(Branch.Count - 1);
+
+				if (depth == 0)
+					// we are trying to combine two nodes at root level.
+					// Can't propagate further  up than the root
+					throw new InvalidOperationException($"We can not combine two nodes at the root level.");
+				node = node + child;
+				depth--;
+			}
+
+			if (Branch.Count < depth + 1)
+			{
+				// Add enough nodes so that we can insert node at depth `depth`
+				var numExtraNodes = depth + 1 - Branch.Count;
+				for (var i = 0; i < numExtraNodes; i++)
+					Branch.Add(null);
+			}
+			// Push the last node to the branch
+			Branch[(int)depth] = node;
+			return this;
+		}
+	}
+#endif
+}


### PR DESCRIPTION
This is a prerequisite for #1141 
It introduce a logic for building tapscript tree.

* based on types with the same name in rust-bitcoin and bitcoind
  * https://github.com/rust-bitcoin/rust-bitcoin/blob/70eb92cc870b05bd57d5c8d400af8995581fcb9b/bitcoin/src/util/taproot.rs#L184
  * https://github.com/bitcoin/bitcoin/blob/f0c646f026e652082e798800136dc06c734fdab6/src/script/standard.h#L226

It is expected to be used in TransactionBuilder and (possibly in) PSBT.