### PR TITLE
Passing spans by value

### DIFF
--- a/NBitcoin.Altcoins/Argoneum.cs
+++ b/NBitcoin.Altcoins/Argoneum.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using NBitcoin.Crypto;
@@ -354,7 +354,7 @@ namespace NBitcoin.Altcoins
 					stream.ReadWriteAsVarInt(ref extraPayloadSize);
 					if (ExtraPayload.Length != extraPayloadSize)
 						ExtraPayload = new byte[extraPayloadSize];
-					stream.ReadWrite(ref ExtraPayload);
+					stream.ReadWrite(ExtraPayload);
 				}
 			}
 		}

--- a/NBitcoin.Altcoins/BGold.cs
+++ b/NBitcoin.Altcoins/BGold.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin;
+using NBitcoin;
 using System.Reflection;
 using NBitcoin.DataEncoders;
 using NBitcoin.Protocol;
@@ -160,7 +160,7 @@ namespace NBitcoin.Altcoins
 						{
 							nSolution = new byte[nSolutionSize];
 						}
-						stream.ReadWrite(ref nSolution);
+						stream.ReadWrite(nSolution);
 					}
 				}
 				else

--- a/NBitcoin.Altcoins/Bitcoinplus.cs
+++ b/NBitcoin.Altcoins/Bitcoinplus.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin;
+using NBitcoin;
 using NBitcoin.Altcoins.HashX11;
 using NBitcoin.Crypto;
 using NBitcoin.DataEncoders;
@@ -278,7 +278,7 @@ namespace NBitcoin.Altcoins
                     if (stream.Serializing)
                     {
                         var bytes = (_Inputs[i].WitScript ?? WitScript.Empty).ToBytes();
-                        stream.ReadWrite(ref bytes);
+                        stream.ReadWrite(bytes);
                     }
                     else
                     {

--- a/NBitcoin.Altcoins/Dash.cs
+++ b/NBitcoin.Altcoins/Dash.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin.Crypto;
+using NBitcoin.Crypto;
 using NBitcoin.DataEncoders;
 using NBitcoin.Protocol;
 using System;
@@ -348,7 +348,7 @@ namespace NBitcoin.Altcoins
 					stream.ReadWriteAsVarInt(ref extraPayloadSize);
 					if (ExtraPayload.Length != extraPayloadSize)
 						ExtraPayload = new byte[extraPayloadSize];
-					stream.ReadWrite(ref ExtraPayload);
+					stream.ReadWrite(ExtraPayload);
 				}
 			}
 		}

--- a/NBitcoin.Altcoins/Elements/BitcoinStreamExtensions.cs
+++ b/NBitcoin.Altcoins/Elements/BitcoinStreamExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using NBitcoin.Protocol;
 
@@ -70,7 +70,7 @@ namespace NBitcoin.Altcoins.Elements
 					throw new ArgumentOutOfRangeException("Array size too big");
 				data = new byte[len];
 			}
-			bitcoinStream.ReadWriteBytes(ref data);
+			bitcoinStream.ReadWriteBytes(data);
 		}
 	}
 }

--- a/NBitcoin.Altcoins/Elements/ElementsTransaction.cs
+++ b/NBitcoin.Altcoins/Elements/ElementsTransaction.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin.BouncyCastle.Crypto.Digests;
+using NBitcoin.BouncyCastle.Crypto.Digests;
 using NBitcoin.Crypto;
 using System;
 using System.IO;
@@ -135,7 +135,7 @@ namespace NBitcoin.Altcoins.Elements
 
 			if (_Commitment.Length > 1)
 			{
-				stream.ReadWrite(ref _Commitment, 1, _Commitment.Length - 1);
+				stream.ReadWrite(_Commitment, 1, _Commitment.Length - 1);
 			}
 		}
 
@@ -696,10 +696,10 @@ namespace NBitcoin.Altcoins.Elements
 						stream.ReadWriteAsVarString(ref bytes);
 
 						bytes = (_Inputs[i].WitScript ?? WitScript.Empty).ToBytes();
-						stream.ReadWrite(ref bytes);
+						stream.ReadWrite(bytes);
 
 						bytes = (((ElementsTxIn)_Inputs[i]).PeginWitScript ?? WitScript.Empty).ToBytes();
