### PR TITLE
Fix: GenerateNonce(ECPubKey) wasn't random as expected

### DIFF
--- a/NBitcoin.Tests/Secp256k1Tests.cs
+++ b/NBitcoin.Tests/Secp256k1Tests.cs
@@ -3985,6 +3985,13 @@ namespace NBitcoin.Tests
 			// Add the scripts there
 			var treeInfo = builder.Finalize(new TaprootInternalPubKey(aggregatedKey.ToXOnlyPubKey().ToBytes()));
 			musig = new MusigContext(ecPubKeys, msg32);
+
+			// Sanity check that GenerateNonce do not reuse nonces
+			var n1 = musig.GenerateNonce(ecPubKeys[0]);
+			var n2 = musig.GenerateNonce(ecPubKeys[0]);
+			Assert.NotEqual(Encoders.Hex.EncodeData(n1.CreatePubNonce().ToBytes()), Encoders.Hex.EncodeData(n2.CreatePubNonce().ToBytes()));
+			//
+
 			nonces = ecPubKeys.Select(c => musig.GenerateNonce(c)).ToArray();
 			musig.Tweak(treeInfo.OutputPubKey.Tweak.Span);
 			musig.ProcessNonces(nonces.Select(n => n.CreatePubNonce()).ToArray());

--- a/NBitcoin/Secp256k1/Musig/MusigContext.cs
+++ b/NBitcoin/Secp256k1/Musig/MusigContext.cs
@@ -467,7 +467,7 @@ namespace NBitcoin.Secp256k1.Musig
 		/// <returns>A private nonce whose public part intended to be sent to other signers</returns>
 		public MusigPrivNonce GenerateNonce(ECPubKey signingPubKey)
 		{
-			return GenerateNonce(signingPubKey, Array.Empty<byte>());
+			return GenerateNonce(signingPubKey, null);
 		}
 		/// <summary>
 		/// This function derives a secret nonce that will be required for signing and


### PR DESCRIPTION
Because an empty `sessionId` was passed instead of null, the nonce wouldn't be randomly generated, using a constant zero byte `sessionId` leading to nonce reuse...