### PR TITLE
Improve performance of `Utils.ArrayEquals`

### DIFF
--- a/NBitcoin.Bench/README.md
+++ b/NBitcoin.Bench/README.md
@@ -2,11 +2,12 @@
 
 This project use BenchmarkDotnet to measure performance of parts of NBitcoin implementation.
 
-You can generate flamegraph to view with Perfview on Windows with the following command:
+You can generate flamegraph to view with [PerfView](https://github.com/microsoft/perfview) on Windows with the following command:
+
 ```powershell
 dotnet run -c Release -- --runtimes net8.0 --filter *GolombRiceFilters* --profiler ETW
 ```
 
-Where `GolombRiceFilters` is the name of the benchmark class you are insterested in.
+Where `GolombRiceFilters` is the name of the benchmark class you are interested in.
 
 For generating flamegraph on linux, see [this comment](https://github.com/MetacoSA/NBitcoin/pull/656#issuecomment-462927805).

--- a/NBitcoin.Bench/UtilsBench.cs
+++ b/NBitcoin.Bench/UtilsBench.cs
@@ -1,0 +1,56 @@
+﻿using BenchmarkDotNet.Attributes;
+using NBitcoin.DataEncoders;
+using System;
+using System.Collections.Generic;
+
+namespace NBitcoin.Bench;
+
+[MemoryDiagnoser]
+public class UtilsBench
+{
+	private static readonly byte[] taprootPubKeyA = Encoders.Hex.DecodeData("54c9e50dde41d5fc0b3dc0ff1ed4f6603a493d0a50dcc1badc3a5d959da7e750");
+	private static readonly byte[] taprootPubKeyB = Encoders.Hex.DecodeData("7ca556cf2fc5ba848c5ede3c8f0605dc78c005244915ad42b4b15076eb4b2c43");
+
+	public static IEnumerable<object[]> ArrayEqualArgs
+	{
+		get
+		{
+			yield return new byte[][] { [], [] }; // No bytes.
+			yield return new byte[][] { [], [0x01] }; // Empty array against non-empty array.
+			yield return new byte[][] { [0x01], [0x02] }; // 1-byte arrays which are not equal.
+			yield return new byte[][] { [0x01, 0x02], [0x01, 0x03] }; // 2-byte arrays which are not equal.
+			yield return new byte[][] { [0x01, 0x02, 0x03], [0x02, 0x03, 0x04] }; // 3-byte arrays which are not equal.
+			yield return new byte[][] { [0x01, 0x02, 0x03, 0x04, 0x05], [0x01, 0x02, 0x03, 0x04, 0x05] }; // 5-byte arrays which are equal.
+			yield return new byte[][] { [0x01, 0x02, 0x03, 0x04, 0x06, 0x05], [0x01, 0x02, 0x03, 0x04, 0x05, 0x06] }; // 6-byte arrays which are not equal.
+			yield return new byte[][] { [.. taprootPubKeyA], [.. taprootPubKeyA] }; // Create a copy to avoid reference equality
+			yield return new byte[][] { [.. taprootPubKeyA], [.. taprootPubKeyB] };
+		}
+	}
+
+	[Benchmark(Baseline = true)]
+	[BenchmarkCategory("Master")]
+	[ArgumentsSource(nameof(ArrayEqualArgs))]
+	public bool ArrayEqual_Master(byte[] a, byte[] b)
+	{
+		return ArrayEqual_OldImpl(a, b);
+	}
+
+	[Benchmark]
+	[ArgumentsSource(nameof(ArrayEqualArgs))]
+	public bool ArrayEqual(byte[] a, byte[] b)
+	{
+		return Utils.ArrayEqual(a, b);
+	}
+
+	private static bool ArrayEqual_OldImpl(byte[] a, byte[] b)
+	{
+		if (a == null && b == null)
+			return true;
+		if (a == null)
+			return false;
+		if (b == null)
+			return false;
+
+		return Utils.ArrayEqual(a, 0, b, 0, Math.Max(a.Length, b.Length));
+	}
+}

--- a/NBitcoin.Bench/UtilsBench.cs
+++ b/NBitcoin.Bench/UtilsBench.cs
@@ -1,6 +1,5 @@
 ﻿using BenchmarkDotNet.Attributes;
 using NBitcoin.DataEncoders;
-using System;
 using System.Collections.Generic;
 
 namespace NBitcoin.Bench;
@@ -27,30 +26,10 @@ public class UtilsBench
 		}
 	}
 
-	[Benchmark(Baseline = true)]
-	[BenchmarkCategory("Master")]
-	[ArgumentsSource(nameof(ArrayEqualArgs))]
-	public bool ArrayEqual_Master(byte[] a, byte[] b)
-	{
-		return ArrayEqual_OldImpl(a, b);
-	}
-
 	[Benchmark]
 	[ArgumentsSource(nameof(ArrayEqualArgs))]
 	public bool ArrayEqual(byte[] a, byte[] b)
 	{
 		return Utils.ArrayEqual(a, b);
-	}
-
-	private static bool ArrayEqual_OldImpl(byte[] a, byte[] b)
-	{
-		if (a == null && b == null)
-			return true;
-		if (a == null)
-			return false;
-		if (b == null)
-			return false;
-
-		return Utils.ArrayEqual(a, 0, b, 0, Math.Max(a.Length, b.Length));
 	}
 }

--- a/NBitcoin.Tests/util_tests.cs
+++ b/NBitcoin.Tests/util_tests.cs
@@ -938,7 +938,7 @@ namespace NBitcoin.Tests
 				Assert.True(Utils.ArrayEqual(text1, plainText));
 				Assert.Equal(text2, Encoders.ASCII.EncodeData(plainText));
 