-						stream.ReadWrite(ref bytes);
+						stream.ReadWrite(bytes);
 					}
 					else
 					{

--- a/NBitcoin.Altcoins/Polis.cs
+++ b/NBitcoin.Altcoins/Polis.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin;
+using NBitcoin;
 using NBitcoin.Crypto;
 using NBitcoin.DataEncoders;
 using NBitcoin.Protocol;
@@ -348,7 +348,7 @@ namespace NBitcoin.Altcoins
 					stream.ReadWriteAsVarInt(ref extraPayloadSize);
 					if (ExtraPayload.Length != extraPayloadSize)
 						ExtraPayload = new byte[extraPayloadSize];
-					stream.ReadWrite(ref ExtraPayload);
+					stream.ReadWrite(ExtraPayload);
 				}
 			}
 		}

--- a/NBitcoin.Altcoins/Stratis.cs
+++ b/NBitcoin.Altcoins/Stratis.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin.Altcoins.HashX11;
+using NBitcoin.Altcoins.HashX11;
 using NBitcoin.Crypto;
 using NBitcoin.DataEncoders;
 using NBitcoin.Protocol;
@@ -302,7 +302,7 @@ namespace NBitcoin.Altcoins
 					if (stream.Serializing)
 					{
 						var bytes = (_Inputs[i].WitScript ?? WitScript.Empty).ToBytes();
-						stream.ReadWrite(ref bytes);
+						stream.ReadWrite(bytes);
 					}
 					else
 					{

--- a/NBitcoin.Tests/NBitcoin.Tests.csproj
+++ b/NBitcoin.Tests/NBitcoin.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<Company>Metaco SA</Company>

--- a/NBitcoin.Tests/transaction_tests.cs
+++ b/NBitcoin.Tests/transaction_tests.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin;
+using NBitcoin;
 using NBitcoin.Altcoins.Elements;
 using NBitcoin.Crypto;
 using NBitcoin.DataEncoders;
@@ -1878,7 +1878,7 @@ namespace NBitcoin.Tests
 			});
 			BitcoinStreamCoverageCore(new byte[] { 1, 2, 3, 4 }, (BitcoinStream bs, ref byte[] items) =>
 			{
-				bs.ReadWrite(ref items);
+				bs.ReadWrite(items);
 			});
 			BitcoinStreamCoverageCore(new uint160[] { new uint160(1), new uint160(2), new uint160(3), new uint160(4) }, (BitcoinStream bs, ref uint160[] items) =>
 			{

--- a/NBitcoin/BIP174/PSBTInput.cs
+++ b/NBitcoin/BIP174/PSBTInput.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using System.Linq;
 using System.Collections.Generic;
@@ -762,9 +762,9 @@ namespace NBitcoin
 					bs.ReadWrite(hash);
 				}
 				var b = pathPair.Value.RootedKeyPath.MasterFingerprint.ToBytes();
-				bs.ReadWrite(ref b);
+				bs.ReadWrite(b);
 				b = pathPair.Value.RootedKeyPath.KeyPath.ToBytes();
-				bs.ReadWrite(ref b);
+				bs.ReadWrite(b);
 				b = ((MemoryStream)bs.Inner).ToArrayEfficient();
 				stream.ReadWriteAsVarString(ref b);
 			}

--- a/NBitcoin/BIP174/PSBTOutput.cs
+++ b/NBitcoin/BIP174/PSBTOutput.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using System.Linq;
 using System.Collections.Generic;
@@ -188,9 +188,9 @@ namespace NBitcoin
 					bs.ReadWrite(hash);
 				}
 				var b = pathPair.Value.RootedKeyPath.MasterFingerprint.ToBytes();
-				bs.ReadWrite(ref b);
+				bs.ReadWrite(b);
 				b = pathPair.Value.RootedKeyPath.KeyPath.ToBytes();
-				bs.ReadWrite(ref b);
+				bs.ReadWrite(b);
 				b = ((MemoryStream)bs.Inner).ToArrayEfficient();
 				stream.ReadWriteAsVarString(ref b);
 			}

--- a/NBitcoin/BIP174/PartiallySignedTransaction.cs
+++ b/NBitcoin/BIP174/PartiallySignedTransaction.cs
@@ -875,9 +875,9 @@ namespace NBitcoin
 				stream.ReadWriteAsVarInt(ref len);
 				stream.ReadWrite(PSBTConstants.PSBT_GLOBAL_XPUB);
 				var vb = XPubVersionBytes;
