### PR TITLE
Slightly faster `HexEncoder.EncodeData` for .NET 6

### DIFF
--- a/NBitcoin/DataEncoders/HexEncoder.cs
+++ b/NBitcoin/DataEncoders/HexEncoder.cs
@@ -57,7 +57,9 @@ namespace NBitcoin.DataEncoders
 			if (data == null)
 				throw new ArgumentNullException(nameof(data));
 
-#if !HAS_SPAN
+#if NET6_0_OR_GREATER
+			return Convert.ToHexString(data, offset, count);
+#elif !HAS_SPAN
 			int pos = 0;
 			var s = new char[2 * count];
 			for (var i = offset; i < offset + count; i++)

--- a/NBitcoin/DataEncoders/HexEncoder.cs
+++ b/NBitcoin/DataEncoders/HexEncoder.cs
@@ -58,7 +58,7 @@ namespace NBitcoin.DataEncoders
 				throw new ArgumentNullException(nameof(data));
 
 #if NET6_0_OR_GREATER
-			return Convert.ToHexString(data, offset, count);
+			return Convert.ToHexString(data, offset, count).ToLowerInvariant();
 #elif !HAS_SPAN
 			int pos = 0;
 			var s = new char[2 * count];


### PR DESCRIPTION
## Master branch (20965133)

```powershell
dotnet run -c Release --framework net6.0 -- --runtimes net6.0 --filter *HexBench*
```

```
| Method |     Mean |    Error |   StdDev |
|------- |---------:|---------:|---------:|
| Decode | 55.94 ns | 0.445 ns | 0.395 ns |
| Encode | 82.44 ns | 0.872 ns | 0.816 ns |
```

## Master + the PR's first commit (bd2e61b1)

```powershell
dotnet run -c Release --framework net6.0 -- --runtimes net6.0 --filter *HexBench*
```

```
| Method |     Mean |    Error |   StdDev |
|------- |---------:|---------:|---------:|
| Decode | 56.14 ns | 0.385 ns | 0.341 ns |
| Encode | 30.02 ns | 0.499 ns | 0.467 ns |
```

`Encode` is about 2.5 times faster. The reason why it is so fast is because .NET uses a vectorized implementation for HEX encoding. 

The issue with this commit is that the resulting hexadecimal strings are capitalized. Please upvote https://github.com/dotnet/runtime/issues/58937, https://github.com/dotnet/runtime/issues/73026, and https://github.com/dotnet/runtime/issues/60393 if you like.

## This PR (bc496179)

```powershell
dotnet run -c Release --framework net6.0 -- --runtimes net6.0 --filter *HexBench*
```

```
| Method |     Mean |    Error |   StdDev |
|------- |---------:|---------:|---------:|
| Decode | 54.68 ns | 0.530 ns | 0.470 ns |
| Encode | 68.04 ns | 1.005 ns | 0.940 ns |
```

`Encode` is about 1.2 times faster.


## Resources

* https://github.com/dotnet/runtime/blob/dfd618dc648ba9b11dd0f8034f78113d69f223cd/src/libraries/System.Runtime.Extensions/tests/System/Convert.ToHexString.cs
* https://learn.microsoft.com/en-us/dotnet/api/system.convert.tohexstring?view=net-5.0
* https://github.com/dotnet/runtime/issues/15675
* https://github.com/dotnet/runtime/pull/44111 - Vectorize HexConverter.EncodeToUtf16 using SSSE3