### PR TITLE
fix: apply Math.Round to FeeRate to mitigate rounding issues

### DIFF
--- a/NBitcoin/FeeRate.cs
+++ b/NBitcoin/FeeRate.cs
@@ -56,7 +56,7 @@ namespace NBitcoin
 			if (feePaid.Satoshi < 0)
 				throw new ArgumentOutOfRangeException(nameof(feePaid), "Cannot be less than 0.");
 			if (size > 0)
-				_FeePerK = (long)((decimal)feePaid.Satoshi / (decimal)size * 1000m);
+				_FeePerK = (long)Math.Round((decimal)feePaid.Satoshi / size * 1000m, MidpointRounding.AwayFromZero);
 			else
 				_FeePerK = Money.Zero;
 		}


### PR DESCRIPTION
**Problem:**
The FeeRate constructor FeeRate(Money feePaid, int size) might lead to minor rounding issues due to direct casting to long, especially when feePaid.Satoshi/size has a fractional part >= 0.5.

This issue manifest in other projects using NBitcoin, in particular: [https://github.com/zkSNACKs/WalletWasabi/issues/11215](https://github.com/zkSNACKs/WalletWasabi/issues/11215)

E.g.:
The fee rate per byte would be: 101/70 = 1.442857...
The fee rate per kilobyte would be: 1.442857 * 1000 = 1442.857...
But, when converted to long, the value becomes 1442, effectively rounding down and losing the 0.857 fractional value.

**Solution:**
Implemented Math.Round to handle rounding more predictably and prevent potential issues with transaction fee calculation precision. 

By using Math.Round with MidpointRounding.AwayFromZero, any decimal value from .5 to .999' is always rounded up to the next whole number. Without specifying MidpointRounding.AwayFromZero, and thus using the default MidpointRounding.ToEven (Banker’s Rounding), values ending in .5 are rounded to the nearest even whole number, which may produce discrepancies or undesired results in certain circumstances.

This fix ensures that fee rate calculations are more accurate and prevents underpaying or overpaying fees due to rounding discrepancies.