-				stream.ReadWrite(ref vb);
+				stream.ReadWrite(vb);
 				var bytes = xpub.Key.ExtPubKey.ToBytes();
-				stream.ReadWrite(ref bytes);
+				stream.ReadWrite(bytes);
 				var path = xpub.Value.KeyPath.ToBytes();
 				var pathInfo = xpub.Value.MasterFingerprint.ToBytes().Concat(path);
 				stream.ReadWriteAsVarString(ref pathInfo);

--- a/NBitcoin/BitcoinStream.cs
+++ b/NBitcoin/BitcoinStream.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin.Protocol;
+using NBitcoin.Protocol;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -331,19 +331,19 @@ namespace NBitcoin
 			}
 		}
 
-		public void ReadWrite(ref byte[] arr)
+		public void ReadWrite(byte[] arr)
 		{
-			ReadWriteBytes(ref arr);
+			ReadWriteBytes(arr);
 		}
 #if HAS_SPAN
-		public void ReadWrite(ref Span<byte> arr)
+		public void ReadWrite(Span<byte> arr)
 		{
 			ReadWriteBytes(arr);
 		}
 #endif
-		public void ReadWrite(ref byte[] arr, int offset, int count)
+		public void ReadWrite(byte[] arr, int offset, int count)
 		{
-			ReadWriteBytes(ref arr, offset, count);
+			ReadWriteBytes(arr, offset, count);
 		}
 		public void ReadWrite<T>(ref T[] arr) where T : IBitcoinSerializable, new()
 		{
@@ -399,7 +399,7 @@ namespace NBitcoin
 			}
 			if (IsBigEndian)
 				Array.Reverse(bytes);
-			ReadWriteBytes(ref bytes);
+			ReadWriteBytes(bytes);
 			if (IsBigEndian)
 				Array.Reverse(bytes);
 			ulong valueTemp = 0;
@@ -412,7 +412,7 @@ namespace NBitcoin
 		}
 
 #if HAS_SPAN
-		internal void ReadWriteBytes(ref byte[] data, int offset = 0, int count = -1)
+		internal void ReadWriteBytes(byte[] data, int offset = 0, int count = -1)
 		{
 			if(data == null)
 				throw new ArgumentNullException(nameof(data));
@@ -441,7 +441,7 @@ namespace NBitcoin
 			}
 		}
 #else
-		internal void ReadWriteBytes(ref byte[] data, int offset = 0, int count = -1)
+		internal void ReadWriteBytes(byte[] data, int offset = 0, int count = -1)
 		{
 			if (data == null)
 				throw new ArgumentNullException(nameof(data));

--- a/NBitcoin/OpenAsset/ColorMarker.cs
+++ b/NBitcoin/OpenAsset/ColorMarker.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin.DataEncoders;
+using NBitcoin.DataEncoders;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -164,7 +164,7 @@ namespace NBitcoin.OpenAsset
 			while ((value >>= 7) != 0uL);
 			Array.Resize(ref bytes, count);
 			bytes[bytes.Length - 1] &= 127;
-			stream.ReadWrite(ref bytes);
+			stream.ReadWrite(bytes);
 		}
 
 		public ColorMarker()

--- a/NBitcoin/OpenAsset/ColoredTransaction.cs
+++ b/NBitcoin/OpenAsset/ColoredTransaction.cs
@@ -1,4 +1,4 @@
-﻿#if !NOJSONNET
+#if !NOJSONNET
 using Newtonsoft.Json.Linq;
 #endif
 using System;