-				// Encrypt twice, should not give twice same cypher
+				// Encrypt twice, should not give twice same cipher
 				var cipherText3 = key.PubKey.Encrypt(plainText);
 				Assert.True(!Utils.ArrayEqual(cipherText1, cipherText3));
 			}

--- a/NBitcoin/Utils.cs
+++ b/NBitcoin/Utils.cs
@@ -471,24 +471,26 @@ namespace NBitcoin
 			}
 			catch { }
 		}
-		public static bool ArrayEqual(byte[] a, byte[] b)
+		public static bool ArrayEqual(byte[]? a, byte[]? b)
 		{
 			if (a == null && b == null)
 				return true;
-			if (a == null)
+			if (a == null || b == null)
 				return false;
-			if (b == null)
-				return false;
-			return ArrayEqual(a, 0, b, 0, Math.Max(a.Length, b.Length));
+
+			if (a.Length != b.Length)
+				return a.Length == 0 && b.Length == 0;
+
+			return ArrayEqual(a, 0, b, 0, a.Length);
 		}
-		public static bool ArrayEqual(byte[] a, int startA, byte[] b, int startB, int length)
+
+		public static bool ArrayEqual(byte[]? a, int startA, byte[]? b, int startB, int length)
 		{
 			if (a == null && b == null)
 				return true;
-			if (a == null)
+			if (a == null || b == null)
 				return false;
-			if (b == null)
-				return false;
+
 			var alen = a.Length - startA;
 			var blen = b.Length - startB;
 

--- a/NBitcoin/Utils.cs
+++ b/NBitcoin/Utils.cs
@@ -479,7 +479,7 @@ namespace NBitcoin
 				return false;
 
 			if (a.Length != b.Length)
-				return a.Length == 0 && b.Length == 0;
+				return false;
 
 			return ArrayEqual(a, 0, b, 0, a.Length);
 		}


### PR DESCRIPTION
| Method            | a        | b        | Mean       | Error     | StdDev    | Ratio | RatioSD | Allocated | Alloc Ratio |
|------------------ |--------- |--------- |-----------:|----------:|----------:|------:|--------:|----------:|------------:|
| ArrayEqual_Master | Byte[0]  | Byte[0]  |  0.8767 ns | 0.0168 ns | 0.0157 ns |  1.00 |    0.02 |         - |          NA |
| ArrayEqual_PR     | Byte[0]  | Byte[0]  |  0.4866 ns | 0.0270 ns | 0.0252 ns |  0.56 |    0.03 |         - |          NA |
| ArrayEqual_Master | Byte[0]  | Byte[1]  |  1.5359 ns | 0.0430 ns | 0.0402 ns |  1.75 |    0.05 |         - |          NA |
| ArrayEqual_PR     | Byte[0]  | Byte[1]  |  0.4870 ns | 0.0127 ns | 0.0112 ns |  0.56 |    0.02 |         - |          NA |
| ArrayEqual_Master | Byte[1]  | Byte[1]  |  1.4931 ns | 0.0406 ns | 0.0380 ns |  1.70 |    0.05 |         - |          NA |
| ArrayEqual_PR     | Byte[1]  | Byte[1]  |  1.0676 ns | 0.0187 ns | 0.0166 ns |  1.22 |    0.03 |         - |          NA |
| ArrayEqual_Master | Byte[2]  | Byte[2]  |  2.0147 ns | 0.0723 ns | 0.1082 ns |  2.30 |    0.13 |         - |          NA |
| ArrayEqual_PR     | Byte[2]  | Byte[2]  |  1.7478 ns | 0.0227 ns | 0.0213 ns |  1.99 |    0.04 |         - |          NA |
| ArrayEqual_Master | Byte[3]  | Byte[3]  |  1.3874 ns | 0.0204 ns | 0.0181 ns |  1.58 |    0.03 |         - |          NA |
| ArrayEqual_PR     | Byte[3]  | Byte[3]  |  1.0474 ns | 0.0202 ns | 0.0179 ns |  1.20 |    0.03 |         - |          NA |
| ArrayEqual_Master | Byte[5]  | Byte[5]  |  3.9556 ns | 0.0566 ns | 0.0501 ns |  4.51 |    0.10 |         - |          NA |
| ArrayEqual_PR     | Byte[5]  | Byte[5]  |  3.2429 ns | 0.0727 ns | 0.0680 ns |  3.70 |    0.10 |         - |          NA |
| ArrayEqual_Master | Byte[6]  | Byte[6]  |  3.9994 ns | 0.0537 ns | 0.0449 ns |  4.56 |    0.09 |         - |          NA |
| ArrayEqual_PR     | Byte[6]  | Byte[6]  |  3.7730 ns | 0.0481 ns | 0.0450 ns |  4.30 |    0.09 |         - |          NA |
| ArrayEqual_Master | Byte[32] | Byte[32] | 21.1504 ns | 0.3606 ns | 0.4008 ns | 24.13 |    0.61 |         - |          NA |
| ArrayEqual_PR     | Byte[32] | Byte[32] | 18.9925 ns | 0.2618 ns | 0.2449 ns | 21.67 |    0.46 |         - |          NA |
| ArrayEqual_Master | Byte[32] | Byte[32] |  1.4625 ns | 0.0593 ns | 0.0812 ns |  1.67 |    0.10 |         - |          NA |
| ArrayEqual_PR     | Byte[32] | Byte[32] |  1.2298 ns | 0.0190 ns | 0.0178 ns |  1.40 |    0.03 |         - |          NA |