### PR TITLE
Fixing that Id should be increment when batching requests with certain RPC providers.

### DIFF
--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -809,8 +809,11 @@ namespace NBitcoin.RPC
 			if (batches == null)
 				throw new InvalidOperationException("This RPCClient instance is not a batch, use PrepareBatch");
 			_BatchedRequests = null;
+
+			int id = 0;
 			while (batches.TryDequeue(out req))
 			{
+				req.Item1.Id = ++id;
 				requests.Add(req);
 			}
 			if (requests.Count == 0)


### PR DESCRIPTION
We are currently transitioning our RPCs to Chainstack. When multiple requests are combined into a single HTTP request, we ensure that each RPC request is assigned a unique ID.