### PR TITLE
Enforce CompactSize canonical representation

### DIFF
--- a/NBitcoin.Tests/script_tests.cs
+++ b/NBitcoin.Tests/script_tests.cs
@@ -1105,17 +1105,15 @@ namespace NBitcoin.Tests
 			}
 
 			// Test on non canonic values
-			testCases = new (byte[] Bytes, ulong Value)[]
+			var nonCanonicalTestCases = new byte[][]
 			{
-				(Bytes: new byte[] { 0xFD, 0x01, 0x00 }, Value: 0x01),
-				(Bytes: new byte[] { 0xFE, 0x01, 0x00, 0x00, 0x00 }, Value: 0x01),
-				(Bytes: new byte[] { 0xFF, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, Value: 0x01)
+				new byte[] { 0xFD, 0x01, 0x00 },
+				new byte[] { 0xFE, 0x01, 0x00, 0x00, 0x00 },
+				new byte[] { 0xFF, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 },
 			};
-			foreach (var testCase in testCases)
-			{
-				var stream = new BitcoinStream(testCase.Bytes);
-				Assert.Equal(testCase.Value, VarInt.StaticRead(stream));
-			}
+			Assert.All(nonCanonicalTestCases,
+				testCase => Assert.Throws<InvalidDataException>(
+					()=> VarInt.StaticRead(new BitcoinStream(testCase))));
 		}
 
 		[Fact]

--- a/NBitcoin/Protocol/VarInt.cs
+++ b/NBitcoin/Protocol/VarInt.cs
@@ -141,18 +141,24 @@ namespace NBitcoin.Protocol
 			{
 				var value = (ushort)0;
 				bs.ReadWrite(ref value);
+				if (value < 0xFD)
+					throw new InvalidDataException("non-canonical representation for varint");
 				return value;
 			}
 			else if (prefix == 0xFE)
 			{
 				var value = (uint)0;
 				bs.ReadWrite(ref value);
+				if (value < 0x10000)
+					throw new InvalidDataException("non-canonical representation for varint");
 				return value;
 			}
 			else
 			{
 				var value = (ulong)0;
 				bs.ReadWrite(ref value);
+				if (value < 0x100000000)
+					throw new InvalidDataException("non-canonical representation for varint");
 				return value;
 			}
 		}


### PR DESCRIPTION
This PR enforces CompactSize (VarInt) canonical decoding to prevent array size manipulation. I think the non-canonical representation enables manipulations like the one reported in #1303 and makes no sense or at least it has no utility other than to contradict the purpose of VarInt.

If this is not okay, I can implement a more local fix.

Close https://github.com/MetacoSA/NBitcoin/issues/1303