### PR TITLE
Fix improper parsing of transaction with some nVersion

### DIFF
--- a/NBitcoin.Altcoins/Bitcoinplus.cs
+++ b/NBitcoin.Altcoins/Bitcoinplus.cs
@@ -338,11 +338,7 @@ namespace NBitcoin.Altcoins
                 stream.ReadWrite(ref vinTemp);
 				vinTemp.Transaction = this;
 
-				var hasNoDummy = (nVersionTemp & NoDummyInput) != 0 && vinTemp.Count == 0;
-                if (witSupported && hasNoDummy)
-                    nVersionTemp = nVersionTemp & ~NoDummyInput;
-
-                if (vinTemp.Count == 0 && witSupported && !hasNoDummy)
+                if (vinTemp.Count == 0 && witSupported)
                 {
                     /* We read a dummy or an empty vin. */
                     stream.ReadWrite(ref flags);
@@ -392,8 +388,7 @@ namespace NBitcoin.Altcoins
             private void SerializeTxn(BitcoinStream stream, bool witSupported)
             {
                 byte flags = 0;
-                var version = (witSupported && (this.Inputs.Count == 0 && this.Outputs.Count > 0)) ? this.Version | NoDummyInput : this.Version;
-                stream.ReadWrite(ref version);
+                stream.ReadWrite(ref nVersion);
 
                 // POS Timestamp
                 var time = this.Time;

--- a/NBitcoin.Altcoins/Litecoin.cs
+++ b/NBitcoin.Altcoins/Litecoin.cs
@@ -161,9 +161,7 @@ namespace NBitcoin.Altcoins
 			public override void ReadWrite(BitcoinStream stream)
 			{
 				var witSupported = (((uint)stream.TransactionOptions & (uint)TransactionOptions.Witness) != 0) &&
-									stream.ProtocolCapabilities.SupportWitness;
-
-				//var mwebSupported = false; //when mweb is supported in nbitcoin this is to be fixed
+								stream.ProtocolCapabilities.SupportWitness;
 
 				byte flags = 0;
 				if (!stream.Serializing)
@@ -172,11 +170,8 @@ namespace NBitcoin.Altcoins
 					/* Try to read the vin. In case the dummy is there, this will be read as an empty vector. */
 					stream.ReadWrite(ref vin);
 					vin.Transaction = this;
-					var hasNoDummy = (nVersion & NoDummyInput) != 0 && vin.Count == 0;
-					if (witSupported && hasNoDummy)
-						nVersion = nVersion & ~NoDummyInput;
 
-					if (vin.Count == 0 && witSupported && !hasNoDummy)
+					if (vin.Count == 0 && witSupported)
 					{
 						/* We read a dummy or an empty vin. */
 						stream.ReadWrite(ref flags);
@@ -224,8 +219,7 @@ namespace NBitcoin.Altcoins
 				}
 				else
 				{
-					var version = (witSupported && (vin.Count == 0 && vout.Count > 0)) ? nVersion | NoDummyInput : nVersion;
-					stream.ReadWrite(ref version);
+					stream.ReadWrite(ref nVersion);
 
 					if (witSupported)
 					{
@@ -238,8 +232,8 @@ namespace NBitcoin.Altcoins
 					if (flags != 0)
 					{
 						/* Use extended format in case witnesses are to be serialized. */
-						TxInList vinDummy = new TxInList();
-						stream.ReadWrite(ref vinDummy);
+						byte marker = 0;
+						stream.ReadWrite(ref marker);
 						stream.ReadWrite(ref flags);
 					}
 					stream.ReadWrite(ref vin);

--- a/NBitcoin.Altcoins/NBitcoin.Altcoins.csproj
+++ b/NBitcoin.Altcoins/NBitcoin.Altcoins.csproj
@@ -17,7 +17,7 @@
     <TargetFrameworks Condition="'$(TargetFrameworkOverride)' != ''">$(TargetFrameworkOverride)</TargetFrameworks>
 		<NoWarn>1591;1573;1572;1584;1570;3021</NoWarn>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>4.0.6</Version>
+    <Version>4.0.7</Version>
 	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\NBitcoin\NBitcoin.csproj" />

--- a/NBitcoin.Altcoins/Stratis.cs
+++ b/NBitcoin.Altcoins/Stratis.cs
@@ -360,11 +360,8 @@ namespace NBitcoin.Altcoins
 				// Try to read the vin. In case the dummy is there, this will be read as an empty vector.
 				stream.ReadWrite(ref vinTemp);
 				vinTemp.Transaction = this;
-				var hasNoDummy = (nVersionTemp & NoDummyInput) != 0 && vinTemp.Count == 0;
-				if (witSupported && hasNoDummy)
-					nVersionTemp = nVersionTemp & ~NoDummyInput;
 
-				if (vinTemp.Count == 0 && witSupported && !hasNoDummy)
+				if (vinTemp.Count == 0 && witSupported)
 				{
 					// We read a dummy or an empty vin.
 					stream.ReadWrite(ref flags);
@@ -414,8 +411,7 @@ namespace NBitcoin.Altcoins
 			private void SerializeTxn(BitcoinStream stream, bool witSupported)
 			{
 				byte flags = 0;
-				var version = (witSupported && (this.Inputs.Count == 0 && this.Outputs.Count > 0)) ? this.Version | NoDummyInput : this.Version;
-				stream.ReadWrite(ref version);
+				stream.ReadWrite(ref nVersion);
 
 				// POS Timestamp
 				var time = this.Time;

--- a/NBitcoin.TestFramework/NBitcoin.TestFramework.csproj
+++ b/NBitcoin.TestFramework/NBitcoin.TestFramework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<VersionPrefix>3.0.39</VersionPrefix>
+		<VersionPrefix>3.0.40</VersionPrefix>
 		<LangVersion>12.0</LangVersion>
 		<TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
 		<TargetFrameworks Condition="'$(BuildingInsideVisualStudio)' == 'true'">netstandard2.1</TargetFrameworks>

--- a/NBitcoin.Tests/PSBTTests.cs
+++ b/NBitcoin.Tests/PSBTTests.cs
@@ -8,6 +8,8 @@ using System.Collections.Generic;
 using System.Linq;
 using static NBitcoin.Tests.Comparer;
 using Xunit.Abstractions;
+using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace NBitcoin.Tests
 {
@@ -192,6 +194,15 @@ namespace NBitcoin.Tests
 				Assert.Equal(psbt, psbt2, ComparerInstance);
 			}
 		}
+
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void FixVersionParsingBug()
+		{
+			var tx = Transaction.Parse("39a75f190001010000000000000000000000000000000000000000000000000000000000000000ffffffff4903d7ae0d04970a256861627a637862fabe6d6d86846e235af48afb776d0a32cb278930b7dd601fb0e05011789ef233a3e0e7d1010000000000000012b299f4e40000000000ffffffffffffffff02ec12bb1200000000160014b6f3cfc20084e3b9f0d12b0e6f9da8fcbcf5a2d90000000000000000266a24aa21a9edc8a9c6157fb538507480083f8f5144e2f73d1bd9b6b5fabde17bd08ff524b7100120000000000000000000000000000000000000000000000000000000000000000000000000", Network.Main);
+			Assert.Equal("889d4fed1ec4a775d02082b5ff727f48d93013469db709d8d435e15b173118f3", tx.GetHash().ToString());
+		}
+
 		[Fact]
 		[Trait("UnitTest", "UnitTest")]
 		public void AddCoinsShouldNotRemoveInfoFromPSBT()

--- a/NBitcoin/NBitcoin.csproj
+++ b/NBitcoin/NBitcoin.csproj
@@ -12,7 +12,7 @@
 		<RepositoryType>git</RepositoryType>
 	</PropertyGroup>
 	<PropertyGroup>
-		<Version Condition=" '$(Version)' == '' ">8.0.11</Version>
+		<Version Condition=" '$(Version)' == '' ">8.0.12</Version>
 		<LangVersion>12.0</LangVersion>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/NBitcoin/Transaction.cs
+++ b/NBitcoin/Transaction.cs
@@ -1530,9 +1530,6 @@ namespace NBitcoin
 			}
 		}
 
-		//Since it is impossible to serialize a transaction with 0 input without problems during deserialization with wit activated, we fit a flag in the version to workaround it
-		protected const uint NoDummyInput = (1 << 27);
-
 #region IBitcoinSerializable Members
 
 		public virtual void ReadWrite(BitcoinStream stream)
@@ -1547,11 +1544,8 @@ namespace NBitcoin
 				/* Try to read the vin. In case the dummy is there, this will be read as an empty vector. */
 				stream.ReadWrite(ref vin);
 				vin.Transaction = this;
-				var hasNoDummy = (nVersion & NoDummyInput) != 0 && vin.Count == 0;
-				if (witSupported && hasNoDummy)
-					nVersion = nVersion & ~NoDummyInput;
 
-				if (vin.Count == 0 && witSupported && !hasNoDummy)
+				if (vin.Count == 0 && witSupported)
 				{
 					/* We read a dummy or an empty vin. */
 					stream.ReadWrite(ref flags);
@@ -1580,8 +1574,11 @@ namespace NBitcoin
 				{
 					/* The witness flag is present, and we support witnesses. */
 					flags ^= 1;
-					Witness wit = new Witness(Inputs);
-					wit.ReadWrite(stream);
+					if (Inputs.Count != 0)
+					{
+						Witness wit = new Witness(Inputs);
+						wit.ReadWrite(stream);
+					}
 				}
 				if (flags != 0)
 				{
@@ -1591,8 +1588,7 @@ namespace NBitcoin
 			}
 			else
 			{
-				var version = (witSupported && (vin.Count == 0 && vout.Count > 0)) ? nVersion | NoDummyInput : nVersion;
-				stream.ReadWrite(ref version);
+				stream.ReadWrite(ref nVersion);
 
 				if (witSupported)
 				{


### PR DESCRIPTION
The coinbase transaction [889d4fed1ec4a775d02082b5ff727f48d93013469db709d8d435e15b173118f3](https://mempool.space/tx/889d4fed1ec4a775d02082b5ff727f48d93013469db709d8d435e15b173118f3) wasn't properly parsed by NBitcoin, resulting in code crashing when parsing block 896727.

The root cause seems to be that I based my implementation on code that was done pre-release of segwit https://github.com/bitcoin/bitcoin/commit/e37b16a75c1ff86d515ef3050d2c76432ea71225 .