### PR TITLE
Fix ComputeTapTweak span aliasing causing all-zero output key on .NET 10 ARM64

### DIFF
--- a/NBitcoin.Tests/TaprootBuilderTests.cs
+++ b/NBitcoin.Tests/TaprootBuilderTests.cs
@@ -225,6 +225,33 @@ namespace NBitcoin.Tests
 			var expectedSpk = "5120003cdb72825a12ea62f5834f3c47f9bf48d58d27f5ad1e6576ac613b093125f3";
 			Assert.Equal( expectedSpk, spk.ToHex());
 		}
+
+		[Fact]
+		[Trait("UnitTest", "UnitTest")]
+		public void ComputeTapTweak_DoesNotProduceAllZeroOutputKey()
+		{
+			// Regression test for .NET 10 ARM64 JIT span-aliasing bug.
+			// ComputeTapTweak previously reused the same Span<byte> for
+			// WriteToSpan serialization and GetHash output, which caused
+			// AddTweak to return an all-zero key on ARM64.
+			// BIP341 test vector: internal key with no script tree (key-path only).
+			var hex = Encoders.Hex;
+			var internalKey = TaprootInternalPubKey.Parse(
+				"d6889cb081036e0faefa3a35157ad71086b123b2b144b649798b494c300a961d");
+			var fullPubKey = internalKey.GetTaprootFullPubKey();
+
+			var outputBytes = new byte[32];
+			fullPubKey.OutputKey.pubkey.WriteToSpan(outputBytes);
+
+			// Output key must not be all zeros
+			Assert.False(Array.TrueForAll(outputBytes, b => b == 0),
+				"TaprootFullPubKey output key is all zeros — ComputeTapTweak span aliasing bug");
+
+			// Expected output key for this internal key with null merkle root (BIP341)
+			Assert.Equal(
+				"53a1f6e454df1aa2776a2814a721372d6258050de330b3c6d10ee8f4e0dda343",
+				hex.EncodeData(outputBytes));
+		}
 #endif
 	}
 }

--- a/NBitcoin/TaprootFullPubKey.cs
+++ b/NBitcoin/TaprootFullPubKey.cs
@@ -33,14 +33,19 @@ namespace NBitcoin
 
 		internal static void ComputeTapTweak(TaprootInternalPubKey internalKey, uint256? merkleRoot, Span<byte> tweak32)
 		{
+			// Use a separate buffer for serialization to avoid reusing tweak32
+			// as both scratch space and output. Reusing the same Span<byte> for
+			// WriteToSpan/ToBytes input and GetHash output triggers a .NET 10
+			// ARM64 JIT miscompilation due to span aliasing.
+			Span<byte> buf = stackalloc byte[32];
 			using Secp256k1.SHA256 sha = new Secp256k1.SHA256();
 			sha.InitializeTagged("TapTweak");
-			internalKey.pubkey.WriteToSpan(tweak32);
-			sha.Write(tweak32);
+			internalKey.pubkey.WriteToSpan(buf);
+			sha.Write(buf);
 			if (merkleRoot is uint256)
 			{
-				merkleRoot.ToBytes(tweak32);
-				sha.Write(tweak32);
+				merkleRoot.ToBytes(buf);
+				sha.Write(buf);
 			}
 			sha.GetHash(tweak32);
 		}


### PR DESCRIPTION
## Summary

`TaprootFullPubKey.ComputeTapTweak` reuses the same `Span<byte> tweak32` for:
1. `WriteToSpan` (serializing the internal pubkey)
2. `SHA256.Write` (feeding the hash)
3. `merkleRoot.ToBytes` (serializing the merkle root)
4. `SHA256.GetHash` (writing the hash output)

On .NET 10 ARM64 (Android), the JIT miscompiles this span aliasing pattern. The result is that `AddTweak` receives a corrupted tweak value and returns an all-zero `ECXOnlyPubKey`, producing invalid P2TR output scripts.

## Root Cause

The .NET 10 ARM64 JIT appears to optimize away or reorder memory operations when the same `Span<byte>` is used as both input and output across multiple method calls within the same scope. This is a JIT codegen bug — the C# code is semantically correct (each use of `tweak32` is sequential and non-overlapping), but the generated native code does not preserve the correct memory ordering.

## Fix

Use a separate `stackalloc byte[32]` buffer (`buf`) for the serialization writes (`WriteToSpan`, `ToBytes`), keeping `tweak32` exclusively for the final `GetHash` output. This eliminates the aliasing pattern that triggers the JIT bug.

## Impact

- **Affected**: Any .NET 10 ARM64 consumer calling `GetTaprootFullPubKey()` or `TaprootFullPubKey.Create()` — produces all-zero output keys, leading to funds sent to unspendable addresses
- **Not affected**: x64, .NET 8/9, or any platform where the JIT correctly handles the aliasing

## Testing

- Added regression test `ComputeTapTweak_DoesNotProduceAllZeroOutputKey` using BIP341 test vector
- All 6 existing taproot tests continue to pass
- Verified fix produces correct output on ARM64 Android device

## Related

- Discovered while upgrading [Angor](https://github.com/block-core/angor) to .NET 10 + Avalonia 12 for Android
- Transaction with bug: `160f198ba0f7dacbc097d6a61703b3121af38b7362d17b063cd9152f74012598` (signet, funds sent to all-zero P2TR)
