### PR TITLE
Node: Add `VersionHandshakeAsync`

### DIFF
--- a/NBitcoin.Tests/ProtocolTests.cs
+++ b/NBitcoin.Tests/ProtocolTests.cs
@@ -326,7 +326,7 @@ namespace NBitcoin.Tests
 					Eventually(() =>
 					{
 						Assert.NotEmpty(group.ConnectedNodes);
-						Assert.All(group.ConnectedNodes, connectedNode => 
+						Assert.All(group.ConnectedNodes, connectedNode =>
 							Assert.True(connectedNode.RemoteSocketEndpoint.IsEqualTo(node.NodeEndpoint)));
 					});
 				}
@@ -955,12 +955,10 @@ namespace NBitcoin.Tests
 			using (var tester = new NodeServerTester())
 			{
 				tester.Server2.Nonce = tester.Server1.Nonce;
-				var ex =  Assert.ThrowsAny<Exception>(() =>
+				Assert.Throws<InvalidOperationException>(() =>
 				{
 					tester.Node1.VersionHandshake();
 				});
-
-				Assert.True((ex is InvalidOperationException) || (ex is OperationCanceledException));
 			}
 		}
 

--- a/NBitcoin.Tests/ProtocolTests.cs
+++ b/NBitcoin.Tests/ProtocolTests.cs
@@ -955,7 +955,7 @@ namespace NBitcoin.Tests
 			using (var tester = new NodeServerTester())
 			{
 				tester.Server2.Nonce = tester.Server1.Nonce;
-				Assert.Throws<InvalidOperationException>(() =>
+				Assert.Throws<OperationCanceledException>(() =>
 				{
 					tester.Node1.VersionHandshake();
 				});

--- a/NBitcoin.Tests/ProtocolTests.cs
+++ b/NBitcoin.Tests/ProtocolTests.cs
@@ -955,10 +955,12 @@ namespace NBitcoin.Tests
 			using (var tester = new NodeServerTester())
 			{
 				tester.Server2.Nonce = tester.Server1.Nonce;
-				Assert.Throws<OperationCanceledException>(() =>
+				var ex =  Assert.ThrowsAny<Exception>(() =>
 				{
 					tester.Node1.VersionHandshake();
 				});
+
+				Assert.True((ex is InvalidOperationException) || (ex is OperationCanceledException));
 			}
 		}
 

--- a/NBitcoin.Tests/RPCClientTests.cs
+++ b/NBitcoin.Tests/RPCClientTests.cs
@@ -906,10 +906,10 @@ namespace NBitcoin.Tests
 				requests.Add(rpc.GetBlockHashAsync(8));
 				rpc.SendBatch();
 				rpc = rpc.PrepareBatch();
-				Assert.Equal(TaskStatus.RanToCompletion, requests[0].Status);
-				Assert.Equal(TaskStatus.Faulted, requests[1].Status);
-				Assert.Equal(TaskStatus.RanToCompletion, requests[2].Status);
-				Assert.Equal(TaskStatus.RanToCompletion, requests[3].Status);
+				await requests[0];
+				await Assert.ThrowsAsync<RPCException>(async () => await requests[1]);
+				await requests[2];
+				await requests[3];
 				requests.Clear();
 
 				requests.Add(rpc.GetBlockHashAsync(10));

--- a/NBitcoin/NBitcoin.csproj
+++ b/NBitcoin/NBitcoin.csproj
@@ -31,7 +31,7 @@
 		<DocumentationFile>bin\Release\NBitcoin.XML</DocumentationFile>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'net472' ">
-		<DefineConstants>$(DefineConstants);CLASSICDOTNET;NO_ARRAY_FILL;NULLABLE_SHIMS;NO_SOCKETASYNC;NO_RECORDS</DefineConstants>
+		<DefineConstants>$(DefineConstants);CLASSICDOTNET;NO_ARRAY_FILL;NULLABLE_SHIMS;NO_SOCKETASYNC;NO_RECORDS;NO_CHANNELS</DefineConstants>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'netstandard2.0'  Or '$(TargetFramework)' == 'net8.0'">
 		<DefineConstants>$(DefineConstants);NOCUSTOMSSLVALIDATION;NO_NATIVERIPEMD160</DefineConstants>
@@ -41,10 +41,10 @@
     <RemoveBC>true</RemoveBC>
 	</PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
-	<DefineConstants>$(DefineConstants);NO_SOCKETASYNC;NO_RECORDS</DefineConstants>
+	<DefineConstants>$(DefineConstants);NO_SOCKETASYNC;NO_RECORDS;NO_CHANNELS</DefineConstants>
   </PropertyGroup>
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-		<DefineConstants>$(DefineConstants);NETSTANDARD;NO_ARRAY_FILL;NULLABLE_SHIMS;NO_NATIVE_RFC2898_HMACSHA512;NO_NATIVERIPEMD160;NO_SOCKETASYNC;NO_RECORDS</DefineConstants>
+		<DefineConstants>$(DefineConstants);NETSTANDARD;NO_ARRAY_FILL;NULLABLE_SHIMS;NO_NATIVE_RFC2898_HMACSHA512;NO_NATIVERIPEMD160;NO_SOCKETASYNC;NO_RECORDS;NO_CHANNELS</DefineConstants>
 	</PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
 		<DefineConstants>$(DefineConstants);SECP256K1_VERIFY</DefineConstants>

--- a/NBitcoin/Protocol/MessageListener.cs
+++ b/NBitcoin/Protocol/MessageListener.cs
@@ -1,10 +1,10 @@
 ﻿#if !NOSOCKET
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
+#if !NO_CHANNELS
+using System.Threading.Channels;
+#endif
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin.Logging;
@@ -119,11 +119,12 @@ namespace NBitcoin.Protocol
 		#endregion
 
 	}
-
+#if NO_CHANNELS
 	public class PollMessageListener<T> : MessageListener<T>
 	{
 
 		BlockingCollection<T> _MessageQueue = new BlockingCollection<T>(new ConcurrentQueue<T>());
+		public int Count => _MessageQueue.Count;
 		public BlockingCollection<T> MessageQueue
 		{
 			get
@@ -146,5 +147,39 @@ namespace NBitcoin.Protocol
 
 		#endregion
 	}
+#else
+	public class PollMessageListener<T> : MessageListener<T>
+	{
+
+		Channel<T> _MessageQueue = Channel.CreateUnbounded<T>();
+		public int Count => _MessageQueue.Reader.Count;
+		public Channel<T> MessageQueue
+		{
+			get
+			{
+				return _MessageQueue;
+			}
+		}
+
+		public T ReceiveMessage(CancellationToken cancellationToken = default(CancellationToken))
+		{
+			return ReceiveMessageAsync(cancellationToken).GetAwaiter().GetResult();
+		}
+
+		public virtual async Task<T> ReceiveMessageAsync(CancellationToken cancellationToken = default(CancellationToken))
+		{
+			return await _MessageQueue.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+		}
+
+		#region MessageListener Members
+
+		public virtual void PushMessage(T message)
+		{
+			_MessageQueue.Writer.TryWrite(message);
+		}
+
+		#endregion
+	}
+#endif
 }
 #endif

--- a/NBitcoin/Protocol/Node.cs
+++ b/NBitcoin/Protocol/Node.cs
@@ -589,7 +589,7 @@ namespace NBitcoin.Protocol
 				int socksFail = 0;
 				while (true)
 				{
-					
+
 					if (groupFail > 50 || socksFail > 50)
 					{
 						parameters.ConnectCancellation.WaitHandle.WaitOne((int)TimeSpan.FromSeconds(60).TotalMilliseconds);
@@ -930,7 +930,7 @@ namespace NBitcoin.Protocol
 		/// Send a message to the peer asynchronously
 		/// </summary>
 		/// <param name="payload">The payload to send</param>
-		/// <param name="System.OperationCanceledException">The node has been disconnected</param>
+		/// <param name="System.InvalidOperationException">The node has been disconnected</param>
 		public Task SendMessageAsync(Payload payload)
 		{
 			if (payload is null)
@@ -943,7 +943,7 @@ namespace NBitcoin.Protocol
 #endif
 			if (!IsConnected)
 			{
-				completion.SetException(new OperationCanceledException("The peer has been disconnected"));
+				completion.SetException(new InvalidOperationException("The peer has been disconnected"));
 				return completion.Task;
 			}
 
@@ -1140,7 +1140,7 @@ namespace NBitcoin.Protocol
 #nullable disable
 
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// <param name="cancellation"></param>
 		public void RespondToHandShake(CancellationToken cancellation = default(CancellationToken))

--- a/NBitcoin/Protocol/Node.cs
+++ b/NBitcoin/Protocol/Node.cs
@@ -1092,6 +1092,10 @@ namespace NBitcoin.Protocol
 		{
 			VersionHandshakeAsync(requirements, cancellationToken).GetAwaiter().GetResult();
 		}
+		public Task VersionHandshakeAsync(CancellationToken cancellationToken = default(CancellationToken))
+		{
+			return VersionHandshakeAsync(null, cancellationToken);
+		}
 
 #nullable enable
 		public async Task VersionHandshakeAsync(NodeRequirement? requirements, CancellationToken cancellationToken = default(CancellationToken))
@@ -1106,7 +1110,7 @@ namespace NBitcoin.Protocol
 
 				await SendMessageAsync(MyVersion).ConfigureAwait(false);
 				#if !NO_CHANNELS
-				var version = await listener.ReceivePayloadAsync<VersionPayload>(cancellationToken);
+				var version = await listener.ReceivePayloadAsync<VersionPayload>(cancellationToken).ConfigureAwait(false);
 				#else
 				var version = listener.ReceivePayload<VersionPayload>(cancellationToken);
 				#endif
@@ -1141,7 +1145,7 @@ namespace NBitcoin.Protocol
 				await SendMessageAsync(new VerAckPayload()).ConfigureAwait(false);
 
 				#if !NO_CHANNELS
-				await listener.ReceivePayloadAsync<VerAckPayload>(cancellationToken);
+				await listener.ReceivePayloadAsync<VerAckPayload>(cancellationToken).ConfigureAwait(false);
 				#else
 				listener.ReceivePayload<VerAckPayload>(cancellationToken);
 				#endif

--- a/NBitcoin/Protocol/Node.cs
+++ b/NBitcoin/Protocol/Node.cs
@@ -1023,16 +1023,31 @@ namespace NBitcoin.Protocol
 				return _MessageProducer;
 			}
 		}
-
+#if !NO_CHANNELS
+		public TPayload ReceiveMessage<TPayload>(TimeSpan timeout) where TPayload : Payload
+		{
+			var source = new CancellationTokenSource();
+			source.CancelAfter(timeout);
+			return ReceiveMessageAsync<TPayload>(source.Token).GetAwaiter().GetResult();
+		}
+		public TPayload ReceiveMessage<TPayload>(CancellationToken cancellationToken = default(CancellationToken)) where TPayload : Payload
+		{
+			return ReceiveMessageAsync<TPayload>(cancellationToken).GetAwaiter().GetResult();
+		}
+		public async Task<TPayload> ReceiveMessageAsync<TPayload>(CancellationToken cancellationToken = default(CancellationToken)) where TPayload : Payload
+		{
+			using (var listener = new NodeListener(this))
+			{
+				return await listener.ReceivePayloadAsync<TPayload>(cancellationToken).ConfigureAwait(false);
+			}
+		}
+#else
 		public TPayload ReceiveMessage<TPayload>(TimeSpan timeout) where TPayload : Payload
 		{
 			var source = new CancellationTokenSource();
 			source.CancelAfter(timeout);
 			return ReceiveMessage<TPayload>(source.Token);
 		}
-
-
-
 		public TPayload ReceiveMessage<TPayload>(CancellationToken cancellationToken = default(CancellationToken)) where TPayload : Payload
 		{
 			using (var listener = new NodeListener(this))
@@ -1040,7 +1055,7 @@ namespace NBitcoin.Protocol
 				return listener.ReceivePayload<TPayload>(cancellationToken);
 			}
 		}
-
+#endif
 		/// <summary>
 		/// Send addr unsolicited message of the AddressFrom peer when passing to Handshaked state
 		/// </summary>
@@ -1090,7 +1105,11 @@ namespace NBitcoin.Protocol
 			{
 
 				await SendMessageAsync(MyVersion).ConfigureAwait(false);
+				#if !NO_CHANNELS
+				var version = await listener.ReceivePayloadAsync<VersionPayload>(cancellationToken);
+				#else
 				var version = listener.ReceivePayload<VersionPayload>(cancellationToken);
+				#endif
 				_PeerVersion = version;
 				SetVersion(Math.Min(MyVersion.Version, version.Version));
 
@@ -1121,7 +1140,11 @@ namespace NBitcoin.Protocol
 
 				await SendMessageAsync(new VerAckPayload()).ConfigureAwait(false);
 
+				#if !NO_CHANNELS
+				await listener.ReceivePayloadAsync<VerAckPayload>(cancellationToken);
+				#else
 				listener.ReceivePayload<VerAckPayload>(cancellationToken);
+				#endif
 
 				State = NodeState.HandShaked;
 
@@ -1591,7 +1614,7 @@ namespace NBitcoin.Protocol
 					while (remaining.Count != 0)
 					{
 						var block = listener.ReceivePayload<BlockPayload>(cancellationToken).Object;
-						maxQueued = Math.Max(listener.MessageQueue.Count, maxQueued);
+						maxQueued = Math.Max(listener.Count, maxQueued);
 						if (remaining.Peek() == block.GetHash())
 						{
 							remaining.Dequeue();

--- a/NBitcoin/Protocol/Node.cs
+++ b/NBitcoin/Protocol/Node.cs
@@ -1068,10 +1068,13 @@ namespace NBitcoin.Protocol
 			}
 		}
 
+		[Obsolete("Use VersionHandshakeAsync instead")]
 		public void VersionHandshake(CancellationToken cancellationToken = default(CancellationToken))
 		{
 			VersionHandshake(null, cancellationToken);
 		}
+
+		[Obsolete("Use VersionHandshakeAsync instead")]
 		public void VersionHandshake(NodeRequirement requirements, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			if (State == NodeState.HandShaked)
@@ -1131,7 +1134,66 @@ namespace NBitcoin.Protocol
 			}
 		}
 
+#nullable enable
+		public async Task VersionHandshakeAsync(NodeRequirement? requirements, CancellationToken cancellationToken = default(CancellationToken))
+		{
+			if (State == NodeState.HandShaked)
+				throw new InvalidOperationException("Already handshaked");
+			requirements = requirements ?? new NodeRequirement();
+			using (var listener = CreateListener()
+									.Where(p => p.Message.Payload is VersionPayload ||
+												p.Message.Payload is VerAckPayload))
+			{
 
+				await SendMessageAsync(MyVersion).ConfigureAwait(false);
+				var version = listener.ReceivePayload<VersionPayload>(cancellationToken);
+				_PeerVersion = version;
+				SetVersion(Math.Min(MyVersion.Version, version.Version));
+
+				var receiverAddress = version.AddressReceiver.GetStringAddress();
+				var addressFrom = MyVersion.AddressFrom.GetStringAddress();
+				if (receiverAddress != addressFrom)
+					Logs.NodeServer.LogWarning($"Different external address detected by the node {receiverAddress} instead of {addressFrom}");
+
+				if (ProtocolCapabilities.PeerTooOld)
+				{
+					Logs.NodeServer.LogWarning("Outdated version {version} disconnecting", version.Version);
+					Disconnect("Outdated version");
+					return;
+				}
+
+				if (!requirements.Check(version, ProtocolCapabilities))
+				{
+					Disconnect("The peer does not support the required services requirement");
+					return;
+				}
+
+				// As a courtesy we do not send sendaddr to nodes that do not support it.
+				if (ProtocolCapabilities.SupportAddrv2)
+				{
+					// Signal ADDRv2 support (BIP155).
+					await SendMessageAsync(new SendAddrV2Payload()).ConfigureAwait(false);
+				}
+
+				await SendMessageAsync(new VerAckPayload()).ConfigureAwait(false);
+
+				listener.ReceivePayload<VerAckPayload>(cancellationToken);
+
+				State = NodeState.HandShaked;
+
+				if (Advertize)
+				{
+					if (MyVersion.AddressFrom is IPEndPoint iPEndPoint && !iPEndPoint.Address.IsRoutable(true))
+						return;
+
+					await SendMessageAsync(new AddrPayload(new NetworkAddress(MyVersion.AddressFrom)
+					{
+						Time = DateTimeOffset.UtcNow
+					})).ConfigureAwait(false);
+				}
+			}
+		}
+#nullable disable
 
 		/// <summary>
 		/// 

--- a/NBitcoin/Protocol/Node.cs
+++ b/NBitcoin/Protocol/Node.cs
@@ -1068,70 +1068,14 @@ namespace NBitcoin.Protocol
 			}
 		}
 
