### PR TITLE
`OutPoint`: Use `CompareTo` in `operator==`

### DIFF
--- a/NBitcoin.Bench/OutPointBench.cs
+++ b/NBitcoin.Bench/OutPointBench.cs
@@ -1,0 +1,60 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NBitcoin.Bench
+{
+	public class OutPointBench
+	{
+		private const int Count = 10000;
+		private OutPoint[] _outPoints;
+
+		[GlobalSetup]
+		public void Setup()
+		{
+			Random random = new Random(Seed: 53454);
+
+			_outPoints = new OutPoint[Count];
+
+			for (int i = 0; i < Count; i++)
+			{
+				uint256 txid = new uint256(RandomUtils.GetBytes(32));
+				int n = random.Next(1_000_000) % 2;
+
+				_outPoints[i] = new OutPoint(txid, n);
+			}
+		}
+
+		[Benchmark]
+		public void Old()
+		{
+			_ = DoComparisons(newImplementation: false);
+		}
+
+		[Benchmark]
+		public void New()
+		{
+			_ = DoComparisons(newImplementation: true);
+		}
+
+		private int DoComparisons(bool newImplementation)
+		{
+			int count = 0;
+
+			foreach (OutPoint o1 in _outPoints)
+			{
+				foreach (OutPoint o2 in _outPoints)
+				{
+					if (OutPoint.OperatorEqualsEquals(newImplementation, o1, o2))
+					{
+						count++;
+					}
+				}
+			}
+
+			return count;
+		}
+	}
+}

--- a/NBitcoin/Transaction.cs
+++ b/NBitcoin/Transaction.cs
@@ -178,6 +178,27 @@ namespace NBitcoin
 			return (a.hash == b.hash && a.n == b.n);
 		}
 
+		public static bool OperatorEqualsEquals(bool newImpl, OutPoint? a, OutPoint? b)
+		{
+			if (Object.ReferenceEquals(a, null))
+			{
+				return Object.ReferenceEquals(b, null);
+			}
+			if (Object.ReferenceEquals(b, null))
+			{
+				return false;
+			}
+
+			if (newImpl)
+			{
+				return (a.hash == b.hash && a.n.CompareTo(b.n) == 0);
+			}
+			else
+			{
+				return (a.hash == b.hash && a.n == b.n);
+			}
+		}
+
 		public static bool operator !=(OutPoint? a, OutPoint? b)
 		{
 			return !(a == b);
@@ -206,6 +227,7 @@ namespace NBitcoin
 			return $"{Hash}-{N}";
 		}
 	}
+
 #nullable disable
 	public class TxIn : IBitcoinSerializable
 	{


### PR DESCRIPTION
I have not measured the change but it seems that for many cases it should be faster.