### PR TITLE
Fix: Send batch could hang if the service was sending error 404

### DIFF
--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -904,12 +904,7 @@ namespace NBitcoin.RPC
 							}
 							return;
 						}
-						if (httpResponse.Content == null ||
-							(httpResponse.Content.Headers.ContentLength == null || httpResponse.Content.Headers.ContentLength.Value == 0) ||
-							!httpResponse.Content.Headers.ContentType.MediaType.Equals("application/json", StringComparison.Ordinal))
-						{
-							httpResponse.EnsureSuccessStatusCode(); // Let's throw
-						}
+						httpResponse.EnsureSuccessStatusCode(); // Let's throw
 					}
 				}
 			}


### PR DESCRIPTION
If a RPC service was replying HTTP 404, then the Send Batch wouldn't set the result of the batched requests.