### PR TITLE
Modernize `Stream.ReadEx` 

### DIFF
--- a/NBitcoin/Utils.cs
+++ b/NBitcoin/Utils.cs
@@ -315,24 +315,15 @@ namespace NBitcoin
 			if (offset > buffer.Length - count)
 				throw new ArgumentOutOfRangeException("count");
 
-#if NET8_0_OR_GREATER
-			try
-			{
-				stream.ReadExactlyAsync(buffer, offset, count, cancellation).GetAwaiter().GetResult();
-				return count;
-			}
-			catch (EndOfStreamException)
-			{
-				return 0;
-			}
-#else
 			int totalReadCount = 0;
 
 			while (totalReadCount < count)
 			{
-				cancellation.ThrowIfCancellationRequested();
-
+#if NET8_0_OR_GREATER
+				int currentReadCount = stream.ReadAsync(buffer, offset + totalReadCount, count - totalReadCount, cancellation).GetAwaiter().GetResult();
+#else
 				int currentReadCount;
+				cancellation.ThrowIfCancellationRequested();
 
 				//Big performance problem with BeginRead for other stream types than NetworkStream.
 				//Only take the slow path if cancellation is possible.
@@ -356,6 +347,7 @@ namespace NBitcoin
 					//IO interruption not supported in this path.
 					currentReadCount = stream.Read(buffer, offset + totalReadCount, count - totalReadCount);
 				}
+#endif
 
 				if (currentReadCount == 0)
 					return 0;
@@ -364,7 +356,6 @@ namespace NBitcoin
 			}
 
 			return totalReadCount;
-#endif
 		}
 
 #if HAS_SPAN

--- a/NBitcoin/Utils.cs
+++ b/NBitcoin/Utils.cs
@@ -319,35 +319,7 @@ namespace NBitcoin
 
 			while (totalReadCount < count)
 			{
-#if NET8_0_OR_GREATER
 				int currentReadCount = stream.ReadAsync(buffer, offset + totalReadCount, count - totalReadCount, cancellation).GetAwaiter().GetResult();
-#else
-				int currentReadCount;
-				cancellation.ThrowIfCancellationRequested();
-
-				//Big performance problem with BeginRead for other stream types than NetworkStream.
-				//Only take the slow path if cancellation is possible.
-				if (stream is NetworkStream && cancellation.CanBeCanceled)
-				{
-					var ar = stream.BeginRead(buffer, offset + totalReadCount, count - totalReadCount, null, null);
-					if (!ar.CompletedSynchronously)
-					{
-						WaitHandle.WaitAny(new WaitHandle[] { ar.AsyncWaitHandle, cancellation.WaitHandle }, -1);
-					}
-
-					//EndRead might block, so we need to test cancellation before calling it.
-					//This also is a bug because calling EndRead after BeginRead is contractually required.
-					//A potential fix is to use the ReadAsync API. Another fix is to register a callback with BeginRead that calls EndRead in all cases.
-					cancellation.ThrowIfCancellationRequested();
-
-					currentReadCount = stream.EndRead(ar);
-				}
-				else
-				{
-					//IO interruption not supported in this path.
-					currentReadCount = stream.Read(buffer, offset + totalReadCount, count - totalReadCount);
-				}
-#endif
 
 				if (currentReadCount == 0)
 					return 0;

--- a/NBitcoin/Utils.cs
+++ b/NBitcoin/Utils.cs
@@ -302,7 +302,6 @@ namespace NBitcoin
 			}
 		}
 
-#if !NETSTANDARD1X
 		public static int ReadEx(this Stream stream, byte[] buffer, int offset, int count, CancellationToken cancellation = default(CancellationToken))
 		{
 			if (stream == null)
@@ -316,6 +315,17 @@ namespace NBitcoin
 			if (offset > buffer.Length - count)
 				throw new ArgumentOutOfRangeException("count");
 
+#if NET8_0_OR_GREATER
+			try
+			{
+				stream.ReadExactlyAsync(buffer, offset, count, cancellation).GetAwaiter().GetResult();
+				return count;
+			}
+			catch (EndOfStreamException)
+			{
+				return 0;
+			}
+#else
 			int totalReadCount = 0;
 
 			while (totalReadCount < count)
@@ -354,45 +364,8 @@ namespace NBitcoin
 			}
 
 			return totalReadCount;
+#endif
 		}
-#else
-
-		public static int ReadEx(this Stream stream, byte[] buffer, int offset, int count, CancellationToken cancellation = default(CancellationToken))
-		{
-			if(stream == null) throw new ArgumentNullException(nameof(stream));
-			if(buffer == null) throw new ArgumentNullException(nameof(buffer));
-			if(offset < 0 || offset > buffer.Length) throw new ArgumentOutOfRangeException("offset");
-			if(count <= 0 || count > buffer.Length) throw new ArgumentOutOfRangeException("count"); //Disallow 0 as a debugging aid.
-			if(offset > buffer.Length - count) throw new ArgumentOutOfRangeException("count");
-
-			//IO interruption not supported on these platforms.
-
-			int totalReadCount = 0;
-#if !NOSOCKET
-			var interruptable = stream is NetworkStream && cancellation.CanBeCanceled;
-#endif
-			while(totalReadCount < count)
-			{
-				cancellation.ThrowIfCancellationRequested();
-				int currentReadCount = 0;
-#if !NOSOCKET
-				if(interruptable)
-				{
-					currentReadCount = stream.ReadAsync(buffer, offset + totalReadCount, count - totalReadCount, cancellation).GetAwaiter().GetResult();
-				}
-				else
-#endif
-				{
-					currentReadCount = stream.Read(buffer, offset + totalReadCount, count - totalReadCount);
-				}
-				if(currentReadCount == 0)
-					return 0;
-				totalReadCount += currentReadCount;
-			}
-
-			return totalReadCount;
-		}
-#endif
 
 #if HAS_SPAN
 		public static int ReadEx(this Stream stream, Span<byte> buffer, CancellationToken cancellation = default(CancellationToken))


### PR DESCRIPTION
On Wasabi side, I can still see some unobserved exception. I suspect that `Stream.ReadEx` might be another potential source of unobserved exceptions so I tried to modernize it.