### PR TITLE
Optimize SHA computations for .NET 8+

### DIFF
--- a/NBitcoin.Bench/HashBench.cs
+++ b/NBitcoin.Bench/HashBench.cs
@@ -1,0 +1,35 @@
+﻿using BenchmarkDotNet.Attributes;
+using NBitcoin.Crypto;
+using NBitcoin.DataEncoders;
+
+namespace NBitcoin.Bench;
+
+[MemoryDiagnoser]
+public class HashBench
+{
+	private byte[] bytes;
+
+	[GlobalSetup]
+	public void Setup()
+	{
+		bytes = Encoders.Hex.DecodeData("d54994ece1d11b19785c7248868696250ab195605b469632b7bd68130e880c9a");
+	}
+
+	[Benchmark]
+	public void SHA1()
+	{
+		Hashes.SHA1(bytes, 0, bytes.Length);
+	}
+
+	[Benchmark]
+	public void SHA256()
+	{
+		Hashes.SHA256(bytes);
+	}
+
+	[Benchmark]
+	public void SHA512()
+	{
+		Hashes.SHA512(bytes);
+	}
+}

--- a/NBitcoin/Crypto/HashStream.cs
+++ b/NBitcoin/Crypto/HashStream.cs
@@ -5,9 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using NBitcoin.DataEncoders;
-#if !NONATIVEHASH
 using System.Security.Cryptography;
-#endif
 
 namespace NBitcoin.Crypto
 {
@@ -132,11 +130,7 @@ namespace NBitcoin.Crypto
 			}
 		}
 
-#if NONATIVEHASH
-		byte[] _Buffer = new byte[32];
-#else
 		byte[] _Buffer = System.Buffers.ArrayPool<byte>.Shared.Rent(32);
-#endif
 
 		int _Pos;
 		public override void WriteByte(byte value)
@@ -155,27 +149,6 @@ namespace NBitcoin.Crypto
 			return false;
 		}
 
-#if NONATIVEHASH
-		BouncyCastle.Crypto.Digests.Sha256Digest sha = new BouncyCastle.Crypto.Digests.Sha256Digest();
-		private void ProcessBlock()
-		{
-			sha.BlockUpdate(_Buffer, 0, _Pos);
-			_Pos = 0;
-		}
-
-		public override uint256 GetHash()
-		{
-			ProcessBlock();
-			sha.DoFinal(_Buffer, 0);
-			if (SingleSHA256)
-				return new uint256(_Buffer);
-			_Pos = 32;
-			ProcessBlock();
-			sha.DoFinal(_Buffer, 0);
-			return new uint256(_Buffer);
-		}
-
-#else
 		System.Security.Cryptography.SHA256 sha = System.Security.Cryptography.SHA256.Create();
 		private void ProcessBlock()
 		{
@@ -225,7 +198,6 @@ namespace NBitcoin.Crypto
 				sha.Dispose();
 			base.Dispose(disposing);
 		}
-#endif
 	}
 
 	/// <summary>

--- a/NBitcoin/Crypto/Hashes.cs
+++ b/NBitcoin/Crypto/Hashes.cs
@@ -106,6 +106,8 @@ namespace NBitcoin.Crypto
 			byte[] rv = new byte[20];
 			sha1.DoFinal(rv, 0);
 			return rv;
