### PR TITLE
Remove use of `NO_MEM_BUFFER`

### DIFF
--- a/NBitcoin/Crypto/HashStream.cs
+++ b/NBitcoin/Crypto/HashStream.cs
@@ -310,12 +310,7 @@ namespace NBitcoin.Crypto
 
 		public override uint256 GetHash()
 		{
-#if NO_MEM_BUFFER
-			var copy = ms.ToArray();
-			return GetHash(copy, 0, (int)copy.Length);
-#else
 			return GetHash(ms.GetBuffer(), 0, (int)ms.Length);
-#endif
 		}
 
 		protected abstract uint256 GetHash(byte[] data, int offset, int length);

--- a/NBitcoin/IBitcoinSerializable.cs
+++ b/NBitcoin/IBitcoinSerializable.cs
@@ -90,13 +90,9 @@ namespace NBitcoin
 
 		public static byte[] ToArrayEfficient(this MemoryStream ms)
 		{
-#if NO_MEM_BUFFER
-			return ms.ToArray();
-#else
 			var bytes = ms.GetBuffer();
 			Array.Resize(ref bytes, (int)ms.Length);
 			return bytes;
-#endif
 		}
 	}
 }


### PR DESCRIPTION
`NO_MEM_BUFFER` was removed in https://github.com/MetacoSA/NBitcoin/pull/1243 (commit https://github.com/MetacoSA/NBitcoin/commit/4780a7f38189444e9961fa952a0ecea29721c90b)