### PR TITLE
RestClient.GetBlockHashByHeightAsync and tests

### DIFF
--- a/NBitcoin.Tests/RestClientTests.cs
+++ b/NBitcoin.Tests/RestClientTests.cs
@@ -154,5 +154,28 @@ namespace NBitcoin.Tests
 				Assert.Empty(headers);
 			}
 		}
+
+		[Fact]
+		public async Task CanGetBlockHashByHeight()
+		{			
+			using (var builder = NodeBuilderEx.Create())
+			{
+				var node = builder.CreateNode();
+				var client = node.CreateRESTClient();
+				builder.StartAll();
+								
+				var genesisHash = await client.GetBlockHashByHeightAsync(0);
+				Assert.Equal(RegNetGenesisBlock.GetHash(), genesisHash);
+				
+				var expectedHash = node.Generate(1).FirstOrDefault();
+								
+				var actualHash = await client.GetBlockHashByHeightAsync(1);
+				Assert.Equal(expectedHash, actualHash);
+
+				// Should throw exception for non-existent block height
+				await Assert.ThrowsAsync<RestApiException>(async () => 
+					await client.GetBlockHashByHeightAsync(2));
+			}
+		}
 	}
 }

--- a/NBitcoin/RPC/RestClient.cs
+++ b/NBitcoin/RPC/RestClient.cs
@@ -202,6 +202,18 @@ namespace NBitcoin.RPC
 			return utxos;
 		}
 
+		/// <summary>
+		/// Gets the block hash by height.
+		/// </summary>
+		/// <param name="height">The block height.</param>
+		/// <returns>The block hash at the specified height.</returns>		
+		public async Task<uint256> GetBlockHashByHeightAsync(int height)
+		{
+			var result = await SendRequestAsync("blockhashbyheight", RestResponseFormat.Json, height.ToString()).ConfigureAwait(false);
+			var o = JObject.Parse(Encoding.UTF8.GetString(result, 0, result.Length));
+			return uint256.Parse((string)o["blockhash"]);			
+		}
+
 		public async Task<byte[]> SendRequestAsync(string resource, RestResponseFormat format, params string[] parms)
 		{
 			var request = BuildHttpRequest(resource, format, parms);


### PR DESCRIPTION
Implement RestClient.GetBlockHashByHeightAsync by calling /rest/blockhashbyheight/{height}.json.

Included test that passes on linux compiling for dotnet 6 and rolling forward to 9.