-		[Obsolete("Use VersionHandshakeAsync instead")]
 		public void VersionHandshake(CancellationToken cancellationToken = default(CancellationToken))
 		{
 			VersionHandshake(null, cancellationToken);
 		}
 
-		[Obsolete("Use VersionHandshakeAsync instead")]
 		public void VersionHandshake(NodeRequirement requirements, CancellationToken cancellationToken = default(CancellationToken))
 		{
-			if (State == NodeState.HandShaked)
-				throw new InvalidOperationException("Already handshaked");
-			requirements = requirements ?? new NodeRequirement();
-			using (var listener = CreateListener()
-									.Where(p => p.Message.Payload is VersionPayload ||
-												p.Message.Payload is VerAckPayload))
-			{
-
-				SendMessageAsync(MyVersion);
-				var version = listener.ReceivePayload<VersionPayload>(cancellationToken);
-				_PeerVersion = version;
-				SetVersion(Math.Min(MyVersion.Version, version.Version));
-
-				var receiverAddress = version.AddressReceiver.GetStringAddress();
-				var addressFrom = MyVersion.AddressFrom.GetStringAddress();
-				if (receiverAddress != addressFrom)
-					Logs.NodeServer.LogWarning($"Different external address detected by the node {receiverAddress} instead of {addressFrom}");
-
-				if (ProtocolCapabilities.PeerTooOld)
-				{
-					Logs.NodeServer.LogWarning("Outdated version {version} disconnecting", version.Version);
-					Disconnect("Outdated version");
-					return;
-				}
-
-				if (!requirements.Check(version, ProtocolCapabilities))
-				{
-					Disconnect("The peer does not support the required services requirement");
-					return;
-				}
-
-				// As a cortesy we do not send sendaddr to nodes that do not support it.
-				if (ProtocolCapabilities.SupportAddrv2)
-				{
-					// Signal ADDRv2 support (BIP155).
-					SendMessageAsync(new SendAddrV2Payload());
-				}
-
-				SendMessageAsync(new VerAckPayload());
-
-				listener.ReceivePayload<VerAckPayload>(cancellationToken);
-
-				State = NodeState.HandShaked;
-
-				if (Advertize)
-				{
-					if (MyVersion.AddressFrom is IPEndPoint iPEndPoint && !iPEndPoint.Address.IsRoutable(true))
-						return;
-
-					SendMessageAsync(new AddrPayload(new NetworkAddress(MyVersion.AddressFrom)
-					{
-						Time = DateTimeOffset.UtcNow
-					}));
-				}
-			}
+			VersionHandshakeAsync(requirements, cancellationToken).GetAwaiter().GetResult();
 		}
 
 #nullable enable

