### PR TITLE
Support Qtum hardfork v27.1

### DIFF
--- a/NBitcoin.Altcoins/Qtum.cs
+++ b/NBitcoin.Altcoins/Qtum.cs
@@ -179,7 +179,7 @@ namespace NBitcoin.Altcoins
 			.SetMagic(0xd3a6cff1)
 			.SetPort(3888)
 			.SetRPCPort(3889)
-			.SetMaxP2PVersion(70021)
+			.SetMaxP2PVersion(70022)
 			.SetName("qtum-main")
 			.AddAlias("qtum-mainnet")
 			.AddDNSSeeds(new[]{
@@ -219,7 +219,7 @@ namespace NBitcoin.Altcoins
 			.SetMagic(0x0615220d)
 			.SetPort(13888)
 			.SetRPCPort(13889)
-			.SetMaxP2PVersion(70021)
+			.SetMaxP2PVersion(70022)
 			.SetName("qtum-test")
 			.AddAlias("qtum-testnet")
 			.AddDNSSeeds(new[]{
@@ -260,7 +260,7 @@ namespace NBitcoin.Altcoins
 			.SetMagic(0xe1c6ddfd)
 			.SetPort(23888)
 			.SetRPCPort(13889)
-			.SetMaxP2PVersion(70021)
+			.SetMaxP2PVersion(70022)
 			.SetName("qtum-reg")
 			.AddAlias("qtum-regtest")
 			.AddSeeds(new NetworkAddress[0])


### PR DESCRIPTION
Qtum had a hardfork and now it rejects peers using old P2P version.

> https://github.com/qtumproject/qtum/blob/master/src/node/protocol_version.h#L12

Please also update NBXplorer and BTCPayServer once this is pushed. Thank you.