### PR TITLE
Optimize `HexEncoder.DecodeData` methods for .NET 8+

### DIFF
--- a/NBitcoin.Bench/HexBench.cs
+++ b/NBitcoin.Bench/HexBench.cs
@@ -7,8 +7,9 @@ namespace NBitcoin.Bench;
 [MemoryDiagnoser]
 public class HexBench
 {
-	readonly string str = "d54994ece1d11b19785c7248868696250ab195605b469632b7bd68130e880c9a";
-	readonly string uint256_str = "00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+	const string str = "d54994ece1d11b19785c7248868696250ab195605b469632b7bd68130e880c9a";
+	const string uint256_str = "00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+
 	private byte[] bytes;
 
 	[GlobalSetup]
@@ -24,9 +25,12 @@ public class HexBench
 	}
 
 	[Benchmark]
-	public void DecodeDataSpan()
+	[Arguments(uint256_str)] // 32 bytes
+	[Arguments(uint256_str + uint256_str)] // 64 bytes
+	[Arguments(uint256_str + uint256_str + uint256_str)] // 96 bytes
+	public void DecodeDataSpan(string hexString)
 	{
-		Span<byte> tmp = stackalloc byte[32];
+		Span<byte> tmp = stackalloc byte[hexString.Length / 2];
 		HexEncoder hex = (HexEncoder)Encoders.Hex;
 		hex.DecodeData(uint256_str, tmp);
 	}

--- a/NBitcoin.Bench/HexBench.cs
+++ b/NBitcoin.Bench/HexBench.cs
@@ -37,7 +37,7 @@ public class HexBench
 	{
 		Span<byte> tmp = stackalloc byte[hexString.Length / 2];
 		HexEncoder hex = (HexEncoder)Encoders.Hex;
-		hex.DecodeData(uint256_str, tmp);
+		hex.DecodeData(hexString, tmp);
 	}
 
 	[Benchmark]

--- a/NBitcoin.Bench/HexBench.cs
+++ b/NBitcoin.Bench/HexBench.cs
@@ -9,6 +9,7 @@ public class HexBench
 {
 	const string str = "d54994ece1d11b19785c7248868696250ab195605b469632b7bd68130e880c9a";
 	const string uint256_str = "00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+	string random_str_10kb;
 
 	private byte[] bytes;
 
@@ -16,6 +17,10 @@ public class HexBench
 	public void Setup()
 	{
 		bytes = Encoders.Hex.DecodeData(str);
+
+		var randomBytes = new byte[10 * 1024];
+		Random.Shared.NextBytes(randomBytes);
+		random_str_10kb = Encoders.Hex.EncodeData(randomBytes);
 	}
 
 	[Benchmark]
@@ -33,6 +38,14 @@ public class HexBench
 		Span<byte> tmp = stackalloc byte[hexString.Length / 2];
 		HexEncoder hex = (HexEncoder)Encoders.Hex;
 		hex.DecodeData(uint256_str, tmp);
+	}
+
+	[Benchmark]
+	public void DecodeDataLongSpan()
+	{
+		Span<byte> tmp = stackalloc byte[random_str_10kb.Length / 2];
+		HexEncoder hex = (HexEncoder)Encoders.Hex;
+		hex.DecodeData(random_str_10kb, tmp);
 	}
 
 	[Benchmark]

--- a/NBitcoin.Bench/HexBench.cs
+++ b/NBitcoin.Bench/HexBench.cs
@@ -1,32 +1,39 @@
 ﻿using BenchmarkDotNet.Attributes;
 using NBitcoin.DataEncoders;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace NBitcoin.Bench
