### PR TITLE
Fix: Install libssl in CI workflow for dotnetcore31 failing job in pipeline

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -23,6 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Install libssl
+        run: |
+          wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl1.0/libssl1.0.0_1.0.2n-1ubuntu5_amd64.deb
+          sudo dpkg -i libssl1.0.0_1.0.2n-1ubuntu5_amd64.deb
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '6.0.x'


### PR DESCRIPTION
Comes from this change on master branch https://github.com/MetacoSA/NBitcoin/commit/73e047a04d7978d79afdd379daa0f82b9e36072f