@@ -55,14 +55,14 @@ namespace NBitcoin.OpenAsset
 			if (stream.Serializing)
 			{
 				byte[] assetId = Asset.Id.ToBytes();
-				stream.ReadWrite(ref assetId);
+				stream.ReadWrite(assetId);
 				long quantity = Asset.Quantity;
 				stream.ReadWrite(ref quantity);
 			}
 			else
 			{
 				byte[] assetId = new byte[20];
-				stream.ReadWrite(ref assetId);
+				stream.ReadWrite(assetId);
 				long quantity = 0;
 				stream.ReadWrite(ref quantity);
 				Asset = new AssetMoney(new AssetId(assetId), quantity);

--- a/NBitcoin/Protocol/AddressManager.cs
+++ b/NBitcoin/Protocol/AddressManager.cs
@@ -78,7 +78,7 @@ namespace NBitcoin.Protocol
 			public void ReadWrite(BitcoinStream stream)
 			{
 				stream.ReadWrite(ref _Address);
-				stream.ReadWrite(ref source);
+				stream.ReadWrite(source);
 				stream.ReadWrite(ref nLastSuccess);
 				stream.ReadWrite(ref nAttempts);
 			}

--- a/NBitcoin/Protocol/Message.cs
+++ b/NBitcoin/Protocol/Message.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin.Crypto;
+using NBitcoin.Crypto;
 using NBitcoin.DataEncoders;
 using System;
 using System.Buffers;
@@ -80,7 +80,7 @@ namespace NBitcoin.Protocol
 			if (stream.Serializing || (!stream.Serializing && !_SkipMagic))
 				stream.ReadWrite(ref magic);
 
-			stream.ReadWrite(ref command);
+			stream.ReadWrite(command);
 
 			if (stream.Serializing)
 			{
@@ -123,7 +123,7 @@ namespace NBitcoin.Protocol
 					if (stream.ProtocolCapabilities.SupportCheckSum)
 						stream.ReadWrite(ref expectedChecksum);
 
-					stream.ReadWrite(ref payloadBytes, 0, length);
+					stream.ReadWrite(payloadBytes, 0, length);
 
 					//  We do not verify the checksum anymore because for 1000 blocks, it takes 80 seconds.
 

--- a/NBitcoin/Protocol/NetworkAddress.cs
+++ b/NBitcoin/Protocol/NetworkAddress.cs
@@ -1,4 +1,4 @@
-﻿#if !NOSOCKET
+#if !NOSOCKET
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -443,12 +443,12 @@ namespace NBitcoin.Protocol
 				if (stream.Serializing)
 				{
 					var localAddr = IsAddrV1Compatible ? SerializeV1Array() : IPV6_NONE;
-					stream.ReadWrite(ref localAddr);
+					stream.ReadWrite(localAddr);
 				}
 				else
 				{
 					var localAddr = new byte[ADDR_IPV6_SIZE];
-					stream.ReadWrite(ref localAddr);
+					stream.ReadWrite(localAddr);
 					SetLegacyIpv6(localAddr);
 				}
 			}

--- a/NBitcoin/Protocol/Payloads/CompactFilterPayload.cs
+++ b/NBitcoin/Protocol/Payloads/CompactFilterPayload.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace NBitcoin.Protocol
@@ -54,7 +54,7 @@ namespace NBitcoin.Protocol
 		{
 			stream.ReadWrite(ref _FilterType);
 			stream.ReadWrite(ref _BlockHash);
-			stream.ReadWrite(ref _FilterBytes);
+			stream.ReadWrite(_FilterBytes);
 		}
 	}
 

--- a/NBitcoin/Protocol/UnknowPayload.cs
+++ b/NBitcoin/Protocol/UnknowPayload.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -43,7 +43,7 @@ namespace NBitcoin.Protocol
 		}
 		public override void ReadWriteCore(BitcoinStream stream)
 		{
-			stream.ReadWrite(ref _Data);
+			stream.ReadWrite(_Data);
 		}
 	}
 }

--- a/NBitcoin/Protocol/VarString.cs
+++ b/NBitcoin/Protocol/VarString.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -49,7 +49,7 @@ namespace NBitcoin.Protocol
 					throw new ArgumentOutOfRangeException("Array size not big");
 				_Bytes = new byte[len.ToLong()];
 			}
-			stream.ReadWrite(ref _Bytes);
+			stream.ReadWrite(_Bytes);
 		}
 
 		internal static void StaticWrite(BitcoinStream bs, byte[] bytes)
@@ -59,7 +59,7 @@ namespace NBitcoin.Protocol
 				throw new ArgumentOutOfRangeException("Array size too big");
 			VarInt.StaticWrite(bs, len);
 			if (bytes != null)
-				bs.ReadWrite(ref bytes);
+				bs.ReadWrite(bytes);
 		}
 
 		internal static void StaticRead(BitcoinStream bs, ref byte[] bytes)
@@ -68,7 +68,7 @@ namespace NBitcoin.Protocol
 			if (len > (uint)bs.MaxArraySize)
 				throw new ArgumentOutOfRangeException("Array size too big");
 			bytes = new byte[len];
-			bs.ReadWrite(ref bytes);
+			bs.ReadWrite(bytes);
 		}
 
 		#endregion

