### PR TITLE
Remove use of `NO_RCA`

### DIFF
--- a/NBitcoin/Protocol/Behaviors/BroadcastTransactionBehavior.cs
+++ b/NBitcoin/Protocol/Behaviors/BroadcastTransactionBehavior.cs
@@ -98,11 +98,8 @@ namespace NBitcoin.Protocol.Behaviors
 		{
 			if (transaction == null)
 				throw new ArgumentNullException(nameof(transaction));
-#if NO_RCA
-			TaskCompletionSource<bool> completion = new TaskCompletionSource<bool>();
-#else
-			TaskCompletionSource<bool> completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-#endif
+
+			var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 			var hash = transaction.GetHash();
 			if (BroadcastedTransaction.TryAdd(hash, transaction))
 			{

--- a/NBitcoin/Protocol/Connectors/SocketExtensions.cs
+++ b/NBitcoin/Protocol/Connectors/SocketExtensions.cs
@@ -35,11 +35,7 @@ namespace NBitcoin.Protocol.Connectors
 #else
 		public static async Task ConnectAsync(this Socket socket, EndPoint remoteEP, CancellationToken cancellationToken)
 		{
-#if NO_RCA
-			TaskCompletionSource<bool> completion = new TaskCompletionSource<bool>();
-#else
-			TaskCompletionSource<bool> completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-#endif
+			var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 			var args = new SocketAsyncEventArgs();
 			using (cancellationToken.Register(() =>
 			{

--- a/NBitcoin/Protocol/Node.cs
+++ b/NBitcoin/Protocol/Node.cs
@@ -936,11 +936,8 @@ namespace NBitcoin.Protocol
 			if (payload is null)
 				throw new ArgumentNullException(nameof(payload));
 
-#if NO_RCA
-			TaskCompletionSource<bool> completion = new TaskCompletionSource<bool>();
-#else
-			TaskCompletionSource<bool> completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-#endif
+			var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
 			if (!IsConnected)
 			{
 				completion.SetException(new InvalidOperationException("The peer has been disconnected"));

--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -1019,11 +1019,7 @@ namespace NBitcoin.RPC
 			var batches = _BatchedRequests;
 			if (batches != null)
 			{
-#if NO_RCA
-				TaskCompletionSource<RPCResponse> source = new TaskCompletionSource<RPCResponse>();
-#else
-				TaskCompletionSource<RPCResponse> source = new TaskCompletionSource<RPCResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
-#endif
+				var source = new TaskCompletionSource<RPCResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
 				batches.Enqueue(Tuple.Create(request, source));
 				response = await source.Task.ConfigureAwait(false);
 				if (request.ThrowIfRPCError)


### PR DESCRIPTION
`NO_RCA` is no longer necessary because it is supported [starting](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.taskcreationoptions) with .NET Framework 4.6 and NBitcoin supports .NET Framework 4.7.2+.

See also https://github.com/MetacoSA/NBitcoin/pull/1243 (commit https://github.com/MetacoSA/NBitcoin/commit/4780a7f38189444e9961fa952a0ecea29721c90b)