### PR TITLE
RPCClient should throw an HTTP error if a command send http error without JSON

### DIFF
--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -996,7 +996,10 @@ namespace NBitcoin.RPC
 						{
 							response = RPCResponse.Load(await httpResponse.Content.ReadAsStreamAsync());
 							if (request.ThrowIfRPCError)
+							{
 								response.ThrowIfError();
+								httpResponse.EnsureSuccessStatusCode();
+							}
 						}
 						else if (await IsWorkQueueFull(httpResponse))
 						{


### PR DESCRIPTION
Without this change, if the route send an http error without JSON, the response would be `null`.