### PR TITLE
README.md: fix GitHubActions CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NBitcoin
 
 [![Join the chat at https://chat.btcpayserver.org/btcpayserver/channels/nbitcoin](https://img.shields.io/badge/Community%20Chat-Mattermost-%230058cc)](https://chat.btcpayserver.org/btcpayserver/channels/nbitcoin)
-[![Build status](https://github.com/MetacoSA/NBitcoin/workflows/CI/badge.svg)](https://github.com/MetacoSA/NBitcoin/actions?query=workflow%3ACI)
+[![Build status](https://github.com/MetacoSA/NBitcoin/workflows/CI/badge.svg?branch=master&event=push)](https://github.com/MetacoSA/NBitcoin/actions?query=branch%3Amaster)
 
 NBitcoin is the most complete Bitcoin library for the .NET platform. It implements all most relevant Bitcoin Improvement Proposals (BIPs). It also provides low level access to Bitcoin primitives so you can easily build your application on top of it. Join us in our [mattermost chat room](https://chat.btcpayserver.org/btcpayserver/channels/nbitcoin).
 It works on Windows, Mac and Linux with Xamarin, Unity, .NET Core or CLR. (Porting to Unity should not be that hard if you need it)


### PR DESCRIPTION
* It was red colour because some PR was failing to build, but what needs to be shown in the README file is the status for the master branch.
* Link changed to filter by branch too (so that a green badge leads to a green build at the top when clicking the link).