### PR TITLE
Make ChainInfo.Difficulty an ulong

### DIFF
--- a/NBitcoin/RPC/RestClient.cs
+++ b/NBitcoin/RPC/RestClient.cs
@@ -173,7 +173,7 @@ namespace NBitcoin.RPC
 				BestBlockHash = uint256.Parse((string)o["bestblockhash"]),
 				Blocks = (int)o["blocks"],
 				ChainWork = uint256.Parse((string)o["chainwork"]),
-				Difficulty = (int)o["difficulty"],
+				Difficulty = (ulong)o["difficulty"],
 				Headers = (int)o["headers"],
 				VerificationProgress = (decimal)o["verificationprogress"],
 				IsPruned = (bool)o["pruned"]
@@ -289,7 +289,7 @@ namespace NBitcoin.RPC
 			get;
 			internal set;
 		}
-		public int Difficulty
+		public ulong Difficulty
 		{
 			get;
 			internal set;


### PR DESCRIPTION
ChainInfo.Difficulty is an int. It passes all test since the testdata has Difficulty == 0. It crashes against current chain data.  I could not figure out how to create a test that sets a value. 