--- a/NBitcoin/Protocol/NodeListener.cs
+++ b/NBitcoin/Protocol/NodeListener.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -35,7 +34,48 @@ namespace NBitcoin.Protocol
 			_Predicates.Add(i => i.Message.Payload is TPayload);
 			return this;
 		}
+#if !NO_CHANNELS
+		public TPayload ReceivePayload<TPayload>(CancellationToken cancellationToken = default(CancellationToken)) where TPayload : Payload
+		=> ReceivePayloadAsync<TPayload>(cancellationToken).GetAwaiter().GetResult();
+		public async Task<TPayload> ReceivePayloadAsync<TPayload>(CancellationToken cancellationToken = default(CancellationToken))
+			where TPayload : Payload
+		{
+			if (!Node.IsConnected)
+				throw new InvalidOperationException("The node is not in a connected state");
+			Queue<IncomingMessage> pushedAside = new Queue<IncomingMessage>();
+			try
+			{
+				using (var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, Node._Connection.Cancel.Token))
+				{
+					while (true)
+					{
+						var message = await ReceiveMessageAsync(cts.Token).ConfigureAwait(false);
+						if (_Predicates.All(p => p(message)))
+						{
+							if (message.Message.Payload is TPayload)
+								return (TPayload)message.Message.Payload;
+							else
+							{
+								pushedAside.Enqueue(message);
+							}
 
+						}
+					}
+				}
+			}
+			catch (OperationCanceledException)
+			{
+				if (Node._Connection.Cancel.IsCancellationRequested)
+					throw new InvalidOperationException("The node is not in a connected state");
+				throw;
+			}
+			finally
+			{
+				while (pushedAside.Count != 0)
+					PushMessage(pushedAside.Dequeue());
+			}
+		}
+#else
 		public TPayload ReceivePayload<TPayload>(CancellationToken cancellationToken = default(CancellationToken))
 			where TPayload : Payload
 		{
@@ -74,7 +114,7 @@ namespace NBitcoin.Protocol
 					PushMessage(pushedAside.Dequeue());
 			}
 		}
