### PR TITLE
Expose GRFilter's methods that accept a cached stream reader

### DIFF
--- a/NBitcoin.Tests/Bip158_tests.cs
+++ b/NBitcoin.Tests/Bip158_tests.cs
@@ -79,10 +79,13 @@ namespace NBitcoin.Tests
 				.Build();
 
 			var testKey = key.ToBytes().SafeSubarray(0, 16);
+			var reader = filter.GetGRStreamReader();
+
 			// The filter should match all the values that were added.
 			foreach (var name in names)
 			{
 				Assert.True(filter.Match(name, testKey));
+				Assert.True(filter.Match(name, testKey, reader));
 			}
 
 			// The filter should NOT match any extra value.
@@ -445,9 +448,10 @@ namespace NBitcoin.Tests
 			var filter = builder.Build();
 
 			var keyMatch = key.ToBytes().SafeSubarray(0, 16);
+			var reader = filter.GetGRStreamReader();
 			foreach (var script in scripts)
 			{
-				var match = filter.MatchAny(new[] { script.ToBytes() }, keyMatch);
+				var match = filter.Match(script.ToBytes(), keyMatch, reader);
 				Assert.True(match);
 			}
 		}

--- a/NBitcoin.Tests/Bip158_tests.cs
+++ b/NBitcoin.Tests/Bip158_tests.cs
@@ -79,7 +79,7 @@ namespace NBitcoin.Tests
 				.Build();
 
 			var testKey = key.ToBytes().SafeSubarray(0, 16);
-			var reader = filter.GetGRStreamReader();
+			var reader = filter.GetNewGRStreamReader();
 
 			// The filter should match all the values that were added.
 			foreach (var name in names)
@@ -448,7 +448,7 @@ namespace NBitcoin.Tests
 			var filter = builder.Build();
 
 			var keyMatch = key.ToBytes().SafeSubarray(0, 16);