+#elif NET8_0_OR_GREATER
+			return System.Security.Cryptography.SHA1.HashData(data.AsSpan(offset, count));
 #else
 			using (var sha1 = System.Security.Cryptography.SHA1.Create())
 			{
@@ -634,7 +636,11 @@ namespace NBitcoin.Crypto
 #if HAS_SPAN
 		public static byte[] SHA256(ReadOnlySpan<byte> data)
 		{
+#if NET8_0_OR_GREATER
+			return System.Security.Cryptography.SHA256.HashData(data);
+#else
 			return SHA256(data.ToArray(), 0, data.Length);
+#endif
 		}
 #endif
 
@@ -646,6 +652,8 @@ namespace NBitcoin.Crypto
 			byte[] rv = new byte[32];
 			sha256.DoFinal(rv, 0);
 			return rv;
+#elif NET8_0_OR_GREATER
+			return System.Security.Cryptography.SHA256.HashData(data.AsSpan(offset, count));
 #else
 			using (var sha = System.Security.Cryptography.SHA256.Create())
 			{
@@ -668,6 +676,8 @@ namespace NBitcoin.Crypto
 			byte[] rv = new byte[32];
 			sha512.DoFinal(rv, 0);
 			return rv;
+#elif NET8_0_OR_GREATER
+			return System.Security.Cryptography.SHA512.HashData(data.AsSpan(offset, count));
 #else
 			using (var sha = System.Security.Cryptography.SHA512.Create())
 			{

--- a/NBitcoin/Crypto/Hashes.cs
+++ b/NBitcoin/Crypto/Hashes.cs
@@ -4,15 +4,9 @@ using NBitcoin.BouncyCastle.Security;
 #endif
 using NBitcoin.BouncyCastle.Crypto.Digests;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-#if !NONATIVEHASH
 using System.Security.Cryptography;
-#endif
 
 namespace NBitcoin.Crypto
 {
@@ -40,21 +34,11 @@ namespace NBitcoin.Crypto
 
 		public static byte[] DoubleSHA256RawBytes(byte[] data, int offset, int count)
 		{
-#if NONATIVEHASH
-			Sha256Digest sha256 = new Sha256Digest();
-			sha256.BlockUpdate(data, offset, count);
-			byte[] rv = new byte[32];
-			sha256.DoFinal(rv, 0);
-			sha256.BlockUpdate(rv, 0, rv.Length);
-			sha256.DoFinal(rv, 0);
-			return rv;
-#else
 			using (var sha = System.Security.Cryptography.SHA256.Create())
 			{
 				var h = sha.ComputeHash(data, offset, count);
 				return sha.ComputeHash(h, 0, h.Length);
 			}
-#endif
 		}
 
 		#region Hash160
@@ -656,7 +640,7 @@ namespace NBitcoin.Crypto
 
 		public static byte[] SHA256(byte[] data, int offset, int count)
 		{
-#if USEBC || WINDOWS_UWP || NONATIVEHASH
+#if USEBC || WINDOWS_UWP
 			Sha256Digest sha256 = new Sha256Digest();
 			sha256.BlockUpdate(data, offset, count);
 			byte[] rv = new byte[32];
@@ -678,7 +662,7 @@ namespace NBitcoin.Crypto
 
 		public static byte[] SHA512(byte[] data, int offset, int count)
 		{
-#if USEBC || WINDOWS_UWP || NONATIVEHASH
+#if USEBC || WINDOWS_UWP
 			Sha512Digest sha512 = new Sha512Digest();
 			sha512.BlockUpdate(data, offset, count);
 			byte[] rv = new byte[32];
@@ -781,44 +765,6 @@ namespace NBitcoin.Crypto
 			}
 		}
 
-#if NONATIVEHASH
-		public static byte[] HMACSHA512(byte[] key, byte[] data)
-		{
-			var mac = new NBitcoin.BouncyCastle.Crypto.Macs.HMac(new Sha512Digest());
-			mac.Init(new KeyParameter(key));
-			mac.BlockUpdate(data, 0, data.Length);
-			byte[] result = new byte[mac.GetMacSize()];
-			mac.DoFinal(result, 0);
-			return result;
-		}
-#if HAS_SPAN
-		public static bool HMACSHA512(byte[] key, ReadOnlySpan<byte> data, Span<byte> output, out int outputLength)
-		{
-			outputLength = 0;
-			var mac = new NBitcoin.BouncyCastle.Crypto.Macs.HMac(new Sha512Digest());
-			var macSize = mac.GetMacSize();
-			if (output.Length < macSize)
-				return false;
-			mac.Init(new KeyParameter(key));
-			mac.BlockUpdate(data.ToArray(), 0, data.Length);
-			byte[] result = new byte[macSize];
-			mac.DoFinal(result, 0);
-			result.CopyTo(result);
-			outputLength = result.Length;
-			return true;
-		}
-#endif
-		public static byte[] HMACSHA256(byte[] key, byte[] data)
-		{
-			var mac = new NBitcoin.BouncyCastle.Crypto.Macs.HMac(new Sha256Digest());
-			mac.Init(new KeyParameter(key));
-			mac.BlockUpdate(data, 0, data.Length);
-			byte[] result = new byte[mac.GetMacSize()];
-			mac.DoFinal(result, 0);
-			return result;
-		}
-
-#else
 		public static byte[] HMACSHA512(byte[] key, byte[] data)
 		{
 			return new HMACSHA512(key).ComputeHash(data);
@@ -834,7 +780,7 @@ namespace NBitcoin.Crypto
 		{
 			return new HMACSHA256(key).ComputeHash(data);
 		}
-#endif
+
 #if HAS_SPAN
 		public static void BIP32Hash(byte[] chainCode, uint nChild, byte header, Span<byte> data, Span<byte> output)
 		{


### PR DESCRIPTION
Stacked on #1315 to avoid conflicts

master:

| Method | Mean     | Error    | StdDev   | Gen0   | Allocated |
|------- |---------:|---------:|---------:|-------:|----------:|
| SHA1   | 546.5 ns | 10.91 ns | 25.06 ns | 0.0353 |     224 B |
| SHA256 | 578.6 ns | 11.50 ns | 19.52 ns | 0.0381 |     240 B |
| SHA512 | 679.1 ns | 13.48 ns | 24.30 ns | 0.0477 |     304 B |

PR:

| Method | Mean     | Error   | StdDev   | Median   | Gen0   | Allocated |
|------- |---------:|--------:|---------:|---------:|-------:|----------:|
| SHA1   | 300.7 ns | 6.01 ns | 10.68 ns | 305.7 ns | 0.0076 |      48 B |
| SHA256 | 365.5 ns | 7.29 ns | 10.46 ns | 370.5 ns | 0.0086 |      56 B |
| SHA512 | 445.5 ns | 4.86 ns |  3.79 ns | 444.7 ns | 0.0138 |      88 B |

The CPU time improvements are in the range of 35% - 45% and memory improvements are 70%+.