### PR TITLE
feat(secp): make keys IEqutable

### DIFF
--- a/NBitcoin/Secp256k1/ECPrivKey.cs
+++ b/NBitcoin/Secp256k1/ECPrivKey.cs
@@ -116,7 +116,7 @@ namespace NBitcoin.Secp256k1
 #if SECP256K1_LIB
 	public
 #endif
-	partial class ECPrivKey : IDisposable
+	partial class ECPrivKey : IDisposable, IEquatable<ECPrivKey>
 	{
 		internal bool cleared = false;
 #if SECP256K1_LIB
@@ -811,6 +811,15 @@ namespace NBitcoin.Secp256k1
 			return true;
 		}
 
+		public bool Equals(ECPrivKey? other)
+		{
+			if (other is ECPrivKey item)
+			{
+				return this == item;
+			}
+			return false;
+		}
+
 		public override bool Equals(object? obj)
 		{
 			if (obj is ECPrivKey item)
@@ -894,7 +903,7 @@ namespace NBitcoin.Secp256k1
 		{
 			if (this.cleared)
 				return;
-				
+
 			Clear();
 		}
 

--- a/NBitcoin/Secp256k1/ECPubKey.cs
+++ b/NBitcoin/Secp256k1/ECPubKey.cs
@@ -12,7 +12,7 @@ namespace NBitcoin.Secp256k1
 #if SECP256K1_LIB
 	public
 #endif
-	partial class ECPubKey : IComparable<ECPubKey>
+	partial class ECPubKey : IComparable<ECPubKey>, IEquatable<ECPubKey>
 	{
 
 #if SECP256K1_LIB
@@ -242,6 +242,12 @@ namespace NBitcoin.Secp256k1
 			return new ECPubKey(Q.Negate(), ctx);
 		}
 
+		public bool Equals(ECPubKey? other)
+		{
+			if (other is ECPubKey item)
+				return this == item;
+			return false;
+		}
 
 		public override bool Equals(object? obj)
 		{

--- a/NBitcoin/Secp256k1/ECXOnlyPubKey.cs
+++ b/NBitcoin/Secp256k1/ECXOnlyPubKey.cs
@@ -15,7 +15,7 @@ namespace NBitcoin.Secp256k1
 #if SECP256K1_LIB
 	public
 #endif
-	partial class ECXOnlyPubKey : IComparable<ECXOnlyPubKey>
+	partial class ECXOnlyPubKey : IComparable<ECXOnlyPubKey>, IEquatable<ECXOnlyPubKey>
 	{
 		internal static byte[] TAG_BIP0340Challenge = ASCIIEncoding.ASCII.GetBytes("BIP0340/challenge");
 #if SECP256K1_LIB
@@ -179,7 +179,35 @@ namespace NBitcoin.Secp256k1
 
 		public override int GetHashCode()
 		{
-			return this.Q.x.GetHashCode();
+			return Q.x.GetHashCode();
+		}
+
+		public bool Equals(ECXOnlyPubKey? other)
+		{
+			if (other is ECXOnlyPubKey)
+				return this == other;
+			return false;
+		}
+
+		public override bool Equals(object? obj)
+		{
+			if (obj is ECXOnlyPubKey item)
+				return this == item;
+			return false;
+		}
+
+		public static bool operator ==(ECXOnlyPubKey? a, ECXOnlyPubKey? b)
+		{
+			if (a is ECXOnlyPubKey aa && b is ECXOnlyPubKey bb)
+			{
+				return aa.Q.x == bb.Q.x;
+			}
+			return a is null && b is null;
+		}
+
+		public static bool operator !=(ECXOnlyPubKey? a, ECXOnlyPubKey? b)
+		{
+			return !(a == b);
 		}
 	}
 }


### PR DESCRIPTION
Implements IEqutable interface for ECPrivKey, ECPubKey and ECXOnlyPubkey, along with == overrides
Allows direct comparisions without serialization. FE already implemented these overrides, so the fix is pretty straightfoward.
 