-			var reader = filter.GetGRStreamReader();
+			var reader = filter.GetNewGRStreamReader();
 			foreach (var script in scripts)
 			{
 				var match = filter.Match(script.ToBytes(), keyMatch, reader);

--- a/NBitcoin/BIP158/BitStream.cs
+++ b/NBitcoin/BIP158/BitStream.cs
@@ -205,7 +205,7 @@ namespace NBitcoin
 
 	public class CachedGRCodedStreamReader : GRCodedStreamReader
 	{
-		private List<ulong> _cachedValues;
+		private readonly List<ulong> _cachedValues;
 		private int _position;
 
 		internal CachedGRCodedStreamReader(BitStream stream, byte p, ulong lastValue) : base(stream, p, lastValue)
@@ -218,12 +218,12 @@ namespace NBitcoin
 		{
 			if (_position >= _cachedValues.Count)
 			{
-				if (!base.TryRead(out var readedValue))
+				if (!base.TryRead(out var readValue))
 				{
 					value = 0;
 					return false;
 				}
-				_cachedValues.Add(readedValue);
+				_cachedValues.Add(readValue);
 			}
 			value = _cachedValues[_position++];
 			return true;

--- a/NBitcoin/BIP158/GolombRiceFilter.cs
+++ b/NBitcoin/BIP158/GolombRiceFilter.cs
@@ -295,7 +295,7 @@ namespace NBitcoin
 		/// Create a cached Golomb-Rice stream reader.
 		/// </summary>
 		/// <returns>A new cached Golomb-Rice stream reader instance</returns>
-		public CachedGRCodedStreamReader GetGRStreamReader()
+		public CachedGRCodedStreamReader GetNewGRStreamReader()
 		{
 			return new CachedGRCodedStreamReader(new BitStream(Data), P, 0);
 		}

--- a/NBitcoin/BIP158/GolombRiceFilter.cs
+++ b/NBitcoin/BIP158/GolombRiceFilter.cs
@@ -157,9 +157,22 @@ namespace NBitcoin
 		/// <returns>true if the element is in the filter, otherwise false.</returns>
 		public bool Match(byte[] data, byte[] key)
 		{
+			var reader = new GRCodedStreamReader(new BitStream(Data), P, 0);
+			return Match(data, key, reader);
+		}
+
+		/// <summary>
+		/// Checks if the value passed is in the filter.
+		/// </summary>
+		/// <param name="data">Data element to check in the filter.</param>
+		/// <param name="key">Key used for hashing the data elements.</param>
+		/// <param name="reader">Golomb-Rice stream reader.</param>
+		/// <returns>true if the element is in the filter, otherwise false.</returns>
+		public bool Match(byte[] data, byte[] key, GRCodedStreamReader reader)
+		{
 			if (data == null)
 				throw new ArgumentNullException(nameof(data));
-			return MatchAny(new[] { data }, 1, key);
+			return MatchAny(new[] { data }, 1, key, reader);
 		}
 
 		/// <summary>
@@ -170,7 +183,8 @@ namespace NBitcoin
 		/// <returns>true if at least one of the elements is in the filter, otherwise false.</returns>
 		public bool MatchAny(byte[][] data, byte[] key)
 		{
-			return MatchAny(data, data.Length, key);
+			var reader = new GRCodedStreamReader(new BitStream(Data), P, 0);
+			return MatchAny(data, data.Length, key, reader);
 		}
 
 		/// <summary>
@@ -181,19 +195,32 @@ namespace NBitcoin
 		/// <returns>true if at least one of the elements is in the filter, otherwise false.</returns>
 		public bool MatchAny(IEnumerable<byte[]> data, byte[] key)
 		{
+			var reader = new GRCodedStreamReader(new BitStream(Data), P, 0);
+			return MatchAny(data, key, reader);
+		}
+
+		/// <summary>
+		/// Checks if any of the provided elements is in the filter.
+		/// </summary>
+		/// <param name="data">Data elements to check in the filter.</param>
+		/// <param name="key">Key used for hashing the data elements.</param>
+		/// <param name="reader">Golomb-Rice stream reader.</param>
+		/// <returns>true if at least one of the elements is in the filter, otherwise false.</returns>
+		public bool MatchAny(IEnumerable<byte[]> data, byte[] key, GRCodedStreamReader reader)
+		{
 			if (data == null)
 				throw new ArgumentNullException(nameof(data));
 			if (data is byte[][] dataArray)
 			{
-				return MatchAny(dataArray, dataArray.Length, key);
+				return MatchAny(dataArray, dataArray.Length, key, reader);
 			}
 			else if (data is ICollection<byte[]> dataCollection)
 			{
-				return MatchAny(dataCollection, dataCollection.Count, key);
+				return MatchAny(dataCollection, dataCollection.Count, key, reader);
 			}
 			else
 			{
-				return MatchAny(data, data.Count(), key);
+				return MatchAny(data, data.Count(), key, reader);
 			}
 		}
 
@@ -203,7 +230,19 @@ namespace NBitcoin
 		/// <param name="data">Data elements to check in the filter.</param>
 		/// <param name="key">Key used for hashing the data elements.</param>
 		/// <returns>true if at least one of the elements is in the filter, otherwise false.</returns>
-		internal bool MatchAny(IEnumerable<byte[]> data, int dataCount, byte[] key)
+		internal bool MatchAny(IEnumerable<byte[]> data, int dataCount, byte[] key, GRCodedStreamReader reader)
+		{
+			try
+			{
+				return InternalMatchAny(data, dataCount, key, reader);
+			}
+			finally
+			{
+				reader.ResetPosition();
+			}
+		}
+
+		private bool InternalMatchAny(IEnumerable<byte[]> data, int dataCount, byte[] key, GRCodedStreamReader sr)
 		{
 			if (data == null || dataCount == 0)
 				throw new ArgumentException("data can not be null or empty array.", nameof(data));
@@ -211,9 +250,6 @@ namespace NBitcoin
 				throw new ArgumentNullException(nameof(key));
 
 			var hs = ConstructHashedSet(P, N, M, key, data, dataCount);
-
-			var bitStream = new BitStream(Data);
-			var sr = new GRCodedStreamReader(bitStream, P, 0);
 
 			while(sr.TryRead(out var val))
 			{
@@ -253,6 +289,15 @@ namespace NBitcoin
 		public override string ToString()
 		{
 			return NBitcoin.DataEncoders.Encoders.Hex.EncodeData(ToBytes());
+		}
+
+		/// <summary>
+		/// Create a cached Golomb-Rice stream reader.
+		/// </summary>
+		/// <returns>A new cached Golomb-Rice stream reader instance</returns>
+		public CachedGRCodedStreamReader GetGRStreamReader()
+		{
+			return new CachedGRCodedStreamReader(new BitStream(Data), P, 0);
 		}
 
 		internal static ulong FastReduction(ulong value, ulong nhi, ulong nlo)


### PR DESCRIPTION
This allows to use call match the same filter against a different set of elements without requiring to re-read the filter data, which it really expensive.