### PR TITLE
Fix misnaming in exceptions and variable names

### DIFF
--- a/NBitcoin/BIP32/ExtKey.cs
+++ b/NBitcoin/BIP32/ExtKey.cs
@@ -232,7 +232,7 @@ namespace NBitcoin
 				if (bytes == null)
 					throw new ArgumentNullException(nameof(bytes));
 				if (bytes.Length != Length)
-					throw new FormatException($"An extpubkey should be {Length} bytes");
+					throw new FormatException($"An ExtKey should be {Length} bytes");
 				int i = 0;
 				nDepth = bytes[i];
 				i++;
@@ -272,7 +272,7 @@ namespace NBitcoin
 			else
 			{
 				if (bytes.Length != Length)
-					throw new FormatException($"An extpubkey should be {Length} bytes");
+					throw new FormatException($"An ExtKey should be {Length} bytes");
 				int i = 0;
 				nDepth = bytes[i];
 				i++;

--- a/NBitcoin/BIP32/ExtKey.cs
+++ b/NBitcoin/BIP32/ExtKey.cs
@@ -103,8 +103,8 @@ namespace NBitcoin
 		}
 
 		/// <summary>
-		/// Constructor. Reconstructs an extended key from the Base58 representations of 
-		/// the public key and corresponding private key.  
+		/// Constructor. Reconstructs an extended key from the Base58 representations of
+		/// the public key and corresponding private key.
 		/// </summary>
 		public ExtKey(BitcoinExtPubKey extPubKey, BitcoinSecret key)
 			: this(extPubKey.ExtPubKey, key.PrivateKey)
@@ -112,7 +112,7 @@ namespace NBitcoin
 		}
 
 		/// <summary>
-		/// Constructor. Creates an extended key from the public key and corresponding private key.  
+		/// Constructor. Creates an extended key from the public key and corresponding private key.
 		/// </summary>
 		/// <remarks>
 		/// <para>
@@ -366,7 +366,7 @@ namespace NBitcoin
 		}
 
 		/// <summary>
-		/// Derives a new extended key in the hierarchy as the given child number, 
+		/// Derives a new extended key in the hierarchy as the given child number,
 		/// setting the high bit if hardened is specified.
 		/// </summary>
 		public ExtKey Derive(int index, bool hardened)
@@ -451,7 +451,7 @@ namespace NBitcoin
 		}
 
 		/// <summary>
-		/// Recreates the private key of the parent from the private key of the child 
+		/// Recreates the private key of the parent from the private key of the child
 		/// combinated with the public key of the parent (hardened children cannot be
 		/// used to recreate the parent).
 		/// </summary>

--- a/NBitcoin/BIP32/ExtKey.cs
+++ b/NBitcoin/BIP32/ExtKey.cs
@@ -245,9 +245,9 @@ namespace NBitcoin
 				i += 32;
 				if (bytes[i++] != 0)
 					throw new FormatException($"Invalid ExtKey");
-				var pk = new byte[32];
-				Array.Copy(bytes, i, pk, 0, 32);
-				key = new Key(pk);
+				var sk = new byte[32];
+				Array.Copy(bytes, i, sk, 0, 32);
+				key = new Key(sk);
 			}
 		}
 
@@ -285,9 +285,9 @@ namespace NBitcoin
 				i += 32;
 				if (bytes[i++] != 0)
 					throw new FormatException($"Invalid ExtKey");
-				Span<byte> pk = stackalloc byte[32];
-				bytes.Slice(i, 32).CopyTo(pk);
-				key = new Key(pk);
+				Span<byte> sk = stackalloc byte[32];
+				bytes.Slice(i, 32).CopyTo(sk);
+				key = new Key(sk);
 			}
 		}
 		private static Key CalculateKey(ReadOnlySpan<byte> seed, out byte[] chainCode)


### PR DESCRIPTION
My guess is that whoever implemented `ExtKey` copy-pasted parts of it from `ExtPubKey`. I've paid close attention to possible mistakes due to copy-pasting and only found the naming issues. While it's a minor change, it really confused me in the first place.