### PR TITLE
Fix tests

### DIFF
--- a/NBitcoin.Altcoins/Litecoin.cs
+++ b/NBitcoin.Altcoins/Litecoin.cs
@@ -219,6 +219,9 @@ namespace NBitcoin.Altcoins
 				}
 				else
 				{
+					if (Inputs.Count == 0 && !stream.AllowNoInputs)
+						throw new InvalidOperationException("The transaction must have at least one input");
+
 					stream.ReadWrite(ref nVersion);
 
 					if (witSupported)

--- a/NBitcoin.Tests/ChainTests.cs
+++ b/NBitcoin.Tests/ChainTests.cs
@@ -608,7 +608,9 @@ namespace NBitcoin.Tests
 			var nonce = RandomUtils.GetUInt32();
 			foreach (var chain in chains)
 			{
-				var block = TestUtils.CreateFakeBlock(Network.Main.CreateTransaction());
+				var tx = Network.Main.CreateTransaction();
+				tx.Inputs.Add();
+				var block = TestUtils.CreateFakeBlock(tx);
 				block.Header.HashPrevBlock = previous == null ? chain.Tip.HashBlock : previous.HashBlock;
 				block.Header.Nonce = nonce;
 				if (!chain.TrySetTip(block.Header, out last))

--- a/NBitcoin.Tests/ColoredCoinsTests.cs
+++ b/NBitcoin.Tests/ColoredCoinsTests.cs
@@ -151,6 +151,7 @@ namespace NBitcoin.Tests
 			Assert.True(destroyed[0].Id == a2.Id);
 
 			var prior = Network.Main.CreateTransaction();
+			prior.Inputs.Add();
 			prior.Outputs.Add(new TxOut(dust, a1.ScriptPubKey));
 			prior.Outputs.Add(new TxOut(dust, a2.ScriptPubKey));
 			prior.Outputs.Add(new TxOut(dust, h.ScriptPubKey));

--- a/NBitcoin.Tests/Generators/PSBTGenerator.cs
+++ b/NBitcoin.Tests/Generators/PSBTGenerator.cs
@@ -38,7 +38,7 @@ namespace NBitcoin.Tests.Generators
 		/// <param name="network"></param>
 		/// <returns></returns>
 		public static Gen<PSBT> SanePSBT(Network network) =>
-			from inputN in Gen.Choose(0, 8)
+			from inputN in Gen.Choose(1, 8)
 			from scripts in Gen.ListOf(inputN, ScriptGenerator.RandomScriptSig())
 			from txOuts in Gen.Sequence(scripts.Select(sc => OutputFromRedeem(sc)))
 			from prevN in Gen.Choose(0, 5)

--- a/NBitcoin.Tests/PSBTTests.cs
+++ b/NBitcoin.Tests/PSBTTests.cs
@@ -56,6 +56,7 @@ namespace NBitcoin.Tests
 				var bob = bobMaster.Derive(new KeyPath("4/5/6"));
 
 				var funding = network.CreateTransaction();
+				funding.Inputs.Add();
 				funding.Outputs.Add(Money.Coins(1.0m), alice);
 				funding.Outputs.Add(Money.Coins(1.5m), bob);
 
@@ -642,8 +643,9 @@ namespace NBitcoin.Tests
 			var accountExtKey = masterExtkey.Derive(new KeyPath("0'/0'/0'"));
 			var accountRootedKeyPath = new KeyPath("0'/0'/0'").ToRootedKeyPath(masterExtkey);
 			uint hardenedFlag = 0x80000000U;
-		retry:
+			retry:
 			Transaction funding = masterExtkey.Network.CreateTransaction();
+			funding.Inputs.Add();
 			funding.Outputs.Add(Money.Coins(2.0m), accountExtKey.Derive(0 | hardenedFlag).ScriptPubKey);
 			funding.Outputs.Add(Money.Coins(2.0m), accountExtKey.Derive(1 | hardenedFlag).ScriptPubKey);
 #if HAS_SPAN

--- a/NBitcoin.Tests/ProtocolTests.cs
+++ b/NBitcoin.Tests/ProtocolTests.cs
@@ -1102,7 +1102,9 @@ namespace NBitcoin.Tests
 		public void CanRoundtripCmpctBlock()
 		{
 			Block block = Network.Main.Consensus.ConsensusFactory.CreateBlock();
-			block.Transactions.Add(Network.Main.Consensus.ConsensusFactory.CreateTransaction());
+			var tx = Network.Main.Consensus.ConsensusFactory.CreateTransaction();
+			tx.Inputs.Add();
+			block.Transactions.Add(tx);
 			var cmpct = new CmpctBlockPayload(block);
 			cmpct.Clone();
 		}

--- a/NBitcoin.Tests/TestUtils.cs
+++ b/NBitcoin.Tests/TestUtils.cs
@@ -47,7 +47,9 @@ namespace NBitcoin.Tests
 
 		public static Block CreateFakeBlock()
 		{
-			var block = TestUtils.CreateFakeBlock(Network.Main.CreateTransaction());
+			var tx = Network.Main.CreateTransaction();
+			tx.Inputs.Add();
+			var block = TestUtils.CreateFakeBlock(tx);
 			block.Header.HashPrevBlock = new uint256(RandomUtils.GetBytes(32));
 			block.Header.Nonce = RandomUtils.GetUInt32();
 			return block;

--- a/NBitcoin.Tests/script_tests.cs
+++ b/NBitcoin.Tests/script_tests.cs
@@ -149,6 +149,7 @@ namespace NBitcoin.Tests
 		private void BIP65_testsCore(LockTime target, LockTime now, bool expectedResult)
 		{
 			Transaction tx = Network.CreateTransaction();
+			tx.Inputs.Add();
 			tx.Outputs.Add(new TxOut()
 			{
 				ScriptPubKey = new Script(Op.GetPushOp(target.Value), OpcodeType.OP_CHECKLOCKTIMEVERIFY)
@@ -736,6 +737,7 @@ namespace NBitcoin.Tests
 				);
 
 			Transaction txFrom12 = Network.CreateTransaction();
+			txFrom12.Inputs.Add();
 			txFrom12.Outputs.Add(new TxOut());
 			txFrom12.Outputs[0].ScriptPubKey = scriptPubKey12;
 
@@ -780,6 +782,7 @@ namespace NBitcoin.Tests
 
 
 			var txFrom23 = Network.CreateTransaction();
+			txFrom23.Inputs.Add();
 			txFrom23.Outputs.Add(new TxOut());
 			txFrom23.Outputs[0].ScriptPubKey = scriptPubKey23;
 

--- a/NBitcoin.Tests/transaction_tests.cs
+++ b/NBitcoin.Tests/transaction_tests.cs
@@ -988,6 +988,7 @@ namespace NBitcoin.Tests
 			var repo = new NoSqlColoredTransactionRepository(new NoSqlTransactionRepository(), new InMemoryNoSqlRepository());
 
 			var init = Network.CreateTransaction();
+			init.Inputs.Add();
 			init.Outputs.Add("1.0", gold.PubKey);
 			init.Outputs.Add("1.0", silver.PubKey);
 			init.Outputs.Add("1.0", satoshi.PubKey);
@@ -1279,6 +1280,7 @@ namespace NBitcoin.Tests
 			var repo = new NoSqlColoredTransactionRepository();
 
 			var init = Network.CreateTransaction();
+			init.Inputs.Add();
 			init.Outputs.Add("1.0", gold.PubKey);
 			init.Outputs.Add("1.0", silver.PubKey);
 			init.Outputs.Add("1.0", satoshi.PubKey);
@@ -1375,6 +1377,7 @@ namespace NBitcoin.Tests
 
 			//Gold receive 2.5 BTC
 			tx = txBuilder.Network.Consensus.ConsensusFactory.CreateTransaction();
+			tx.Inputs.Add();
 			tx.Outputs.Add("2.5", gold.PubKey);
 			repo.Transactions.Put(tx.GetHash(), tx);
 
@@ -1762,6 +1765,7 @@ namespace NBitcoin.Tests
 			builder.SendEstimatedFees(rate);
 			signed = builder.BuildTransaction(true);
 			Assert.True(builder.Verify(signed, estimatedFees));
+			Assert.Equal(1174, builder.EstimateSize(signed));
 		}
 
 		private Coin RandomCoin(Money amount, IDestination dest, bool p2sh)
@@ -1924,23 +1928,6 @@ namespace NBitcoin.Tests
 			AssertEx.CollectionEquals(before, input);
 		}
 
-		[Fact]
-		[Trait("UnitTest", "UnitTest")]
-		public void CanSerializeInvalidTransactionsBackAndForth()
-		{
-			Transaction before = Network.CreateTransaction();
-			var versionBefore = before.Version;
-			before.Outputs.Add(new TxOut());
-			Transaction after = AssertClone(before);
-			Assert.Equal(before.Version, after.Version);
-			Assert.Equal(versionBefore, after.Version);
-			Assert.True(after.Outputs.Count == 1);
-
-			before = Network.CreateTransaction();
-			after = AssertClone(before);
-			Assert.Equal(before.Version, versionBefore);
-		}
-
 		private Transaction AssertClone(Transaction before)
 		{
 			Transaction after = before.Clone();
@@ -2100,6 +2087,7 @@ namespace NBitcoin.Tests
 			var bob = new Key();
 			//P2SH(P2WSH)
 			var previousTx = Network.CreateTransaction();
+			previousTx.Inputs.Add();
 			previousTx.Outputs.Add(new TxOut(Money.Coins(1.0m), alice.PubKey.ScriptPubKey.WitHash.ScriptPubKey.Hash));
 			var previousCoin = previousTx.Outputs.AsCoins().First();
 
@@ -2658,6 +2646,7 @@ namespace NBitcoin.Tests
 			var bob = new Key();
 			var alice = new Key();
 			var tx = Network.CreateTransaction();
+			tx.Inputs.Add();
 			tx.Outputs.Add(Money.Coins(1.0m), bob);
 			var coins = tx.Outputs.AsCoins().ToArray();
 
@@ -2852,6 +2841,7 @@ namespace NBitcoin.Tests
 		public void CanUseLockTime()
 		{
 			var tx = Network.CreateTransaction();
+			tx.Inputs.Add();
 			tx.LockTime = new LockTime(4);
 			var clone = tx.Clone();
 			Assert.Equal(tx.LockTime, clone.LockTime);
@@ -3082,6 +3072,7 @@ namespace NBitcoin.Tests
 		{
 			var bob = new Key().GetWif(Network.RegTest);
 			Transaction tx = Network.CreateTransaction();
+			tx.Inputs.Add();
 			tx.Outputs.Add(new TxOut(Money.Coins(1.0m), bob.PubKey.ScriptPubKey.WitHash));
 			ScriptCoin coin = new ScriptCoin(tx.Outputs.AsCoins().First(), bob.PubKey.ScriptPubKey);
 

--- a/NBitcoin/BitcoinStream.cs
+++ b/NBitcoin/BitcoinStream.cs
@@ -592,6 +592,7 @@ namespace NBitcoin
 			IsBigEndian = from.IsBigEndian;
 			MaxArraySize = from.MaxArraySize;
 			Type = from.Type;
+			AllowNoInputs = from.AllowNoInputs;
 		}
 
 		public SerializationType Type
@@ -629,6 +630,13 @@ namespace NBitcoin
 			get;
 			set;
 		}
+
+		/// <summary>
+		/// Allows serialization of transactions with no inputs.
+		/// Such transactions are not valid for deserialization, but may still be useful,
+		/// for example, when computing a transaction hash or estimating size.
+		/// </summary>
+		public bool AllowNoInputs { get; set; }
 
 		public void ReadWriteAsVarInt(ref uint val)
 		{

--- a/NBitcoin/IBitcoinSerializable.cs
+++ b/NBitcoin/IBitcoinSerializable.cs
@@ -32,6 +32,7 @@ namespace NBitcoin
 		public static int GetSerializedSize(this IBitcoinSerializable serializable, uint? version, SerializationType serializationType)
 		{
 			BitcoinStream s = new BitcoinStream(Stream.Null, true);
+			s.AllowNoInputs = true;
 			s.Type = serializationType;
 			s.ProtocolVersion = version;
 			s.ReadWrite(serializable);
@@ -40,6 +41,7 @@ namespace NBitcoin
 		public static int GetSerializedSize(this IBitcoinSerializable serializable, TransactionOptions options)
 		{
 			var bms = new BitcoinStream(Stream.Null, true);
+			bms.AllowNoInputs = true;
 			bms.TransactionOptions = options;
 			serializable.ReadWrite(bms);
 			return (int)bms.Counter.WrittenBytes;

--- a/NBitcoin/RPC/RPCClient.Wallet.cs
+++ b/NBitcoin/RPC/RPCClient.Wallet.cs
@@ -380,8 +380,12 @@ namespace NBitcoin.RPC
 			// if there is inputs, then it can't be confusing
 			if (tx.Inputs.Count > 0)
 				return tx.ToHex();
-			// if there is, do this ACK so that NBitcoin does not change the version number
-			return Encoders.Hex.EncodeData(tx.ToBytes(70012 - 1));
+
+			var ms = new MemoryStream();
+			BitcoinStream bs = new BitcoinStream(ms, true);
+			bs.AllowNoInputs = true;
+			tx.ReadWrite(bs);
+			return Encoders.Hex.EncodeData(ms.ToArrayEfficient());
 		}
 
 

--- a/NBitcoin/Transaction.cs
+++ b/NBitcoin/Transaction.cs
@@ -1574,11 +1574,8 @@ namespace NBitcoin
 				{
 					/* The witness flag is present, and we support witnesses. */
 					flags ^= 1;
-					if (Inputs.Count != 0)
-					{
-						Witness wit = new Witness(Inputs);
-						wit.ReadWrite(stream);
-					}
+					Witness wit = new Witness(Inputs);
+					wit.ReadWrite(stream);
 				}
 				if (flags != 0)
 				{
@@ -1588,6 +1585,8 @@ namespace NBitcoin
 			}
 			else
 			{
+				if (Inputs.Count == 0 && !stream.AllowNoInputs)
+					throw new InvalidOperationException("The transaction must have at least one input");
 				stream.ReadWrite(ref nVersion);
 
 				if (witSupported)
@@ -1637,6 +1636,7 @@ namespace NBitcoin
 				{
 					TransactionOptions = TransactionOptions.None,
 					ConsensusFactory = GetConsensusFactory(),
+					AllowNoInputs = true
 				};
 				stream.SerializationTypeScope(SerializationType.Hash);
 				this.ReadWrite(stream);

--- a/NBitcoin/TransactionBuilder.cs
+++ b/NBitcoin/TransactionBuilder.cs
@@ -2443,10 +2443,9 @@ namespace NBitcoin
 			if (tx == null)
 				throw new ArgumentNullException(nameof(tx));
 			var clone = tx.Clone();
-			clone.Inputs.Clear();
-			baseSize = clone.GetSerializedSize() - 1;
-			baseSize += new Protocol.VarInt((ulong)tx.Inputs.Count).GetSerializedSize();
-
+			clone.RemoveSignatures();
+			baseSize = clone.GetSerializedSize();
+			baseSize -= clone.Inputs.Count; // The varint to push scriptSig is accounted later
 			witSize = 0;
 			int nonWitnessCount = 0;
 			bool hasWitness = tx.HasWitness;
@@ -2460,9 +2459,7 @@ namespace NBitcoin
 				else
 					nonWitnessCount++;
 				EstimateScriptSigSize(coin, ref witSize, ref baseSize);
-				baseSize += (32 + 4) + 4;
 			}
-
 
 			if (hasWitness)
 			{


### PR DESCRIPTION
Follow up of https://github.com/MetacoSA/NBitcoin/pull/1269

Since it isn't possible to properly deserialize a transaction without input (and those can't exists on the network), this PR forbidden the serialization of transactions without input.

I added `BitcoinStream.AllowNoInputs` to still allow this for back compatibility reason (`fundrawtransaction` from core) or because it is acceptable, as the serialized bytes will never be read (calculation of the hash or size)