### PR TITLE
Optimize `Encoders.Hex.EncodeData(ReadOnlySpan<byte> data)`

### DIFF
--- a/NBitcoin/DataEncoders/HexEncoder.cs
+++ b/NBitcoin/DataEncoders/HexEncoder.cs
@@ -52,6 +52,14 @@ namespace NBitcoin.DataEncoders
 		private static readonly string[] HexTbl = Enumerable.Range(0, 256).Select(v => v.ToString("x2")).ToArray();
 #endif
 
+#if NET8_0_OR_GREATER
+		public override string EncodeData(ReadOnlySpan<byte> data)
+		{
+			// TODO: Convert.ToHexStringLower (.NET 9+) once available.
+			return Convert.ToHexString(data).ToLowerInvariant();
+		}
+#endif
+
 		public override string EncodeData(byte[] data, int offset, int count)
 		{
 			if (data == null)

--- a/NBitcoin/Secp256k1/ECPrivKey.cs
+++ b/NBitcoin/Secp256k1/ECPrivKey.cs
@@ -298,7 +298,7 @@ namespace NBitcoin.Secp256k1
 		/// </summary>
 		/// <param name="tweak">32 bytes tweak</param>
 		/// <param name="tweakedPrivKey">False If the tweak is not 32 bytes or if the tweak was out of range (chance of around 1 in 2^128 for uniformly random 32-byte arrays, or if the resulting private key would be invalid(only when the tweak is the complement of the private key)</param>
-		/// <exception cref="System.ObjectDisposedException">This instance has been disposed</exception>
+		/// <exception cref="ObjectDisposedException">This instance has been disposed</exception>
 		/// <returns>A tweaked private key</returns>
 		public bool TryTweakAdd(ReadOnlySpan<byte> tweak, out ECPrivKey? tweakedPrivKey)
 		{
@@ -877,9 +877,8 @@ namespace NBitcoin.Secp256k1
 			tweakedPrivkey = null;
 			if (tweak.Length != 32)
 				return false;
-			Scalar factor;
-			int overflow;
-			factor = new Scalar(tweak, out overflow);
+
+			var factor = new Scalar(tweak, out int overflow);
 			var sec = this.sec;
 			bool ret = overflow == 0 && secp256k1_eckey_privkey_tweak_mul(ref sec, factor);
 			if (ret)


### PR DESCRIPTION
By default

```cs
public virtual string EncodeData(ReadOnlySpan<byte> data)
{
	return this.EncodeData(data.ToArray());
}
```

is called. However, this allocates an array so it beats any improvement that `ReadOnlySpan<byte>` provides.

This PR adds:

```cs
#if NET8_0_OR_GREATER
		public override string EncodeData(ReadOnlySpan<byte> data)
		{
			// TODO: Convert.ToHexStringLower (.NET 9+) once available.
			return Convert.ToHexString(data).ToLowerInvariant();
		}
#endif
```

to avoid copying span data.