--- a/NBitcoin/Secp256k1/FE.cs
+++ b/NBitcoin/Secp256k1/FE.cs
@@ -1,4 +1,4 @@
-﻿#if HAS_SPAN
+#if HAS_SPAN
 #nullable enable
 using System;
 using System.Collections.Generic;
@@ -473,7 +473,7 @@ namespace NBitcoin.Secp256k1
 		private readonly FE secp256k1_fe_sqr_inner(int times, int magnitude, bool normalized)
 		{
 			Span<uint> n = stackalloc uint[NCount];
-			this.Deconstruct(ref n, out _, out _);
+			this.Deconstruct(n, out _, out _);
 			ulong c, d;
 			ulong u0, u1, u2, u3, u4, u5, u6, u7, u8;
 			uint t9, t0, t1, t2, t3, t4, t5, t6, t7;
@@ -1192,7 +1192,7 @@ namespace NBitcoin.Secp256k1
 		}
 
 		public readonly void Deconstruct(
-			ref Span<uint> n,
+			Span<uint> n,
 			out int magnitude,
 			out bool normalized
 			)
@@ -1269,7 +1269,7 @@ namespace NBitcoin.Secp256k1
 			Span<uint> t = stackalloc uint[NCount];
 			int magnitude;
 			bool normalized;
-			this.Deconstruct(ref t, out magnitude, out normalized);
+			this.Deconstruct(t, out magnitude, out normalized);
 
 			/* Reduce t9 at the start so there will be at most a single carry from the first pass */
 			uint x = t[9] >> 22; t[9] &= 0x03FFFFFU;
@@ -1304,7 +1304,7 @@ namespace NBitcoin.Secp256k1
 			Span<uint> t = stackalloc uint[NCount];
 			int magnitude;
 			bool normalized;
-			this.Deconstruct(ref t, out magnitude, out normalized);
+			this.Deconstruct(t, out magnitude, out normalized);
 
 			/* Reduce t9 at the start so there will be at most a single carry from the first pass */
 			uint m;
@@ -1362,7 +1362,7 @@ namespace NBitcoin.Secp256k1
 			Span<uint> t = stackalloc uint[NCount];
 			int magnitude;
 			bool normalized;
-			this.Deconstruct(ref t, out magnitude, out normalized);
+			this.Deconstruct(t, out magnitude, out normalized);
 
 			/* Reduce t9 at the start so there will be at most a single carry from the first pass */
 			uint m;
@@ -1506,7 +1506,7 @@ namespace NBitcoin.Secp256k1
 		public readonly bool NormalizesToZero()
 		{
 			Span<uint> t = stackalloc uint[NCount];
-			this.Deconstruct(ref t, out _, out _);
+			this.Deconstruct(t, out _, out _);
 
 			/* z0 tracks a possible raw value of 0, z1 tracks a possible raw value of P */
 			uint z0, z1;

--- a/NBitcoin/Secp256k1/FEStorage.cs
+++ b/NBitcoin/Secp256k1/FEStorage.cs
@@ -1,4 +1,4 @@
-﻿#if HAS_SPAN
+#if HAS_SPAN
 #nullable enable
 using System;
 using System.Collections.Generic;
@@ -112,7 +112,7 @@ namespace NBitcoin.Secp256k1
 				(r.n7 & mask0) | (a.n7 & mask1));
 		}
 