-
+#endif
 		List<Func<IncomingMessage, bool>> _Predicates = new List<Func<IncomingMessage, bool>>();
 
 		#region IDisposable Members


### PR DESCRIPTION
`Node.VersionHandshake` currently generates unobserved exceptions:

```
2026-06-04 15:54:06.585 [ 1] TRC | Program.cs:138                 | System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (The I/O operation has been aborted because of either a thread exit or an application request.)
 ---> System.Net.Sockets.SocketException (995): The I/O operation has been aborted because of either a thread exit or an application request.
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Int32>.GetResult(Int16 token)
   at System.Threading.Tasks.ValueTask`1.ValueTaskSourceAsTask.<>c.<.cctor>b__4_0(Object state)
   --- End of inner exception stack trace ---
```

The reason for it is because there are calls like this: 

https://github.com/MetacoSA/NBitcoin/blob/399e7b221ef4f41a44d81256ebb2d81f74942027/NBitcoin/Protocol/Node.cs#L1085

which is not awaited.

This PR is the least intrusive way to fix it by copying code of `Node.VersionHandshake` and making `Node.VersionHandshake` obsolete. 

I hope that this will positively impact: https://github.com/WalletWasabi/WalletWasabi/pull/14651 where I could just close the PR.

@NicolasDorier if this PR makes sense to you, I could try to fix tests to use the new method.