### PR TITLE
If one output has amount below dust, throw exception instead of removing it

### DIFF
--- a/NBitcoin/TransactionBuilder.cs
+++ b/NBitcoin/TransactionBuilder.cs
@@ -1189,23 +1189,18 @@ namespace NBitcoin
 				{
 					var fee = ctx.CurrentGroupContext.Fee.GetAmount(Money.Zero);
 					txout.Value -= fee;
-
-					var minimumTxOutValue = (parent.DustPrevention ? parent.GetDust(txout.ScriptPubKey) : Money.Zero);
-					if (txout.Value < Money.Zero)
-					{
-						throw new OutputTooSmallException("Can't substract fee from this output because the amount is too small",
-						ctx.Group.Name,
-						-txout.Value
-						);
-					}
 					ctx.CurrentGroupContext.FeePaid = true;
-					if (txout.Value < minimumTxOutValue)
-					{
-						// Between zero and dust, should strip this output.
-						ctx.CurrentGroupContext.DustPreventionTotalRemoved += txout.Value;
-						return;
-					}
 					ctx.CurrentGroupContext.FeeTxOut = txout;
+				}
+
+				var minimumTxOutValue = (parent.DustPrevention ? parent.GetDust(txout.ScriptPubKey) : Money.Zero);
+				if (txout.Value < minimumTxOutValue)
+				{
+					// If the txout is below dust, they throw an exception
+					throw new OutputTooSmallException("Can't substract fee from this output because the amount is too small",
+					ctx.Group.Name,
+					minimumTxOutValue - txout.Value
+					);
 				}
 
 				ctx.CurrentGroupContext.SentOutput += txout.Value;


### PR DESCRIPTION
While it shouldn't really matter economically speaking to remove output with a value that is too small, it is surprising behavior for users, and give rise to several edge case.

Assuming 540 of dust, here is a summary of the changes of behavior:

| Case |      Before |  Now |
|----------|-------------|------|
| you send bob 600 satoshi, but substract 400 sats, the output left is 200 sats. |  Silently remove output | Throw exception |
| you send bob 200 satoshi (without substract fee) |  Silently remove output |   Throw exception |
| you sent bob 600 satoshi, substracted 700 sats of fee | Throw exception |    Throw exception |

Before, we would silently remove such outputs in the built transaction. Now the builder will always throw an exception.