### PR TITLE
change qtum MaxP2PVersion to 70021

### DIFF
--- a/NBitcoin.Altcoins/Qtum.cs
+++ b/NBitcoin.Altcoins/Qtum.cs
@@ -179,7 +179,7 @@ namespace NBitcoin.Altcoins
 			.SetMagic(0xd3a6cff1)
 			.SetPort(3888)
 			.SetRPCPort(3889)
-			.SetMaxP2PVersion(70020)
+			.SetMaxP2PVersion(70021)
 			.SetName("qtum-main")
 			.AddAlias("qtum-mainnet")
 			.AddDNSSeeds(new[]{
@@ -219,7 +219,7 @@ namespace NBitcoin.Altcoins
 			.SetMagic(0x0615220d)
 			.SetPort(13888)
 			.SetRPCPort(13889)
-			.SetMaxP2PVersion(70020)
+			.SetMaxP2PVersion(70021)
 			.SetName("qtum-test")
 			.AddAlias("qtum-testnet")
 			.AddDNSSeeds(new[]{
@@ -260,7 +260,7 @@ namespace NBitcoin.Altcoins
 			.SetMagic(0xe1c6ddfd)
 			.SetPort(23888)
 			.SetRPCPort(13889)
-			.SetMaxP2PVersion(70020)
+			.SetMaxP2PVersion(70021)
 			.SetName("qtum-reg")
 			.AddAlias("qtum-regtest")
 			.AddSeeds(new NetworkAddress[0])


### PR DESCRIPTION
With the hard fork of [Qtum v24.1](https://github.com/qtumproject/qtum/releases/tag/v24.1), the protocol version has changed from 70020 to 70021.

https://github.com/qtumproject/qtum/blob/master/src/version.h#L12

After merging this change in NBitcoin, please also upgrade NBXplorer version.

Hard fork is scheduled for November, so there is no rush.