### PR TITLE
Remove unused test code

### DIFF
--- a/NBitcoin.Tests/bip32_tests.cs
+++ b/NBitcoin.Tests/bip32_tests.cs
@@ -302,8 +302,6 @@ namespace NBitcoin.Tests
 				Assert.Equal(74, data.Length);
 				// Test private key
 				BitcoinExtKey b58key = Network.Main.CreateBitcoinExtKey(key);
-				var a = Encoders.Hex.EncodeData(Encoders.Base58Check.DecodeData(b58key.ToString()));
-				var expected = Encoders.Hex.EncodeData(Encoders.Base58Check.DecodeData(derive.prv));
 				Assert.True(b58key.ToString() == derive.prv);
 				// Test public key
 				BitcoinExtPubKey b58pubkey = Network.Main.CreateBitcoinExtPubKey(pubkey);

--- a/NBitcoin.Tests/key_tests.cs
+++ b/NBitcoin.Tests/key_tests.cs
@@ -71,9 +71,6 @@ namespace NBitcoin.Tests
 
 				var compressedSec = secret.Copy(true);
 
-				var a = secret.PrivateKey.PubKey;
-				var b = compressedSec.PrivateKey.PubKey;
-
 				Assert.Equal(test.CompressedPrivateKeyWIF, compressedSec.ToWif());
 				Assert.Equal(test.CompressedPubKey, compressedSec.PrivateKey.PubKey.ToHex());
 				Assert.True(compressedSec.PrivateKey.PubKey.IsCompressed);

--- a/NBitcoin.Tests/transaction_tests.cs
+++ b/NBitcoin.Tests/transaction_tests.cs
@@ -2323,7 +2323,6 @@ namespace NBitcoin.Tests
 				new TxOut(new Money((i + 1) * Money.COIN), _.redeem.WitHash.ScriptPubKey.Hash),
 				_.redeem
 				)).ToList();
-			var a = witCoins.Select(c => c.Amount).Sum();
 			var allCoins = coins.Concat(scriptCoins).Concat(witCoins).ToArray();
 
 			// Let's create a fake funding Tx with all those coins


### PR DESCRIPTION
While going through the test code, I've noticed that parts of the test code being [unused](https://github.com/MetacoSA/NBitcoin/blob/master/NBitcoin.Tests/bip32_tests.cs#L305-L306). In particular, the `a` and `expected` variables. I grep'ed for all occurrences of the following lines in the test code and skimmed through the files for more unused code:
```csharp
var a =
var b =
var expected =
```

C# not being my home turf, I did not manage to quickly get a static analysis run against the test code to find other cases and prevent this in the future.

This test in my branch [6.0 with netstandard2.0](https://github.com/quapka/NBitcoin/actions/runs/18505991616/job/52736582605#logs) failed first, but succeeded on a manual trigger - not sure how deterministic are the tests then.

