### PR TITLE
Properly validate recid

### DIFF
--- a/NBitcoin/CompactSignature.cs
+++ b/NBitcoin/CompactSignature.cs
@@ -15,9 +15,12 @@ namespace NBitcoin
 				throw new ArgumentNullException(nameof(sig64));
 			if (sig64.Length is not 64)
 				throw new ArgumentException("sig64 should be 64 bytes", nameof(sig64));
+			if (!IsValidRecId(recoveryId))
+				throw new ArgumentOutOfRangeException(nameof(recoveryId), "recoveryId should be recoveryId >= 0 && recoveryId < 4");
 			RecoveryId = recoveryId;
 			Signature = sig64;
 		}
+		public static bool IsValidRecId(int recid) => recid >= 0 && recid < 4;
 
 		/// <summary>
 		/// 

--- a/NBitcoin/Secp256k1/Recovery/SecpRecoverableECDSASignature.cs
+++ b/NBitcoin/Secp256k1/Recovery/SecpRecoverableECDSASignature.cs
@@ -19,14 +19,20 @@ namespace NBitcoin.Secp256k1
 		{
 			if (sig == null)
 				throw new ArgumentNullException(nameof(sig));
+			if (!IsValidRecId(recid))
+				throw new ArgumentOutOfRangeException(nameof(recid), "recid should be recid >= 0 && recid < 4");
 			this.r = sig.r;
 			this.s = sig.s;
 			this.recid = recid;
 		}
 
+		static bool IsValidRecId(int recid) => recid >= 0 && recid < 4;
+
 		public static bool TryCreateFromCompact(ReadOnlySpan<byte> in64, int recid, [MaybeNullWhen(false)] out SecpRecoverableECDSASignature sig)
 		{
 			sig = null;
+			if (!IsValidRecId(recid))
+				return false;
 			if (SecpECDSASignature.TryCreateFromCompact(in64, out var compact) && compact is SecpECDSASignature)
 			{
 				sig = new SecpRecoverableECDSASignature(compact, recid);


### PR DESCRIPTION
Reported by @Kukks 

```
System.InvalidOperationException: VERIFY_CHECK failed (bug in C# secp256k1)
   at NBitcoin.Secp256k1.ECPubKey.VERIFY_CHECK(Boolean value) in C:\Git\NBitcoin\NBitcoin\Secp256k1\Recovery\ECPubKey.cs:line 89
   at NBitcoin.Secp256k1.ECPubKey.TryRecover(Context ctx, SecpRecoverableECDSASignature recoverableSig, ReadOnlySpan1 msg32, ECPubKey& pubkey) in C:\Git\NBitcoin\NBitcoin\Secp256k1\Recovery\ECPubKey.cs:line 29
   at NBitcoin.PubKey.RecoverCompact(uint256 hash, CompactSignature compactSignature) in C:\Git\NBitcoin\NBitcoin\PubKey.cs:line 489
   at NBitcoin.CompactSignature.RecoverPubKey(uint256 hash) in C:\Git\NBitcoin\NBitcoin\CompactSignature.cs:line 34
   at NBitcoin.BIP322.Verify(Byte[] message, BitcoinAddress address, Byte[] signature, Func2 proofOfFundsLookup) in C:\Git\NBitcoin\NBitcoin\BIP322.cs:line 198
```