### PR TITLE
GolombRiceFilter MatchAny fix

### DIFF
--- a/NBitcoin/BIP158/GolombRiceFilter.cs
+++ b/NBitcoin/BIP158/GolombRiceFilter.cs
@@ -251,9 +251,9 @@ namespace NBitcoin
 
 			var hs = ConstructHashedSet(P, N, M, key, data, dataCount);
 
-			while(sr.TryRead(out var val))
+			var dataIndex = 0;
+			while (sr.TryRead(out var val))
 			{
-				var dataIndex = 0;
 				while(true)
 				{
 					if (dataIndex == dataCount)


### PR DESCRIPTION
Fixing GolombRiceFilter.InternalMatchAny to make it O(k+n) from O(k*n).

Bug fix that was introduced at
https://github.com/MetacoSA/NBitcoin/commit/453b92c292020e1d0f2d530d1a35293262d0ee4b