-		public void Deconstruct(ref Span<uint> n)
+		public void Deconstruct(Span<uint> n)
 		{
 			n[0] = n0;
 			n[1] = n1;

--- a/NBitcoin/Secp256k1/Scalar.cs
+++ b/NBitcoin/Secp256k1/Scalar.cs
@@ -1,4 +1,4 @@
-﻿#if HAS_SPAN
+#if HAS_SPAN
 #nullable enable
 using System;
 using System.Collections.Generic;
@@ -390,7 +390,7 @@ namespace NBitcoin.Secp256k1
 		int CondNegate(int flag, out Scalar r)
 		{
 			Span<uint> rd = stackalloc uint[DCount];
-			Deconstruct(ref rd);
+			Deconstruct(rd);
 			/* If we are flag = 0, mask = 00...00 and this is a no-op;
      * if we are flag = 1, mask = 11...11 and this is identical to secp256k1_scalar_negate */
 			uint mask = (flag == 0 ? 1U : 0) - 1;
@@ -908,7 +908,7 @@ namespace NBitcoin.Secp256k1
 		{
 			Span<uint> l = stackalloc uint[16];
 			Span<uint> d = stackalloc uint[DCount];
-			Deconstruct(ref d);
+			Deconstruct(d);
 			for (int i = 0; i < times; i++)
 			{
 				sqr_512(l, d);
@@ -1024,7 +1024,7 @@ namespace NBitcoin.Secp256k1
 		public readonly Scalar Multiply(in Scalar b)
 		{
 			Span<uint> d = stackalloc uint[DCount];
-			this.Deconstruct(ref d);
+			this.Deconstruct(d);
 			Span<uint> l = stackalloc uint[16];
 			mul_512(l, this, b);
 			reduce_512(d, l);
@@ -1109,8 +1109,7 @@ namespace NBitcoin.Secp256k1
 			return a.Add(b);
 		}
 
-		public readonly void Deconstruct(
-				ref Span<uint> d)
+		public readonly void Deconstruct(Span<uint> d)
 		{
 			d[0] = this.d0;
 			d[1] = this.d1;

--- a/NBitcoin/Transaction.cs
+++ b/NBitcoin/Transaction.cs
@@ -1,4 +1,4 @@
-﻿using NBitcoin.Crypto;
+using NBitcoin.Crypto;
 using NBitcoin.DataEncoders;
 using NBitcoin.Protocol;
 using NBitcoin.RPC;
@@ -555,12 +555,12 @@ namespace NBitcoin
 				var compr = Compress();
 				if (compr != null)
 				{
-					stream.ReadWrite(ref compr);
+					stream.ReadWrite(compr);
 					return;
 				}
 				uint nSize = (uint)_Script.Length + nSpecialScripts;
 				stream.ReadWriteAsCompactVarInt(ref nSize);
-				stream.ReadWrite(ref _Script);
+				stream.ReadWrite(_Script);
 			}
 			else
 			{
@@ -569,13 +569,13 @@ namespace NBitcoin
 				if (nSize < nSpecialScripts)
 				{
 					byte[] vch = new byte[GetSpecialSize(nSize)];
-					stream.ReadWrite(ref vch);
+					stream.ReadWrite(vch);
 					_Script = Decompress(nSize, vch).ToBytes();
 					return;
 				}
 				nSize -= nSpecialScripts;
 				_Script = new byte[nSize];
-				stream.ReadWrite(ref _Script);
+				stream.ReadWrite(_Script);
 			}
 		}
 
@@ -1381,7 +1381,7 @@ namespace NBitcoin
 				if (stream.Serializing)
 				{
 					var bytes = (_Inputs[i].WitScript ?? WitScript.Empty).ToBytes();
-					stream.ReadWrite(ref bytes);
+					stream.ReadWrite(bytes);
 				}
 				else
 				{

--- a/NBitcoin/UInt256.cs
+++ b/NBitcoin/UInt256.cs
@@ -1,4 +1,4 @@
-﻿
+
 using System;
 using System.Collections;
 using System.Linq;
@@ -38,22 +38,22 @@ namespace NBitcoin
 				{
 #if !HAS_SPAN
 					var b = Value.ToBytes();
-					stream.ReadWrite(ref b);
+					stream.ReadWrite(b);
 #else
 					Span<byte> b = stackalloc byte[WIDTH_BYTE];
 					Value.ToBytes(b);
-					stream.ReadWrite(ref b);
+					stream.ReadWrite(b);
 #endif
 				}
 				else
 				{
 #if !HAS_SPAN
 					byte[] b = new byte[WIDTH_BYTE];
-					stream.ReadWrite(ref b);
+					stream.ReadWrite(b);
 					_Value = new uint256(b);
 #else
 					Span<byte> b = stackalloc byte[WIDTH_BYTE];
-					stream.ReadWrite(ref b);
+					stream.ReadWrite(b);
 					_Value = new uint256(b);
 #endif
 				}
@@ -583,12 +583,12 @@ namespace NBitcoin
 				if (stream.Serializing)
 				{
 					var b = Value.ToBytes();
-					stream.ReadWrite(ref b);
+					stream.ReadWrite(b);
 				}
 				else
 				{
 					byte[] b = new byte[WIDTH_BYTE];
-					stream.ReadWrite(ref b);
+					stream.ReadWrite(b);
 					_Value = new uint160(b);
 				}
 			}


### PR DESCRIPTION
It makes zero sense to pass spans by references if that span isn't replaced by another one (I mean changing the address it points to). The same applies to arrays as well.