+namespace NBitcoin.Bench;
+
+[MemoryDiagnoser]
+public class HexBench
 {
-	public class HexBench
-	{
-		string str = "d54994ece1d11b19785c7248868696250ab195605b469632b7bd68130e880c9a";
-		private byte[] bytes;
+	readonly string str = "d54994ece1d11b19785c7248868696250ab195605b469632b7bd68130e880c9a";
+	readonly string uint256_str = "00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+	private byte[] bytes;
 
-		[GlobalSetup]
-		public void Setup()
-		{
-			bytes = Encoders.Hex.DecodeData(str);
-		}
-		[Benchmark]
-		public void Decode()
-		{
-			Encoders.Hex.DecodeData(str);
-		}
-		[Benchmark]
-		public void Encode()
-		{
-			Encoders.Hex.EncodeData(bytes);
-		}
+	[GlobalSetup]
+	public void Setup()
+	{
+		bytes = Encoders.Hex.DecodeData(str);
+	}
+
+	[Benchmark]
+	public void DecodeData()
+	{
+		Encoders.Hex.DecodeData(str);
+	}
+
+	[Benchmark]
+	public void DecodeDataSpan()
+	{
+		Span<byte> tmp = stackalloc byte[32];
+		HexEncoder hex = (HexEncoder)Encoders.Hex;
+		hex.DecodeData(uint256_str, tmp);
+	}
+
+	[Benchmark]
+	public void EncodeData()
+	{
+		Encoders.Hex.EncodeData(bytes);
 	}
 }

--- a/NBitcoin.Tests/uint256_tests.cs
+++ b/NBitcoin.Tests/uint256_tests.cs
@@ -1,11 +1,7 @@
-﻿using NBitcoin.Protocol;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace NBitcoin.Tests

--- a/NBitcoin/DataEncoders/HexEncoder.cs
+++ b/NBitcoin/DataEncoders/HexEncoder.cs
@@ -128,6 +128,10 @@ namespace NBitcoin.DataEncoders
 			if (output.Length < (encoded.Length >> 1))
 				throw new ArgumentException("output should be bigger", nameof(output));
 
+#if NET8_0_OR_GREATER
+			var decoded = Convert.FromHexString(encoded);
+			decoded.CopyTo(output);
+#else
 			// TODO: Convert.FromHexString(string source, Span<byte> destination) (.NET 10+) once available.
 			try
 			{
@@ -141,6 +145,7 @@ namespace NBitcoin.DataEncoders
 				}
 			}
 			catch(IndexOutOfRangeException) { throw new FormatException("Invalid Hex String"); }
+#endif
 		}
 #endif
 		public bool IsValid(string str)

--- a/NBitcoin/DataEncoders/HexEncoder.cs
+++ b/NBitcoin/DataEncoders/HexEncoder.cs
@@ -57,7 +57,8 @@ namespace NBitcoin.DataEncoders
 			if (data == null)
 				throw new ArgumentNullException(nameof(data));
 
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
+			// TODO: Convert.ToHexStringLower (.NET 9+) once available.
 			return Convert.ToHexString(data, offset, count).ToLowerInvariant();
 #elif !HAS_SPAN
 			int pos = 0;
@@ -98,6 +99,10 @@ namespace NBitcoin.DataEncoders
 		{
 			if (encoded == null)
 				throw new ArgumentNullException(nameof(encoded));
+
+#if NET8_0_OR_GREATER
+			return Convert.FromHexString(encoded);
+#else
 			if (encoded.Length % 2 == 1)
 				throw new FormatException("Invalid Hex String");
 
@@ -111,6 +116,7 @@ namespace NBitcoin.DataEncoders
 				result[j] = (byte)((hi << 4) | lo);
 			}
 			return result;
+#endif
 		}
 #if HAS_SPAN
 		public void DecodeData(string encoded, Span<byte> output)
@@ -121,6 +127,8 @@ namespace NBitcoin.DataEncoders
 				throw new FormatException("Invalid Hex String");
 			if (output.Length < (encoded.Length >> 1))
 				throw new ArgumentException("output should be bigger", nameof(output));
+
+			// TODO: Convert.FromHexString(string source, Span<byte> destination) (.NET 10+) once available.
 			try
 			{
 				for (int i = 0, j = 0; i < encoded.Length; i += 2, j++)


### PR DESCRIPTION
## Benchmark

```
dotnet run -c Release -- --runtimes net8.0 --filter *HexBench*
```



master:


| Method         | Mean     | Error    | StdDev   | Gen0   | Allocated |
|--------------- |---------:|---------:|---------:|-------:|----------:|
| DecodeData     | 43.36 ns | 0.863 ns | 0.886 ns | 0.0089 |      56 B |
| DecodeDataSpan | 40.19 ns | 0.818 ns | 1.064 ns |      - |         - |
| EncodeData     | 46.64 ns | 0.955 ns | 1.370 ns | 0.0485 |     304 B |

PR (with git 2 commits):

| Method         | Mean     | Error    | StdDev   | Gen0   | Allocated |
|--------------- |---------:|---------:|---------:|-------:|----------:|
| DecodeData     | **20.57 ns** | 0.440 ns | 0.631 ns | 0.0089 |      56 B |
| DecodeDataSpan | 39.59 ns | 0.808 ns | 1.078 ns |      - |         - |
| EncodeData     | 45.65 ns | 0.934 ns | 1.215 ns | 0.0485 |     304 B |

PR (with git 3 commits):

| Method         | Mean     | Error    | StdDev   | Gen0   | Allocated |
|--------------- |---------:|---------:|---------:|-------:|----------:|
| DecodeData     | 21.03 ns | 0.443 ns | 0.843 ns | 0.0089 |      56 B |
| DecodeDataSpan | **22.95 ns** | 0.487 ns | 0.814 ns | 0.0089 |      56 B |
| EncodeData     | 46.27 ns | 0.944 ns | 1.469 ns | 0.0485 |     304 B |

Decoding is about **twice** as fast with the PR compared to master.